### PR TITLE
Benchmark timing information and future support for batch retrieval of data from MySQL

### DIFF
--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -78,12 +78,8 @@ async fn main() {
     let (tx, mut rx) = channel(2);
 
     if cli.memory_db {
-        let db = akd::storage::V2FromV1StorageWrapper::new(
-            akd::storage::memory::AsyncInMemoryDatabase::new(),
-        );
-        let mut directory = Directory::<
-            akd::storage::V2FromV1StorageWrapper<akd::storage::memory::AsyncInMemoryDatabase>,
-        >::new::<Blake3>(&db)
+        let db = akd::storage::memory::newdb::AsyncInMemoryDatabase::new();
+        let mut directory = Directory::<_>::new::<Blake3>(&db)
         .await
         .unwrap();
         tokio::spawn(async move {
@@ -101,7 +97,7 @@ async fn main() {
             MySqlCacheOptions::Default, // enable caching
         )
         .await;
-        let mut directory = Directory::<AsyncMySqlDatabase>::new::<Blake3>(&mysql_db)
+        let mut directory = Directory::<_>::new::<Blake3>(&mysql_db)
             .await
             .unwrap();
         tokio::spawn(async move {

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -30,7 +30,7 @@ use keyed_priority_queue::{Entry, KeyedPriorityQueue};
 pub const DEFAULT_AZKS_KEY: u8 = 1u8;
 /// An append-only zero knowledge set, the data structure used to efficiently implement
 /// a auditable key directory.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(bound = "")]
 pub struct Azks {
     /// The location of the root
@@ -54,6 +54,10 @@ impl Storable for Azks {
 
     fn get_full_binary_key_id(key: &u8) -> Vec<u8> {
         vec![StorageType::Azks as u8, *key]
+    }
+
+    fn key_from_full_binary(_bin: &[u8]) -> Result<u8, String> {
+        Ok(1u8)
     }
 }
 

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -144,10 +144,8 @@ impl Azks {
                 )
                 .await?
             } else {
-                let out =
-                    get_leaf_node::<H, S>(storage, label, 0, value.as_ref(), 0, self.latest_epoch)
-                        .await?;
-                out
+                get_leaf_node::<H, S>(storage, label, 0, value.as_ref(), 0, self.latest_epoch)
+                    .await?
             };
 
             debug!("BEGIN insert leaf");

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -148,6 +148,8 @@ impl<S: V2Storage + Sync + Send> Directory<S> {
 
         self.current_epoch = next_epoch;
 
+        self.storage.log_metrics(log::Level::Info).await;
+
         Ok(())
         // At the moment the tree root is not being written anywhere. Eventually we
         // want to change this to call a write operation to post to a blockchain or some such thing

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -14,6 +14,8 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+pub mod newdb;
+
 // ===== Basic In-Memory database ==== //
 
 /// This struct represents a basic in-memory database.

--- a/src/storage/memory/newdb.rs
+++ b/src/storage/memory/newdb.rs
@@ -215,10 +215,7 @@ impl V2Storage for AsyncInMemoryDatabase {
     }
 
     async fn append_user_states(&self, values: Vec<ValueState>) -> Result<(), StorageError> {
-        let new_vec = values
-            .into_iter()
-            .map(DbRecord::ValueState)
-            .collect();
+        let new_vec = values.into_iter().map(DbRecord::ValueState).collect();
         self.batch_set(new_vec).await
     }
 

--- a/src/storage/memory/newdb.rs
+++ b/src/storage/memory/newdb.rs
@@ -1,0 +1,322 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+//! This module contains various memory representations.
+
+use crate::errors::StorageError;
+use crate::storage::transaction::Transaction;
+use crate::storage::types::{
+    AkdKey, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
+};
+use crate::storage::{Storable, V2Storage};
+
+use async_trait::async_trait;
+use log::{debug, error, info, trace, warn};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// This struct represents a basic in-memory database.
+#[derive(Debug)]
+pub struct AsyncInMemoryDatabase {
+    db: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, DbRecord>>>,
+    trans: Transaction,
+}
+
+unsafe impl Send for AsyncInMemoryDatabase {}
+unsafe impl Sync for AsyncInMemoryDatabase {}
+
+impl AsyncInMemoryDatabase {
+    /// Creates a new in memory db
+    pub fn new() -> Self {
+        Self {
+            db: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            trans: Transaction::new(),
+        }
+    }
+}
+
+impl Default for AsyncInMemoryDatabase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for AsyncInMemoryDatabase {
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            trans: Transaction::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl V2Storage for AsyncInMemoryDatabase {
+    /// Log some information about the db
+    async fn log_metrics(&self, level: log::Level) {
+        let size = self.db.read().await;
+        let msg = format!("InMemDb record count: {}", size.keys().len());
+
+        match level {
+            log::Level::Trace => trace!("{}", msg),
+            log::Level::Debug => debug!("{}", msg),
+            log::Level::Info => info!("{}", msg),
+            log::Level::Warn => warn!("{}", msg),
+            _ => error!("{}", msg),
+        }
+    }
+
+    /// Start a transaction in the storage layer
+    async fn begin_transaction(&mut self) -> bool {
+        self.trans.begin_transaction().await
+    }
+
+    /// Commit a transaction in the storage layer
+    async fn commit_transaction(&mut self) -> Result<(), StorageError> {
+        // this retrieves all the trans operations, and "de-activates" the transaction flag
+        let ops = self.trans.commit_transaction().await?;
+        self.batch_set(ops).await
+    }
+
+    /// Rollback a transaction
+    async fn rollback_transaction(&mut self) -> Result<(), StorageError> {
+        self.trans.rollback_transaction().await
+    }
+
+    /// Retrieve a flag determining if there is a transaction active
+    async fn is_transaction_active(&self) -> bool {
+        self.trans.is_transaction_active().await
+    }
+
+    /// V1Storage a record in the data layer
+    async fn set(&self, record: DbRecord) -> Result<(), StorageError> {
+        if self.is_transaction_active().await {
+            self.trans.set(&record).await;
+            return Ok(());
+        }
+
+        let mut guard = self.db.write().await;
+        guard.insert(record.get_full_binary_id(), record);
+
+        Ok(())
+    }
+
+    async fn batch_set(&self, records: Vec<DbRecord>) -> Result<(), StorageError> {
+        let mut guard = self.db.write().await;
+        for record in records.into_iter() {
+            guard.insert(record.get_full_binary_id(), record);
+        }
+        Ok(())
+    }
+
+    /// Retrieve a stored record from the data layer
+    async fn get<St: Storable>(&self, id: St::Key) -> Result<DbRecord, StorageError> {
+        if self.is_transaction_active().await {
+            if let Some(result) = self.trans.get::<St>(&id).await {
+                // there's a transacted item, return that one since it's "more up to date"
+                return Ok(result);
+            }
+        }
+        let bin_id = St::get_full_binary_key_id(&id);
+
+        let guard = self.db.read().await;
+        if let Some(result) = (*guard).get(&bin_id).cloned() {
+            Ok(result)
+        } else {
+            Err(StorageError::GetError("Not found".to_string()))
+        }
+    }
+
+    /// Retrieve all of the objects of a given type from the storage layer, optionally limiting on "num" results
+    async fn get_all<St: Storable>(
+        &self,
+        num: Option<usize>,
+    ) -> Result<Vec<DbRecord>, StorageError> {
+        let guard = self.db.read().await;
+        let mut list = vec![];
+        for (_, item) in guard.iter() {
+            let ty = match &item {
+                DbRecord::Azks(_) => StorageType::Azks,
+                DbRecord::HistoryNodeState(_) => StorageType::HistoryNodeState,
+                DbRecord::HistoryTreeNode(_) => StorageType::HistoryTreeNode,
+                DbRecord::ValueState(_) => StorageType::ValueState,
+            };
+            if ty == St::data_type() {
+                list.push(item.clone());
+            }
+
+            if let Some(count) = num {
+                if count > 0 && list.len() >= count {
+                    break;
+                }
+            }
+        }
+
+        if self.is_transaction_active().await {
+            // check transacted objects
+            let mut updated = vec![];
+            for item in list.into_iter() {
+                match &item {
+                    DbRecord::Azks(azks) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::append_only_zks::Azks>(&azks.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::HistoryNodeState(state) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::node_state::HistoryNodeState>(&state.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::HistoryTreeNode(node) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::history_tree_node::HistoryTreeNode>(&node.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::ValueState(state) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::storage::types::ValueState>(&state.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                }
+                updated.push(item);
+            }
+            Ok(updated)
+        } else {
+            Ok(list)
+        }
+    }
+
+    /// Add a user state element to the associated user
+    async fn append_user_state(&self, value: &ValueState) -> Result<(), StorageError> {
+        self.set(DbRecord::ValueState(value.clone())).await
+    }
+
+    async fn append_user_states(&self, values: Vec<ValueState>) -> Result<(), StorageError> {
+        let new_vec = values
+            .into_iter()
+            .map(DbRecord::ValueState)
+            .collect();
+        self.batch_set(new_vec).await
+    }
+
+    /// Retrieve the user data for a given user
+    async fn get_user_data(&self, username: &AkdKey) -> Result<KeyData, StorageError> {
+        let guard = self.db.read().await;
+        let mut results = vec![];
+        for (_, item) in guard.iter() {
+            if let DbRecord::ValueState(value_state) = &item {
+                if value_state.username == *username {
+                    results.push(value_state.clone());
+                }
+            }
+        }
+
+        // return ordered by epoch (from smallest -> largest)
+        results.sort_by(|a, b| a.epoch.cmp(&b.epoch));
+
+        Ok(KeyData { states: results })
+    }
+
+    /// Retrieve a specific state for a given user
+    async fn get_user_state(
+        &self,
+        username: &AkdKey,
+        flag: ValueStateRetrievalFlag,
+    ) -> Result<ValueState, StorageError> {
+        let intermediate = self.get_user_data(username).await?.states;
+        match flag {
+            ValueStateRetrievalFlag::MaxEpoch =>
+            // retrieve by max epoch
+            {
+                if let Some(value) = intermediate.iter().max_by(|a, b| a.epoch.cmp(&b.epoch)) {
+                    return Ok(value.clone());
+                }
+            }
+            ValueStateRetrievalFlag::MaxVersion =>
+            // retrieve the max version
+            {
+                if let Some(value) = intermediate.iter().max_by(|a, b| a.version.cmp(&b.version)) {
+                    return Ok(value.clone());
+                }
+            }
+            ValueStateRetrievalFlag::MinEpoch =>
+            // retrieve by min epoch
+            {
+                if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
+                    return Ok(value.clone());
+                }
+            }
+            ValueStateRetrievalFlag::MinVersion =>
+            // retrieve the min version
+            {
+                if let Some(value) = intermediate.iter().min_by(|a, b| a.version.cmp(&b.version)) {
+                    return Ok(value.clone());
+                }
+            }
+            _ =>
+            // search for specific property
+            {
+                let mut tracked_epoch = 0u64;
+                let mut tracker = None;
+                for kvp in intermediate.iter() {
+                    match flag {
+                        ValueStateRetrievalFlag::SpecificVersion(version)
+                            if version == kvp.version =>
+                        {
+                            return Ok(kvp.clone())
+                        }
+                        ValueStateRetrievalFlag::LeqEpoch(epoch) if epoch == kvp.epoch => {
+                            return Ok(kvp.clone());
+                        }
+                        ValueStateRetrievalFlag::LeqEpoch(epoch) if kvp.epoch < epoch => {
+                            match tracked_epoch {
+                                0u64 => {
+                                    tracked_epoch = kvp.epoch;
+                                    tracker = Some(kvp.clone());
+                                }
+                                other_epoch => {
+                                    if kvp.epoch > other_epoch {
+                                        tracker = Some(kvp.clone());
+                                        tracked_epoch = kvp.epoch;
+                                    }
+                                }
+                            }
+                        }
+                        ValueStateRetrievalFlag::SpecificEpoch(epoch) if epoch == kvp.epoch => {
+                            return Ok(kvp.clone())
+                        }
+                        _ => continue,
+                    }
+                }
+
+                if let Some(r) = tracker {
+                    return Ok(r);
+                }
+            }
+        }
+        Err(StorageError::GetError(String::from("Not found")))
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -47,6 +47,9 @@ pub trait Storable: Clone + Serialize + DeserializeOwned + Sync {
 
     /// Retrieve the full binary version of a key (for comparisons)
     fn get_full_binary_key_id(key: &Self::Key) -> Vec<u8>;
+
+    /// Reformat a key from the full-binary specification
+    fn key_from_full_binary(bin: &[u8]) -> Result<Self::Key, String>;
 }
 
 /// Represents the storage layer for the AKD (with associated configuration if necessary)
@@ -166,6 +169,12 @@ pub trait V2Storage: Clone {
 
     /// Retrieve a stored record from the data layer
     async fn get<St: Storable>(&self, id: St::Key) -> Result<DbRecord, StorageError>;
+
+    /// Retrieve a batch of records by id
+    async fn batch_get<St: Storable>(
+        &self,
+        ids: Vec<St::Key>,
+    ) -> Result<Vec<DbRecord>, StorageError>;
 
     /// Retrieve all of the objects of a given type from the storage layer, optionally limiting on "num" results
     async fn get_all<St: Storable>(
@@ -476,6 +485,18 @@ impl<S: V1Storage + Send + Sync> V2Storage for V2FromV1StorageWrapper<S> {
                 }
             }
         }
+    }
+
+    /// Retrieve a batch of records by id
+    async fn batch_get<St: Storable>(
+        &self,
+        ids: Vec<St::Key>,
+    ) -> Result<Vec<DbRecord>, StorageError> {
+        let mut map = Vec::new();
+        for key in ids.into_iter() {
+            map.push(self.get::<St>(key).await?);
+        }
+        Ok(map)
     }
 
     /// Retrieve all of the objects of a given type from the storage layer, optionally limiting on "num" results

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -143,6 +143,9 @@ pub trait V1Storage: Clone {
 /// Updated storage layer with better support of asynchronous work and batched operations
 #[async_trait]
 pub trait V2Storage: Clone {
+    /// Log some information about the cache (hit rate, etc)
+    async fn log_metrics(&self, level: log::Level);
+
     /// Start a transaction in the storage layer
     async fn begin_transaction(&mut self) -> bool;
 
@@ -364,6 +367,9 @@ impl<S: V1Storage + Send + Sync> From<S> for V2FromV1StorageWrapper<S> {
 
 #[async_trait]
 impl<S: V1Storage + Send + Sync> V2Storage for V2FromV1StorageWrapper<S> {
+    /// Log some information about the cache (hit rate, etc)
+    async fn log_metrics(&self, _level: log::Level) {}
+
     /// Start a transaction in the storage layer
     async fn begin_transaction(&mut self) -> bool {
         self.trans.begin_transaction().await

--- a/src/storage/mysql/mod.rs
+++ b/src/storage/mysql/mod.rs
@@ -434,7 +434,8 @@ impl AsyncMySqlDatabase {
             .tcp_port(dport);
         let opts: Opts = builder.into();
         let conn = Conn::new(opts).await?;
-        conn.drop_query(r"CREATE DATABASE IF NOT EXISTS test_db").await?;
+        conn.drop_query(r"CREATE DATABASE IF NOT EXISTS test_db")
+            .await?;
 
         Ok(())
     }

--- a/src/storage/mysql/mod.rs
+++ b/src/storage/mysql/mod.rs
@@ -19,9 +19,11 @@ use log::{debug, error, info, trace, warn};
 use mysql_async::prelude::*;
 use mysql_async::*;
 
+use std::collections::HashSet;
+use std::iter::FromIterator;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
-use tokio::time::{Instant, Duration};
+use tokio::time::{Duration, Instant};
 
 type MySqlError = mysql_async::error::Error;
 
@@ -32,6 +34,7 @@ const TABLE_AZKS: &str = "azks";
 const TABLE_HISTORY_TREE_NODES: &str = "history";
 const TABLE_HISTORY_NODE_STATES: &str = "states";
 const TABLE_USER: &str = "users";
+const TEMP_IDS_TABLE: &str = "temp_ids_table";
 
 const MAXIMUM_SQL_TIER_CONNECTION_TIMEOUT_SECS: u64 = 300;
 const SQL_RECONNECTION_DELAY_SECS: u64 = 5;
@@ -120,7 +123,7 @@ impl AsyncMySqlDatabase {
         port: Option<u16>,
         cache_options: MySqlCacheOptions,
     ) -> Self {
-        let dport = port.unwrap_or(1u16);
+        let dport = port.unwrap_or(3306u16);
         let mut builder = OptsBuilder::new();
         builder
             .ip_or_hostname(endpoint)
@@ -149,7 +152,7 @@ impl AsyncMySqlDatabase {
 
             num_reads: Arc::new(tokio::sync::RwLock::new(0)),
             num_writes: Arc::new(tokio::sync::RwLock::new(0)),
-            time_spent: Arc::new(tokio::sync::RwLock::new(Duration::from_millis(0)))
+            time_spent: Arc::new(tokio::sync::RwLock::new(Duration::from_millis(0))),
         }
     }
 
@@ -336,7 +339,6 @@ impl AsyncMySqlDatabase {
     }
 
     /// Delete all the data in the tables
-    #[allow(dead_code)]
     pub async fn delete_data(&self) -> core::result::Result<(), MySqlError> {
         let mut conn = self.get_connection().await?;
 
@@ -415,6 +417,28 @@ impl AsyncMySqlDatabase {
         Ok(mini_tx)
     }
 
+    /// Create the test database
+    #[allow(dead_code)]
+    pub(crate) async fn create_test_db<T: Into<String>>(
+        endpoint: T,
+        user: Option<T>,
+        password: Option<T>,
+        port: Option<u16>,
+    ) -> core::result::Result<(), MySqlError> {
+        let dport = port.unwrap_or(3306u16);
+        let mut builder = OptsBuilder::new();
+        builder
+            .ip_or_hostname(endpoint)
+            .user(user)
+            .pass(password)
+            .tcp_port(dport);
+        let opts: Opts = builder.into();
+        let conn = Conn::new(opts).await?;
+        conn.drop_query(r"CREATE DATABASE IF NOT EXISTS test_db").await?;
+
+        Ok(())
+    }
+
     /// Cleanup the test data table
     #[allow(dead_code)]
     pub(crate) async fn test_cleanup(&self) -> core::result::Result<(), MySqlError> {
@@ -479,7 +503,12 @@ impl V2Storage for AsyncMySqlDatabase {
         let mut w = self.num_writes.write().await;
         let mut ts = self.time_spent.write().await;
 
-        let msg = format!("MySQL writes: {}, MySQL reads: {}, Time spent in MySQL op: {} s", *w, *r, (*ts).as_millis());
+        let msg = format!(
+            "MySQL writes: {}, MySQL reads: {}, Time spent in MySQL op: {} s",
+            *w,
+            *r,
+            (*ts).as_millis()
+        );
 
         *r = 0;
         *w = 0;
@@ -613,7 +642,7 @@ impl V2Storage for AsyncMySqlDatabase {
 
             let conn = self.get_connection().await?;
             let statement = DbRecord::get_specific_statement::<St>();
-            let params = DbRecord::get_specific_params::<St>(id);
+            let params = DbRecord::get_specific_params::<St>(&id);
             let out = match params {
                 Some(p) => match conn.first_exec(statement, p).await {
                     Err(err) => Err(err),
@@ -646,6 +675,118 @@ impl V2Storage for AsyncMySqlDatabase {
             Ok(None) => Err(StorageError::GetError("Not found".to_string())),
             Err(error) => Err(StorageError::GetError(error.to_string())),
         }
+    }
+
+    /// Retrieve a batch of records by id
+    async fn batch_get<St: Storable>(
+        &self,
+        ids: Vec<St::Key>,
+    ) -> Result<Vec<DbRecord>, StorageError> {
+        let mut map = Vec::new();
+
+        let mut key_set: HashSet<St::Key> = HashSet::from_iter(ids.iter().cloned());
+
+        let trans_active = self.is_transaction_active().await;
+        // first check the transaction log & cache records
+        for id in ids.iter() {
+            if trans_active {
+                // we're in a transaction, meaning the object _might_ be newer and therefore we should try and read if from the transaction
+                // log instead of the raw storage layer
+                if let Some(result) = self.trans.get::<St>(id).await {
+                    map.push(result);
+                    key_set.remove(id);
+                    continue;
+                }
+            }
+
+            if let Some(cache) = &self.cache {
+                if let Some(result) = cache.hit_test::<St>(id).await {
+                    map.push(result);
+                    key_set.remove(id);
+                    continue;
+                }
+            }
+        }
+
+        if !key_set.is_empty() {
+            // these are items to be retrieved from the backing database
+            let result = async {
+                let tic = Instant::now();
+
+                debug!("BEGIN MySQL get batch");
+                let mut conn = self.get_connection().await?;
+
+                let results =
+                    if let Some(create_table_cmd) = DbRecord::get_batch_create_temp_table::<St>() {
+                        // Create the temp table
+                        let out = conn.drop_query(create_table_cmd).await;
+                        conn = self.check_for_infra_error(out)?;
+
+                        // Fill temp table
+                        let fill_statement = DbRecord::get_batch_fill_temp_table::<St>();
+                        for batch in key_set.into_iter().collect::<Vec<St::Key>>().chunks(500) {
+                            // unwrapping here because it's safe to do so, since we've already guarded against type = Azks
+                            let param_groups: Vec<mysql_async::Params> = batch
+                                .iter()
+                                .map(|value| DbRecord::get_specific_params::<St>(value).unwrap())
+                                .collect();
+                            let prepped = conn.prepare(fill_statement.clone()).await?;
+                            let out = prepped.batch(param_groups).await;
+                            conn = self.check_for_infra_error(out)?.close().await?;
+                        }
+
+                        // Query the records which intersect (INNER JOIN) with the temp table of ids
+                        let query = DbRecord::get_batch_statement::<St>();
+                        let out = conn.query(query).await;
+                        let result = self.check_for_infra_error(out)?;
+
+                        let (nconn, out) = result
+                            .reduce_and_drop(vec![], |mut acc, mut row| {
+                                if let Ok(result) = DbRecord::from_row::<St>(&mut row) {
+                                    acc.push(result);
+                                }
+                                acc
+                            })
+                            .await?;
+
+                        // drop the temp table
+                        let t_out = nconn
+                            .drop_query(format!("DROP TEMPORARY TABLE `{}`", TEMP_IDS_TABLE))
+                            .await;
+                        self.check_for_infra_error(t_out)?;
+
+                        out
+                    } else {
+                        // no results (i.e. AZKS table doesn't support "get by batch ids")
+                        vec![]
+                    };
+
+                debug!("END MySQL get batch");
+                let toc = Instant::now() - tic;
+                *(self.time_spent.write().await) += toc;
+
+                if let Some(cache) = &self.cache {
+                    // insert retrieved records into the cache for faster future access
+                    for el in results.iter() {
+                        cache.put(el).await;
+                    }
+                }
+
+                Ok::<Vec<DbRecord>, mysql_async::error::Error>(results)
+            };
+
+            *(self.num_reads.write().await) += 1;
+
+            match result.await {
+                Ok(result_vec) => {
+                    for item in result_vec.into_iter() {
+                        map.push(item);
+                    }
+                }
+                Err(error) => return Err(StorageError::GetError(error.to_string())),
+            }
+        }
+        Ok(map)
     }
 
     /// Retrieve all of the objects of a given type from the storage layer, optionally limiting on "num" results
@@ -952,9 +1093,15 @@ trait MySqlStorable {
 
     fn get_statement<St: Storable>() -> String;
 
+    fn get_batch_create_temp_table<St: Storable>() -> Option<String>;
+
+    fn get_batch_fill_temp_table<St: Storable>() -> String;
+
+    fn get_batch_statement<St: Storable>() -> String;
+
     fn get_specific_statement<St: Storable>() -> String;
 
-    fn get_specific_params<St: Storable>(key: St::Key) -> Option<mysql_async::Params>;
+    fn get_specific_params<St: Storable>(key: &St::Key) -> Option<mysql_async::Params>;
 
     fn from_row<St: Storable>(row: &mut mysql_async::Row) -> core::result::Result<Self, MySqlError>
     where
@@ -1010,6 +1157,89 @@ impl MySqlStorable for DbRecord {
         }
     }
 
+    fn get_batch_create_temp_table<St: Storable>() -> Option<String> {
+        match St::data_type() {
+            StorageType::Azks => None,
+            StorageType::HistoryNodeState => {
+                Some(
+                    format!(
+                        "CREATE TEMPORARY TABLE `{}`(`label_len` INT UNSIGNED NOT NULL, `label_val` BIGINT UNSIGNED NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL)",
+                        TEMP_IDS_TABLE
+                    )
+                )
+            },
+            StorageType::HistoryTreeNode => {
+                Some(
+                    format!(
+                        "CREATE TEMPORARY TABLE `{}`(`location` BIGINT UNSIGNED NOT NULL)",
+                        TEMP_IDS_TABLE
+                    )
+                )
+            },
+            StorageType::ValueState => {
+                Some(
+                    format!(
+                        "CREATE TEMPORARY TABLE `{}`(`username` VARCHAR(256) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL)",
+                        TEMP_IDS_TABLE
+                    )
+                )
+            },
+        }
+    }
+
+    fn get_batch_fill_temp_table<St: Storable>() -> String {
+        match St::data_type() {
+            StorageType::Azks => "".to_string(),
+            StorageType::HistoryNodeState => {
+                format!(
+                    "INSERT INTO `{}` (`label_len`, `label_val`, `epoch`) VALUES (:label_len, :label_val, :epoch)",
+                    TEMP_IDS_TABLE
+                )
+            }
+            StorageType::HistoryTreeNode => {
+                format!(
+                    "INSERT INTO `{}` (`location`) VALUES (:location)",
+                    TEMP_IDS_TABLE
+                )
+            }
+            StorageType::ValueState => {
+                format!(
+                    "INSERT INTO `{}` (`username`, `epoch`) VALUES (:username, :epoch)",
+                    TEMP_IDS_TABLE
+                )
+            }
+        }
+    }
+
+    fn get_batch_statement<St: Storable>() -> String {
+        match St::data_type() {
+            StorageType::Azks => {
+                format!("SELECT {} FROM `{}` LIMIT 1", SELECT_AZKS_DATA, TABLE_AZKS)
+            }
+            StorageType::HistoryNodeState => {
+                format!(
+                    "SELECT a.`label_len`, a.`label_val`, a.`epoch`, a.`value`, a.`child_states` FROM `{}` a INNER JOIN {} ids ON ids.`label_len` = a.`label_len` AND ids.`label_val` = a.`label_val` AND ids.`epoch` = a.`epoch`",
+                    TABLE_HISTORY_NODE_STATES,
+                    TEMP_IDS_TABLE
+                )
+            }
+            StorageType::HistoryTreeNode => {
+                format!(
+                    "SELECT a.`location`, a.`label_len`, a.`label_val`, a.`epochs`, a.`parent`, a.`node_type` FROM `{}` a INNER JOIN {} ids ON ids.`location` = a.`location`",
+                    TABLE_HISTORY_TREE_NODES,
+                    TEMP_IDS_TABLE
+                )
+            }
+            StorageType::ValueState => {
+                format!(
+                    "SELECT a.`username`, a.`epoch`, a.`version`, a.`node_label_val`, a.`node_label_len`, a.`data` FROM `{}` a INNER JOIN {} ids ON ids.`username` = a.`username` AND ids.`epoch` = a.`epoch`",
+                    TABLE_USER,
+                    TEMP_IDS_TABLE
+                )
+            }
+        }
+    }
+
     fn get_specific_statement<St: Storable>() -> String {
         match St::data_type() {
             StorageType::Azks => format!("SELECT {} FROM `{}` LIMIT 1", SELECT_AZKS_DATA, TABLE_AZKS),
@@ -1019,13 +1249,13 @@ impl MySqlStorable for DbRecord {
         }
     }
 
-    fn get_specific_params<St: Storable>(key: St::Key) -> Option<mysql_async::Params> {
-        // TODO: serializing & deserializing just to get type proper type. There MUST be a better way...
+    fn get_specific_params<St: Storable>(key: &St::Key) -> Option<mysql_async::Params> {
         match St::data_type() {
             StorageType::Azks => None,
             StorageType::HistoryNodeState => {
-                let bin = bincode::serialize(&key).unwrap();
-                let back: crate::node_state::NodeStateKey = bincode::deserialize(&bin).unwrap();
+                let bin = St::get_full_binary_key_id(key);
+                let back: crate::node_state::NodeStateKey =
+                    crate::node_state::HistoryNodeState::key_from_full_binary(&bin).unwrap();
                 Some(mysql_async::Params::from(params! {
                     "label_len" => back.0.len,
                     "label_val" => back.0.val,
@@ -1033,16 +1263,17 @@ impl MySqlStorable for DbRecord {
                 }))
             }
             StorageType::HistoryTreeNode => {
-                let bin = bincode::serialize(&key).unwrap();
-                let back: crate::history_tree_node::NodeKey = bincode::deserialize(&bin).unwrap();
+                let bin = St::get_full_binary_key_id(key);
+                let back: crate::history_tree_node::NodeKey =
+                    crate::history_tree_node::HistoryTreeNode::key_from_full_binary(&bin).unwrap();
                 Some(mysql_async::Params::from(params! {
                     "location" => back.0
                 }))
             }
             StorageType::ValueState => {
-                let bin = bincode::serialize(&key).unwrap();
+                let bin = St::get_full_binary_key_id(key);
                 let back: crate::storage::types::ValueStateKey =
-                    bincode::deserialize(&bin).unwrap();
+                    crate::storage::types::ValueState::key_from_full_binary(&bin).unwrap();
                 Some(mysql_async::Params::from(params! {
                     "username" => back.0,
                     "epoch" => back.1

--- a/src/storage/mysql/mod.rs
+++ b/src/storage/mysql/mod.rs
@@ -507,7 +507,7 @@ impl V2Storage for AsyncMySqlDatabase {
             "MySQL writes: {}, MySQL reads: {}, Time spent in MySQL op: {} s",
             *w,
             *r,
-            (*ts).as_millis()
+            (*ts).as_secs_f64()
         );
 
         *r = 0;

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -25,36 +25,50 @@ type HistoryTreeNode = crate::history_tree_node::HistoryTreeNode;
 
 #[tokio::test]
 #[serial]
-async fn async_test_basic_database() {
+async fn test_v1_in_memory_db() {
     let db = AsyncInMemoryDatabase::new();
     async_test_get_and_set_item(&db).await;
     async_test_user_data(&db).await;
-
-    // let db = AsyncInMemoryDbWithCache::new();
-    // async_test_get_and_set_item(&db).await;
-    // async_test_user_data(&db).await;
 }
 
 #[tokio::test]
 #[serial]
-async fn async_test_new_basic_database() {
+async fn test_v1_to_v2_db_wrapper() {
     let mut db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
     async_test_new_get_and_set_item(&db).await;
     async_test_new_user_data(&db).await;
     async_test_transaction(&mut db).await;
-
-    // let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDbWithCache::new());
-    // async_test_new_get_and_set_item(&db).await;
-    // async_test_new_user_data(&db).await;
+    async_test_batch_get_item(&db).await;
 }
 
 #[tokio::test]
 #[serial]
-async fn test_async_mysql_new_db() {
+async fn test_v2_in_memory_db() {
+    let mut db = crate::storage::memory::newdb::AsyncInMemoryDatabase::new();
+    async_test_new_get_and_set_item(&db).await;
+    async_test_new_user_data(&db).await;
+    async_test_transaction(&mut db).await;
+    async_test_batch_get_item(&db).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_mysql_db() {
     if AsyncMySqlDatabase::test_guard() {
+        if let Err(error) = AsyncMySqlDatabase::create_test_db(
+            "localhost",
+            Option::from("root"),
+            Option::from("example"),
+            Option::from(8001),
+        )
+        .await
+        {
+            panic!("Error creating test database: {}", error);
+        }
+
         let mut mysql_db = AsyncMySqlDatabase::new(
             "localhost",
-            "default",
+            "test_db",
             Option::from("root"),
             Option::from("example"),
             Option::from(8001),
@@ -70,6 +84,7 @@ async fn test_async_mysql_new_db() {
         async_test_new_get_and_set_item(&mysql_db).await;
         async_test_new_user_data(&mysql_db).await;
         async_test_transaction(&mut mysql_db).await;
+        async_test_batch_get_item(&mysql_db).await;
 
         // clean the test infra
         if let Err(mysql_async::error::Error::Server(error)) = mysql_db.test_cleanup().await {
@@ -149,6 +164,81 @@ async fn async_test_new_get_and_set_item<Ns: V2Storage>(storage: &Ns) {
 
     // === ValueState storage === //
     // TODO: test with this format of user storage
+}
+
+async fn async_test_batch_get_item<Ns: V2Storage>(storage: &Ns) {
+    let mut rand_users: Vec<String> = vec![];
+    for _ in 0..20 {
+        rand_users.push(
+            thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(30)
+                .map(char::from)
+                .collect(),
+        );
+    }
+
+    let mut data = Vec::new();
+
+    let mut epoch = 1;
+    for value in rand_users.iter() {
+        for user in rand_users.iter() {
+            data.push(DbRecord::ValueState(ValueState {
+                plaintext_val: Values(value.clone()),
+                version: 1u64,
+                label: NodeLabel {
+                    val: 1u64,
+                    len: 1u32,
+                },
+                epoch: epoch,
+                username: AkdKey(user.clone()),
+            }));
+        }
+        epoch += 1;
+    }
+
+    let tic = Instant::now();
+    assert_eq!(Ok(()), storage.batch_set(data.clone()).await);
+    let toc: Duration = Instant::now() - tic;
+    println!("Storage batch op: {} ms", toc.as_millis());
+    let got = storage
+        .get::<ValueState>(ValueStateKey(rand_users[0].clone(), 10))
+        .await;
+    if let Err(_) = got {
+        panic!("Failed to retrieve a user after batch insert");
+    }
+
+    let keys: Vec<ValueStateKey> = rand_users
+        .iter()
+        .map(|user| ValueStateKey(user.clone(), 1))
+        .collect();
+    let got_all = storage.batch_get::<ValueState>(keys).await;
+    match got_all {
+        Err(_) => panic!("Failed to retrieve batch of user at specific epochs"),
+        Ok(lst) if lst.len() != rand_users.len() => {
+            panic!(
+                "Retrieved list length does not match input length {} != {}",
+                lst.len(),
+                rand_users.len()
+            );
+        }
+        Ok(results) => {
+            // correct length, now check the values
+            for result in results.into_iter() {
+                // find the initial record with the same username & epoch
+                let initial_record = data.iter().find(|&x| {
+                    if let DbRecord::ValueState(value_state) = &x {
+                        if let DbRecord::ValueState(retrieved_state) = &result {
+                            return value_state.username == retrieved_state.username && value_state.epoch == retrieved_state.epoch;
+                        }
+                    }
+                    false
+                }).cloned();
+                // assert it matches what was given matches what was retrieved
+                assert_eq!(Some(result), initial_record);
+            }
+        }
+    }
 }
 
 async fn async_test_transaction<S: V2Storage + Sync + Send>(storage: &mut S) {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -226,14 +226,18 @@ async fn async_test_batch_get_item<Ns: V2Storage>(storage: &Ns) {
             // correct length, now check the values
             for result in results.into_iter() {
                 // find the initial record with the same username & epoch
-                let initial_record = data.iter().find(|&x| {
-                    if let DbRecord::ValueState(value_state) = &x {
-                        if let DbRecord::ValueState(retrieved_state) = &result {
-                            return value_state.username == retrieved_state.username && value_state.epoch == retrieved_state.epoch;
+                let initial_record = data
+                    .iter()
+                    .find(|&x| {
+                        if let DbRecord::ValueState(value_state) = &x {
+                            if let DbRecord::ValueState(retrieved_state) = &result {
+                                return value_state.username == retrieved_state.username
+                                    && value_state.epoch == retrieved_state.epoch;
+                            }
                         }
-                    }
-                    false
-                }).cloned();
+                        false
+                    })
+                    .cloned();
                 // assert it matches what was given matches what was retrieved
                 assert_eq!(Some(result), initial_record);
             }

--- a/src/storage/transaction.rs
+++ b/src/storage/transaction.rs
@@ -28,6 +28,12 @@ pub struct Transaction {
     num_writes: Arc<tokio::sync::RwLock<u64>>,
 }
 
+impl std::fmt::Debug for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "a lone transaction")
+    }
+}
+
 impl Transaction {
     pub(crate) fn new() -> Self {
         Self {

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -128,7 +128,7 @@ pub enum ValueStateRetrievalFlag {
 
 /// This needs to be PUBLIC public, since anyone implementing a data-layer will need
 /// to be able to access this and all the internal types
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum DbRecord {
     /// An Azks
     Azks(crate::append_only_zks::Azks),


### PR DESCRIPTION
1. Added a lot of timing & debug info to various parts of the program for doing benchmark calculations of code performance. Example output from POC app
```
======= Benchmark operation requested ======= 
Beginning PUBLISH benchmark of 100 users with 1 updates/user
INFO - Starting the verifiable directory host
INFO - Cache hit since last: 4874, cached size: 3566 items
INFO - Transaction writes: 9771, Transaction reads: 9885
INFO - MySQL writes: 2511, MySQL reads: 3366, Time spent in MySQL op: 11.482 s
PUBLISHED 100 records in 12.164723323 s
Benchmark output: Inserted 100 users with 1 updates/user
Execution time: 12164 ms
Time-per-user (avg): 121649 µs
Time-per-op (avg): 121649 µs
INFO - AKD host shutting down
```
2. Added ```batch_get``` support to the storage layer for future support of node retrieval in batches (rather than 1-by-1)