### PR TITLE
Batch user information retrieval + disabling cache cleaning during a transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 
 /poc/src/.DS_Store
 /poc/target
+/poc/log.txt

--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -26,7 +26,7 @@ fn single_insertion(c: &mut Criterion) {
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-    let db = akd::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
+    let db = InMemoryDb::new();
 
     let mut azks1 = runtime.block_on(Azks::new::<_, Blake3>(&db)).unwrap();
     let mut insertion_set = Vec::<(NodeLabel, Blake3Digest)>::new();

--- a/examples/measurements.rs
+++ b/examples/measurements.rs
@@ -57,7 +57,7 @@ async fn main() {
 
     let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDbWithCache::new());
     let mut akd_dir =
-        Directory::<akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDbWithCache>>::new::<
+        Directory::<_>::new::<
             Blake3_256<BaseElement>,
         >(&db)
         .await

--- a/examples/measurements.rs
+++ b/examples/measurements.rs
@@ -56,10 +56,7 @@ async fn main() {
     let mut existing_keys = Vec::<AkdKey>::new();
 
     let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDbWithCache::new());
-    let mut akd_dir =
-        Directory::<_>::new::<
-            Blake3_256<BaseElement>,
-        >(&db)
+    let mut akd_dir = Directory::<_>::new::<Blake3_256<BaseElement>>(&db)
         .await
         .unwrap();
 

--- a/poc/Cargo.toml
+++ b/poc/Cargo.toml
@@ -15,6 +15,10 @@ hex = "0.4.3"
 structopt = "0.3.13"
 rand = "0.8"
 log = { version = "0.4.8", features = ["kv_unstable"] }
+once_cell = "1"
+thread-id = "3"
+multi_log = "0.1"
+clap = "2"
 
 [dev-dependencies]
 serial_test = "*"

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -12,8 +12,8 @@ use akd::storage::V2Storage;
 use log::{debug, error, info};
 use std::marker::{Send, Sync};
 use tokio::sync::mpsc::*;
-use winter_crypto::Hasher;
 use tokio::time::Instant;
+use winter_crypto::Hasher;
 
 pub(crate) struct Rpc(
     pub(crate) DirectoryCommand,

--- a/poc/src/logs.rs
+++ b/poc/src/logs.rs
@@ -1,3 +1,4 @@
+extern crate thread_id;
 // Copyright (c) Facebook, Inc. and its affiliates.
 //
 // This source code is licensed under both the MIT license found in the
@@ -7,14 +8,71 @@
 
 use colored::*;
 use log::{Level, LevelFilter, Metadata, Record};
+use once_cell::sync::Lazy;
+use once_cell::sync::OnceCell;
+use tokio::time::{Duration, Instant};
+
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+
+static EPOCH: OnceCell<Instant> = OnceCell::new();
 
 pub(crate) struct ConsoleLogger {
     pub(crate) level: Level,
 }
 
 impl ConsoleLogger {
-    pub(crate) fn touch(&self) {
-        println!();
+    pub(crate) fn touch() {
+        EPOCH.get_or_init(Instant::now);
+    }
+
+    pub(crate) fn format_log_record(io: &mut (dyn Write + Send), record: &Record) {
+        let target = {
+            if let Some(target_str) = record.target().split(':').last() {
+                if let Some(line) = record.line() {
+                    format!(" ({}:{})", target_str, line)
+                } else {
+                    format!(" ({})", target_str.to_string())
+                }
+            } else {
+                "".to_string()
+            }
+        };
+
+        let toc = if let Some(epoch) = EPOCH.get() {
+            Instant::now() - *epoch
+        } else {
+            Duration::from_millis(0)
+        };
+
+        let seconds = toc.as_secs();
+        let hours = seconds / 3600;
+        let minutes = (seconds / 60) % 60;
+        let seconds = seconds % 60;
+        let miliseconds = toc.subsec_millis();
+
+        let msg = format!(
+            "[{:02}:{:02}:{:02}.{:03}] ({:x}) {:6} {}{}",
+            hours,
+            minutes,
+            seconds,
+            miliseconds,
+            thread_id::get(),
+            record.level(),
+            record.args(),
+            target
+        );
+        let msg = match record.level() {
+            Level::Trace | Level::Debug => msg.white(),
+            Level::Info => msg.blue(),
+            Level::Warn => msg.yellow(),
+            Level::Error => msg.red(),
+        };
+
+        let _ = writeln!(io, "{}", msg);
     }
 }
 
@@ -24,17 +82,46 @@ impl log::Log for ConsoleLogger {
     }
 
     fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let msg = format!("{} - {}", record.level(), record.args());
-            let msg = match record.level() {
-                Level::Trace | Level::Debug => msg.white(),
-                Level::Info => msg.blue(),
-                Level::Warn => msg.yellow(),
-                Level::Error => msg.red(),
-            };
-            println!("{}", msg);
+        if !self.enabled(record.metadata()) {
+            return;
         }
+        let mut io = std::io::stdout();
+        ConsoleLogger::format_log_record(&mut io, record);
     }
 
-    fn flush(&self) {}
+    fn flush(&self) {
+        let _ = std::io::stdout().flush();
+    }
+}
+
+pub(crate) struct FileLogger {
+    sink: Mutex<File>,
+}
+
+impl FileLogger {
+    pub(crate) fn new<T: AsRef<Path>>(path: T) -> io::Result<Self> {
+        let file = File::create(path)?;
+        Ok(Self {
+            sink: Mutex::new(file),
+        })
+    }
+}
+
+impl log::Log for FileLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        // use the global log-level
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let mut sink = &*self.sink.lock().unwrap();
+        ConsoleLogger::format_log_record(&mut sink, record);
+    }
+
+    fn flush(&self) {
+        let _ = std::io::stdout().flush();
+    }
 }

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -130,7 +130,7 @@ async fn main() {
     let (tx, mut rx) = channel(2);
 
     if cli.memory_db {
-        let db = akd::storage::memory::newdb::AsyncInMemoryDatabase::new();
+        let db = akd::storage::memory::AsyncInMemoryDatabase::new();
         let mut directory = Directory::<_>::new::<Blake3>(&db).await.unwrap();
         tokio::spawn(async move {
             directory_host::init_host::<_, Blake3>(&mut rx, &mut directory).await

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -229,8 +229,7 @@ async fn process_input(
 
                 if let Some(err) = code {
                     error!("Benchmark operation error {}", err);
-                }
-                else {
+                } else {
                     let toc = tic.elapsed();
 
                     let millis = toc.as_millis();

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -10,11 +10,14 @@
 
 use akd::directory::Directory;
 use akd::storage::mysql::{AsyncMySqlDatabase, MySqlCacheOptions};
+use clap::arg_enum;
 use commands::Command;
 use log::{error, info, warn};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
+use std::convert::From;
 use std::io::*;
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 use tokio::sync::mpsc::*;
@@ -30,9 +33,32 @@ use logs::ConsoleLogger;
 
 type Blake3 = Blake3_256<BaseElement>;
 
-static CONSOLE_LOGGER: ConsoleLogger = ConsoleLogger {
-    level: log::Level::Info,
-};
+arg_enum! {
+    #[derive(Debug)]
+    enum PublicLogLevels {
+        Error,
+        Warn,
+        Info,
+        Debug,
+        Trace
+    }
+}
+
+impl PublicLogLevels {
+    pub(crate) fn to_log_level(&self) -> log::Level {
+        match &self {
+            PublicLogLevels::Error => log::Level::Error,
+            PublicLogLevels::Warn => log::Level::Warn,
+            PublicLogLevels::Info => log::Level::Info,
+            PublicLogLevels::Debug => log::Level::Debug,
+            PublicLogLevels::Trace => log::Level::Trace,
+        }
+    }
+}
+
+// static CONSOLE_LOGGER: ConsoleLogger = ConsoleLogger {
+//     level: log::Level::Info,
+// };
 
 /// applicationModes
 #[derive(StructOpt)]
@@ -59,6 +85,16 @@ struct Cli {
     #[structopt(long = "debug", short = "d", name = "Enable debugging mode")]
     debug: bool,
 
+    #[structopt(
+        long = "log_level",
+        short = "l",
+        name = "Adjust the console log-level (default = INFO)",
+        possible_values = &PublicLogLevels::variants(),
+        case_insensitive = true,
+        default_value = "Info"
+    )]
+    console_debug: PublicLogLevels,
+
     #[structopt(subcommand)]
     other_mode: Option<OtherMode>,
 }
@@ -66,22 +102,36 @@ struct Cli {
 // MAIN //
 #[tokio::main]
 async fn main() {
+    ConsoleLogger::touch();
+
     let cli = Cli::from_args();
 
-    // enable the logger
-    if let Err(err) =
-        log::set_logger(&CONSOLE_LOGGER).map(|()| log::set_max_level(log::LevelFilter::Debug))
-    {
-        println!("Error setting logger {}", err);
+    // Initialize logging facades
+    let mut loggers: Vec<Box<dyn log::Log>> = vec![Box::new(ConsoleLogger {
+        level: cli.console_debug.to_log_level(),
+    })];
+
+    let level = if cli.debug {
+        // File-logging enabled in debug mode
+        match logs::FileLogger::new("log.txt") {
+            Err(err) => println!("Error initializing file logger {}", err),
+            Ok(flogger) => loggers.push(Box::new(flogger)),
+        }
+        // drop the log level to debug (console has a max-level of "Info")
+        log::Level::Trace
+    } else {
+        cli.console_debug.to_log_level()
+    };
+
+    if let Err(err) = multi_log::MultiLogger::init(loggers, level) {
+        println!("Error initializing multi-logger {}", err);
     }
 
     let (tx, mut rx) = channel(2);
 
     if cli.memory_db {
         let db = akd::storage::memory::newdb::AsyncInMemoryDatabase::new();
-        let mut directory = Directory::<_>::new::<Blake3>(&db)
-        .await
-        .unwrap();
+        let mut directory = Directory::<_>::new::<Blake3>(&db).await.unwrap();
         tokio::spawn(async move {
             directory_host::init_host::<_, Blake3>(&mut rx, &mut directory).await
         });
@@ -97,9 +147,7 @@ async fn main() {
             MySqlCacheOptions::Default, // enable caching
         )
         .await;
-        let mut directory = Directory::<_>::new::<Blake3>(&mysql_db)
-            .await
-            .unwrap();
+        let mut directory = Directory::<_>::new::<Blake3>(&mysql_db).await.unwrap();
         tokio::spawn(async move {
             directory_host::init_host::<_, Blake3>(&mut rx, &mut directory).await
         });
@@ -172,7 +220,7 @@ async fn process_input(
                     match rpc_rx.await {
                         Err(err) => code = Some(format!("{}", err)),
                         Ok(Err(dir_err)) => code = Some(dir_err),
-                        Ok(Ok(msg)) => println!("{}", msg),
+                        Ok(Ok(msg)) => info!("{}", msg),
                     }
                     if code.is_some() {
                         break;
@@ -180,20 +228,21 @@ async fn process_input(
                 }
 
                 if let Some(err) = code {
-                    error!("Benchmark operation completed in ERROR: {}", err);
+                    error!("Benchmark operation error {}", err);
                 }
+                else {
+                    let toc = tic.elapsed();
 
-                let toc = tic.elapsed();
-
-                let millis = toc.as_millis();
-                println!(
-                    "Benchmark output: Inserted {} users with {} updates/user\nExecution time: {} ms\nTime-per-user (avg): {} \u{00B5}s\nTime-per-op (avg): {} \u{00B5}s",
-                    num_users,
-                    num_updates_per_user,
-                    toc.as_millis(),
-                    toc.as_micros() / *num_users as u128,
-                    toc.as_micros() / *num_users as u128 / *num_updates_per_user as u128
-                );
+                    let millis = toc.as_millis();
+                    println!(
+                        "Benchmark output: Inserted {} users with {} updates/user\nExecution time: {} ms\nTime-per-user (avg): {} \u{00B5}s\nTime-per-op (avg): {} \u{00B5}s",
+                        num_users,
+                        num_updates_per_user,
+                        toc.as_millis(),
+                        toc.as_micros() / *num_users as u128,
+                        toc.as_micros() / *num_users as u128 / *num_updates_per_user as u128
+                    );
+                }
             }
             OtherMode::BenchLookup {
                 num_users,

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -34,11 +34,11 @@ pub const DEFAULT_AZKS_KEY: u8 = 1u8;
 #[serde(bound = "")]
 pub struct Azks {
     /// The location of the root
-    pub root: usize,
+    pub root: u64,
     /// The latest complete epoch
     pub latest_epoch: u64,
     /// The number of nodes ie the size of this tree
-    pub num_nodes: usize, // The size of the tree
+    pub num_nodes: u64, // The size of the tree
 }
 
 impl Storable for Azks {
@@ -131,7 +131,7 @@ impl Azks {
     ) -> Result<(), AkdError> {
         self.increment_epoch();
 
-        let mut hash_q = KeyedPriorityQueue::<usize, i32>::new();
+        let mut hash_q = KeyedPriorityQueue::<u64, i32>::new();
         let mut priorities: i32 = 0;
         let mut root_node = HistoryTreeNode::get_from_storage(storage, NodeKey(self.root)).await?;
         for (label, value) in insertion_set {
@@ -375,7 +375,7 @@ impl Azks {
         storage: &S,
         label: NodeLabel,
         epoch: u64,
-    ) -> Result<(MembershipProof<H>, usize), AkdError> {
+    ) -> Result<(MembershipProof<H>, u64), AkdError> {
         let mut parent_labels = Vec::<NodeLabel>::new();
         let mut sibling_labels = Vec::<[NodeLabel; ARITY - 1]>::new();
         let mut sibling_hashes = Vec::<[H::Digest; ARITY - 1]>::new();

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -18,7 +18,7 @@ use crate::serialization::to_digest;
 use crate::storage::types::StorageType;
 use crate::{errors::*, history_tree_node::HistoryTreeNode, node_state::*, ARITY, *};
 use async_recursion::async_recursion;
-use log::debug;
+use log::trace;
 use std::marker::{Send, Sync};
 use winter_crypto::Hasher;
 
@@ -152,11 +152,11 @@ impl Azks {
                     .await?
             };
 
-            debug!("BEGIN insert leaf");
+            trace!("BEGIN insert leaf");
             root_node
                 .insert_leaf::<_, H>(storage, new_leaf, self.latest_epoch, &mut self.num_nodes)
                 .await?;
-            debug!("END insert leaf");
+            trace!("END insert leaf");
 
             hash_q.push(new_leaf_loc, priorities);
             priorities -= 1;

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -470,7 +470,7 @@ mod tests {
     async fn test_batch_insert_basic() -> Result<(), AkdError> {
         let mut rng = OsRng;
         let num_nodes = 10;
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
 
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
@@ -484,7 +484,7 @@ mod tests {
             azks1.insert_leaf::<_, Blake3>(&db, node, val).await?;
         }
 
-        let db2 = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db2 = AsyncInMemoryDatabase::new();
         let mut azks2 = Azks::new::<_, Blake3>(&db2).await?;
 
         azks2
@@ -504,7 +504,7 @@ mod tests {
     async fn test_insert_permuted() -> Result<(), AkdError> {
         let num_nodes = 10;
         let mut rng = OsRng;
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
 
@@ -520,7 +520,7 @@ mod tests {
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
 
-        let db2 = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db2 = AsyncInMemoryDatabase::new();
         let mut azks2 = Azks::new::<_, Blake3>(&db2).await?;
 
         azks2
@@ -553,7 +553,7 @@ mod tests {
 
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set.clone())
             .await?;
@@ -584,7 +584,7 @@ mod tests {
 
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set.clone())
             .await?;
@@ -612,7 +612,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_intermediate() -> Result<(), AkdError> {
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
         insertion_set.push((NodeLabel::new(0b0, 64), Blake3::hash(&[])));
         insertion_set.push((NodeLabel::new(0b1 << 63, 64), Blake3::hash(&[])));
@@ -645,7 +645,7 @@ mod tests {
             let input = Blake3Digest::new(input);
             insertion_set.push((node, input));
         }
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
         let search_label = insertion_set[num_nodes - 1].0;
         azks.batch_insert_leaves::<_, Blake3>(
@@ -665,7 +665,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_very_tiny() -> Result<(), AkdError> {
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
         let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
@@ -689,7 +689,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_tiny() -> Result<(), AkdError> {
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
         let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
@@ -728,7 +728,7 @@ mod tests {
             insertion_set_1.push((node, input));
         }
 
-        let db = storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+        let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_1.clone())
             .await?;

--- a/src/auditor.rs
+++ b/src/auditor.rs
@@ -36,7 +36,7 @@ pub async fn verify_append_only<H: Hasher + Send + Sync>(
     let unchanged_nodes = proof.unchanged_nodes;
     let inserted = proof.inserted;
 
-    let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+    let db = AsyncInMemoryDatabase::new();
     let mut azks = Azks::new::<_, H>(&db).await?;
     azks.batch_insert_leaves_helper::<_, H>(&db, unchanged_nodes, true)
         .await?;

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -471,11 +471,8 @@ mod tests {
     #[allow(unused)]
     #[tokio::test]
     async fn test_simple_publish() -> Result<(), AkdError> {
-        let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
-        let mut akd = Directory::<
-            crate::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-        >::new::<Blake3>(&db)
-        .await?;
+        let db = AsyncInMemoryDatabase::new();
+        let mut akd = Directory::<_>::new::<Blake3>(&db).await?;
 
         akd.publish::<Blake3>(
             vec![(AkdKey("hello".to_string()), Values("world".to_string()))],
@@ -487,11 +484,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_simiple_lookup() -> Result<(), AkdError> {
-        let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
-        let mut akd = Directory::<
-            crate::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-        >::new::<Blake3>(&db)
-        .await?;
+        let db = AsyncInMemoryDatabase::new();
+        let mut akd = Directory::<_>::new::<Blake3>(&db).await?;
 
         akd.publish::<Blake3>(
             vec![
@@ -515,11 +509,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_key_history() -> Result<(), AkdError> {
-        let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
-        let mut akd = Directory::<
-            crate::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-        >::new::<Blake3>(&db)
-        .await?;
+        let db = AsyncInMemoryDatabase::new();
+        let mut akd = Directory::<_>::new::<Blake3>(&db).await?;
 
         akd.publish::<Blake3>(
             vec![
@@ -621,11 +612,8 @@ mod tests {
     #[allow(unused)]
     #[tokio::test]
     async fn test_simple_audit() -> Result<(), AkdError> {
-        let db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
-        let mut akd = Directory::<
-            crate::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-        >::new::<Blake3>(&db)
-        .await?;
+        let db = AsyncInMemoryDatabase::new();
+        let mut akd = Directory::<_>::new::<Blake3>(&db).await?;
 
         akd.publish::<Blake3>(
             vec![

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -115,7 +115,8 @@ impl<S: V2Storage + Sync + Send> Directory<S> {
                 }
             }
         }
-        let insertion_set = update_set.iter().map(|(x, y)| (*x, *y)).collect();
+        let insertion_set: Vec<(NodeLabel, H::Digest)> =
+            update_set.iter().map(|(x, y)| (*x, *y)).collect();
         // ideally the azks and the state would be updated together.
         // It may also make sense to have a temp version of the server's database
         let mut current_azks = self.retrieve_current_azks().await?;

--- a/src/history_tree_node.rs
+++ b/src/history_tree_node.rs
@@ -13,7 +13,7 @@ use crate::storage::types::{DbRecord, StorageType};
 use crate::storage::{Storable, V2Storage};
 use crate::{node_state::*, Direction, ARITY};
 use async_recursion::async_recursion;
-use log::debug;
+use log::trace;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::marker::{Send, Sync};
@@ -218,14 +218,14 @@ impl HistoryTreeNode {
                 // not equal to the label of the calling node.
                 // This means that the current node needs to be pushed down one level (away from root)
                 // in the tree and replaced with a new node whose label is equal to the longest common prefix.
-                debug!("BEGIN get parent");
+                trace!("BEGIN get parent");
                 let mut parent =
                     HistoryTreeNode::get_from_storage(storage, NodeKey(self.parent)).await?;
-                debug!("BEGIN get direction at epoch {}", epoch);
+                trace!("BEGIN get direction at epoch {}", epoch);
                 let self_dir_in_parent = parent.get_direction_at_ep(storage, self, epoch).await?;
                 let new_node_location = *num_nodes;
 
-                debug!("BEGIN create new node");
+                trace!("BEGIN create new node");
                 let mut new_node = HistoryTreeNode::new(
                     lcs_label,
                     new_node_location,
@@ -236,24 +236,24 @@ impl HistoryTreeNode {
                 new_node.write_to_storage(storage).await?;
                 *num_nodes += 1;
                 // Add this node in the correct dir and child node in the other direction
-                debug!("BEGIN update leaf location");
+                trace!("BEGIN update leaf location");
                 new_leaf.parent = new_node.location;
                 new_leaf.write_to_storage(storage).await?;
 
-                debug!("BEGIN update self");
+                trace!("BEGIN update self");
                 self.parent = new_node.location;
                 self.write_to_storage(storage).await?;
 
-                debug!("BEGIN set node child new_node(new_leaf)");
+                trace!("BEGIN set node child new_node(new_leaf)");
                 new_node
                     .set_node_child::<_, H>(storage, epoch, dir_leaf, &new_leaf)
                     .await?;
-                debug!("BEGIN set node child new_node(self)");
+                trace!("BEGIN set node child new_node(self)");
                 new_node
                     .set_node_child::<_, H>(storage, epoch, dir_self, self)
                     .await?;
 
-                debug!("BEGIN set node child parent(new_node)");
+                trace!("BEGIN set node child parent(new_node)");
                 parent
                     .set_node_child::<_, H>(storage, epoch, self_dir_in_parent, &new_node)
                     .await?;
@@ -266,18 +266,18 @@ impl HistoryTreeNode {
                             .await?;
                     new_node.update_hash::<_, H>(storage, epoch).await?;
                 }
-                debug!("BEGIN save new_node");
+                trace!("BEGIN save new_node");
                 new_node.write_to_storage(storage).await?;
-                debug!("BEGIN save parent");
+                trace!("BEGIN save parent");
                 parent.write_to_storage(storage).await?;
-                debug!("BEGIN retrieve new self");
+                trace!("BEGIN retrieve new self");
                 *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
-                debug!("END insert single leaf (dir_self = Some)");
+                trace!("END insert single leaf (dir_self = Some)");
                 Ok(())
             }
             None => {
                 // case where the current node is equal to the lcs
-                debug!("BEGIN get child at epoch");
+                trace!("BEGIN get child at epoch");
                 let child_st = self
                     .get_child_at_epoch::<_, H>(storage, self.get_latest_epoch()?, dir_leaf)
                     .await?;
@@ -287,30 +287,30 @@ impl HistoryTreeNode {
                         Err(HistoryTreeNodeError::CompressionError(self.label))
                     }
                     DummyChildState::Real => {
-                        debug!("BEGIN get child node from storage");
+                        trace!("BEGIN get child node from storage");
                         let mut child_node =
                             HistoryTreeNode::get_from_storage(storage, NodeKey(child_st.location))
                                 .await?;
-                        debug!("BEGIN insert single leaf helper");
+                        trace!("BEGIN insert single leaf helper");
                         child_node
                             .insert_single_leaf_helper::<_, H>(
                                 storage, new_leaf, epoch, num_nodes, hashing,
                             )
                             .await?;
                         if hashing {
-                            debug!("BEGIN update hashes");
+                            trace!("BEGIN update hashes");
                             *self =
                                 HistoryTreeNode::get_from_storage(storage, NodeKey(self.location))
                                     .await?;
                             self.update_hash::<_, H>(storage, epoch).await?;
                             self.write_to_storage(storage).await?;
                         } else {
-                            debug!("BEGIN retrieve self");
+                            trace!("BEGIN retrieve self");
                             *self =
                                 HistoryTreeNode::get_from_storage(storage, NodeKey(self.location))
                                     .await?;
                         }
-                        debug!("END insert single leaf (dir_self = None)");
+                        trace!("END insert single leaf (dir_self = None)");
                         Ok(())
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,9 @@
 //! type Blake3 = Blake3_256<BaseElement>;
 //! use akd::directory::Directory;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//! let mut akd = Directory::<
-//!    akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!    >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//! let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //! };
 //! ```
 //!
@@ -61,11 +59,9 @@
 //! type Blake3 = Blake3_256<BaseElement>;
 //! use akd::directory::Directory;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // commit the latest changes
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!          (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
@@ -87,11 +83,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //!use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
 //!          .await.unwrap();
@@ -112,11 +106,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //!use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
 //!          .await.unwrap();
@@ -148,11 +140,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
 //!          .await.unwrap();
@@ -173,11 +163,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
 //!          .await.unwrap();
@@ -208,11 +196,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
@@ -238,11 +224,9 @@
 //! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 //! use akd::storage::V2Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
-//! let db = akd::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+//! let db = AsyncInMemoryDatabase::new();
 //! async {
-//!     let mut akd = Directory::<
-//!         akd::storage::V2FromV1StorageWrapper<AsyncInMemoryDatabase>,
-//!         >::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
+//!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
 //!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
 //!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)

--- a/src/node_state.rs
+++ b/src/node_state.rs
@@ -256,7 +256,7 @@ pub struct HistoryChildState {
     ///  Tells you whether this child is a dummy
     pub dummy_marker: DummyChildState,
     /// Says where the child node with this label is located
-    pub location: usize,
+    pub location: u64,
     /// Child node's label
     pub label: NodeLabel,
     /// Child node's hash value
@@ -269,16 +269,16 @@ pub struct HistoryChildState {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ChildStateKey(
     pub(crate) Vec<u8>,
-    pub(crate) usize,
-    pub(crate) usize,
-    pub(crate) usize,
+    pub(crate) u64,
+    pub(crate) u64,
+    pub(crate) u64,
 );
 
 unsafe impl Sync for HistoryChildState {}
 
 impl HistoryChildState {
     /// Instantiates a new [HistoryChildState] with given label and hash val.
-    pub fn new<H: Hasher>(loc: usize, label: NodeLabel, hash_val: H::Digest, ep: u64) -> Self {
+    pub fn new<H: Hasher>(loc: u64, label: NodeLabel, hash_val: H::Digest, ep: u64) -> Self {
         HistoryChildState {
             dummy_marker: DummyChildState::Real,
             location: loc,

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -6,27 +6,26 @@
 // of this source tree.
 //! This module contains various memory representations.
 use crate::errors::StorageError;
-use crate::storage::types::{AkdKey, KeyData, StorageType, ValueState, ValueStateRetrievalFlag};
-use crate::storage::V1Storage;
+use crate::storage::transaction::Transaction;
+use crate::storage::types::{
+    AkdKey, DbRecord, KeyData, StorageType, ValueState, ValueStateKey, ValueStateRetrievalFlag,
+};
+use crate::storage::{Storable, V1Storage, V2Storage};
 use async_trait::async_trait;
 use evmap::{ReadHandle, WriteHandle};
 use lazy_static::lazy_static;
+use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-
-pub mod newdb;
 
 // ===== Basic In-Memory database ==== //
 
 /// This struct represents a basic in-memory database.
 #[derive(Debug)]
 pub struct AsyncInMemoryDatabase {
-    #[allow(clippy::type_complexity)]
-    read_handle: ReadHandle<(StorageType, String), Vec<u8>>,
-    #[allow(clippy::type_complexity)]
-    write_handle: Arc<Mutex<WriteHandle<(StorageType, String), Vec<u8>>>>,
-    user_data_read_handle: ReadHandle<AkdKey, ValueState>,
-    user_data_write_handle: Arc<Mutex<WriteHandle<AkdKey, ValueState>>>,
+    db: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, DbRecord>>>,
+    user_info: Arc<tokio::sync::RwLock<HashMap<String, Vec<ValueState>>>>,
+    trans: Transaction,
 }
 
 unsafe impl Send for AsyncInMemoryDatabase {}
@@ -35,13 +34,10 @@ unsafe impl Sync for AsyncInMemoryDatabase {}
 impl AsyncInMemoryDatabase {
     /// Creates a new in memory db
     pub fn new() -> Self {
-        let (reader, writer) = evmap::new();
-        let (user_read, user_write) = evmap::new();
         Self {
-            read_handle: reader,
-            write_handle: Arc::new(Mutex::new(writer)),
-            user_data_read_handle: user_read,
-            user_data_write_handle: Arc::new(Mutex::new(user_write)),
+            db: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            user_info: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            trans: Transaction::new(),
         }
     }
 }
@@ -55,156 +51,350 @@ impl Default for AsyncInMemoryDatabase {
 impl Clone for AsyncInMemoryDatabase {
     fn clone(&self) -> Self {
         Self {
-            read_handle: self.read_handle.clone(),
-            write_handle: self.write_handle.clone(),
-            user_data_read_handle: self.user_data_read_handle.clone(),
-            user_data_write_handle: self.user_data_write_handle.clone(),
+            db: self.db.clone(),
+            user_info: self.user_info.clone(),
+            trans: Transaction::new(),
         }
     }
 }
 
 #[async_trait]
-impl V1Storage for AsyncInMemoryDatabase {
-    async fn set(&self, pos: String, dt: StorageType, value: &[u8]) -> Result<(), StorageError> {
-        let mut hashmap = self.write_handle.lock().unwrap();
-        // evmap supports multi-values, so we need to clear the value if it's present and then set the new value
-        hashmap.clear((dt, pos.clone()));
-        hashmap.insert((dt, pos), value.to_vec());
-        hashmap.refresh();
+impl V2Storage for AsyncInMemoryDatabase {
+    /// Log some information about the db
+    async fn log_metrics(&self, level: log::Level) {
+        let size = self.db.read().await;
+        let msg = format!("InMemDb record count: {}", size.keys().len());
+
+        match level {
+            log::Level::Trace => trace!("{}", msg),
+            log::Level::Debug => debug!("{}", msg),
+            log::Level::Info => info!("{}", msg),
+            log::Level::Warn => warn!("{}", msg),
+            _ => error!("{}", msg),
+        }
+    }
+
+    /// Start a transaction in the storage layer
+    async fn begin_transaction(&mut self) -> bool {
+        self.trans.begin_transaction().await
+    }
+
+    /// Commit a transaction in the storage layer
+    async fn commit_transaction(&mut self) -> Result<(), StorageError> {
+        // this retrieves all the trans operations, and "de-activates" the transaction flag
+        let ops = self.trans.commit_transaction().await?;
+        self.batch_set(ops).await
+    }
+
+    /// Rollback a transaction
+    async fn rollback_transaction(&mut self) -> Result<(), StorageError> {
+        self.trans.rollback_transaction().await
+    }
+
+    /// Retrieve a flag determining if there is a transaction active
+    async fn is_transaction_active(&self) -> bool {
+        self.trans.is_transaction_active().await
+    }
+
+    /// V1Storage a record in the data layer
+    async fn set(&self, record: DbRecord) -> Result<(), StorageError> {
+        if self.is_transaction_active().await {
+            self.trans.set(&record).await;
+            return Ok(());
+        }
+
+        if let DbRecord::ValueState(value_state) = &record {
+            let mut guard = self.user_info.write().await;
+            let username = value_state.username.0.clone();
+            guard
+                .entry(username)
+                .or_insert_with(Vec::new)
+                .push(value_state.clone());
+        } else {
+            let mut guard = self.db.write().await;
+            guard.insert(record.get_full_binary_id(), record);
+        }
+
         Ok(())
     }
 
-    async fn get(&self, pos: String, dt: StorageType) -> Result<Vec<u8>, StorageError> {
-        if let Some(intermediate) = self.read_handle.get(&(dt, pos)) {
-            if let Some(output) = intermediate.get_one() {
-                return Ok(output.clone());
+    async fn batch_set(&self, records: Vec<DbRecord>) -> Result<(), StorageError> {
+        let mut u_guard = self.user_info.write().await;
+        let mut guard = self.db.write().await;
+
+        for record in records.into_iter() {
+            if let DbRecord::ValueState(value_state) = &record {
+                let username = value_state.username.0.clone();
+                u_guard
+                    .entry(username)
+                    .or_insert_with(Vec::new)
+                    .push(value_state.clone());
+            } else {
+                guard.insert(record.get_full_binary_id(), record);
             }
         }
-        Result::Err(StorageError::GetError(String::from("Not found")))
+        Ok(())
     }
 
-    async fn get_all(
+    /// Retrieve a stored record from the data layer
+    async fn get<St: Storable>(&self, id: St::Key) -> Result<DbRecord, StorageError> {
+        if self.is_transaction_active().await {
+            if let Some(result) = self.trans.get::<St>(&id).await {
+                // there's a transacted item, return that one since it's "more up to date"
+                return Ok(result);
+            }
+        }
+        let bin_id = St::get_full_binary_key_id(&id);
+        // if the request is for a value state, look in the value state set
+        if St::data_type() == StorageType::ValueState {
+            if let Ok(ValueStateKey(username, epoch)) = ValueState::key_from_full_binary(&bin_id) {
+                let u_guard = self.user_info.read().await;
+                if let Some(state) = (*u_guard).get(&username).cloned() {
+                    if let Some(item) = state.iter().find(|&x| x.epoch == epoch) {
+                        return Ok(DbRecord::ValueState(item.clone()));
+                    }
+                }
+                return Err(StorageError::GetError("Not found".to_string()));
+            }
+        }
+        // fallback to regular get/set db
+        let guard = self.db.read().await;
+        if let Some(result) = (*guard).get(&bin_id).cloned() {
+            Ok(result)
+        } else {
+            Err(StorageError::GetError("Not found".to_string()))
+        }
+    }
+
+    /// Retrieve a batch of records by id
+    async fn batch_get<St: Storable>(
         &self,
-        data_type: StorageType,
+        ids: Vec<St::Key>,
+    ) -> Result<Vec<DbRecord>, StorageError> {
+        let mut map = Vec::new();
+        for key in ids.into_iter() {
+            map.push(self.get::<St>(key).await?);
+        }
+        Ok(map)
+    }
+
+    /// Retrieve all of the objects of a given type from the storage layer, optionally limiting on "num" results
+    async fn get_all<St: Storable>(
+        &self,
         num: Option<usize>,
-    ) -> Result<Vec<Vec<u8>>, StorageError> {
-        let mut results = Vec::new();
-        if let Some(handle) = &self.read_handle.read() {
-            for item in handle {
-                let ((dt, _pos), v) = item;
-                if *dt == data_type {
-                    if let Some(output) = v.get_one() {
-                        results.push(output.clone());
-                        if let Some(limit) = num {
-                            if results.len() >= limit {
-                                break;
-                            }
+    ) -> Result<Vec<DbRecord>, StorageError> {
+        let mut list = vec![];
+
+        if St::data_type() == StorageType::ValueState {
+            let u_guard = self.user_info.read().await;
+            for (_, item) in u_guard.iter() {
+                for state in item.iter() {
+                    let record = DbRecord::ValueState(state.clone());
+                    list.push(record);
+                    if let Some(count) = num {
+                        if count > 0 && list.len() >= count {
+                            break;
                         }
+                    }
+                }
+                if let Some(count) = num {
+                    if count > 0 && list.len() >= count {
+                        break;
+                    }
+                }
+            }
+        } else {
+            // fallback to generic lookup for all other data
+            let guard = self.db.read().await;
+            for (_, item) in guard.iter() {
+                let ty = match &item {
+                    DbRecord::Azks(_) => StorageType::Azks,
+                    DbRecord::HistoryNodeState(_) => StorageType::HistoryNodeState,
+                    DbRecord::HistoryTreeNode(_) => StorageType::HistoryTreeNode,
+                    DbRecord::ValueState(_) => StorageType::ValueState,
+                };
+                if ty == St::data_type() {
+                    list.push(item.clone());
+                }
+
+                if let Some(count) = num {
+                    if count > 0 && list.len() >= count {
+                        break;
                     }
                 }
             }
         }
-        Ok(results)
-    }
 
-    async fn append_user_state(
-        &self,
-        username: &AkdKey,
-        value: &ValueState,
-    ) -> Result<(), StorageError> {
-        let mut hashmap = self.user_data_write_handle.lock().unwrap();
-        hashmap.insert(username.clone(), value.clone());
-        hashmap.refresh();
-        Ok(())
-    }
-
-    async fn append_user_states(
-        &self,
-        values: Vec<(AkdKey, ValueState)>,
-    ) -> Result<(), StorageError> {
-        let mut hashmap = self.user_data_write_handle.lock().unwrap();
-        for kvp in values {
-            hashmap.insert(kvp.0.clone(), kvp.1.clone());
-        }
-        hashmap.refresh();
-        Ok(())
-    }
-
-    async fn get_user_data(&self, username: &AkdKey) -> Result<KeyData, StorageError> {
-        if let Some(intermediate) = self.user_data_read_handle.get(username) {
-            let mut results = Vec::new();
-            for kvp in intermediate.iter() {
-                results.push(kvp.clone());
+        if self.is_transaction_active().await {
+            // check transacted objects
+            let mut updated = vec![];
+            for item in list.into_iter() {
+                match &item {
+                    DbRecord::Azks(azks) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::append_only_zks::Azks>(&azks.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::HistoryNodeState(state) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::node_state::HistoryNodeState>(&state.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::HistoryTreeNode(node) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::history_tree_node::HistoryTreeNode>(&node.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                    DbRecord::ValueState(state) => {
+                        if let Some(matching) = self
+                            .trans
+                            .get::<crate::storage::types::ValueState>(&state.get_id())
+                            .await
+                        {
+                            updated.push(matching);
+                            continue;
+                        }
+                    }
+                }
+                updated.push(item);
             }
-            return Ok(KeyData { states: results });
+            Ok(updated)
+        } else {
+            Ok(list)
         }
-        Result::Err(StorageError::GetError(String::from("Not found")))
     }
 
+    /// Add a user state element to the associated user
+    async fn append_user_state(&self, value: &ValueState) -> Result<(), StorageError> {
+        self.set(DbRecord::ValueState(value.clone())).await
+    }
+
+    async fn append_user_states(&self, values: Vec<ValueState>) -> Result<(), StorageError> {
+        let new_vec = values.into_iter().map(DbRecord::ValueState).collect();
+        self.batch_set(new_vec).await
+    }
+
+    /// Retrieve the user data for a given user
+    async fn get_user_data(&self, username: &AkdKey) -> Result<KeyData, StorageError> {
+        let guard = self.user_info.read().await;
+        if let Some(result) = guard.get(&username.0) {
+            let mut results: Vec<ValueState> = result.to_vec();
+            // return ordered by epoch (from smallest -> largest)
+            results.sort_by(|a, b| a.epoch.cmp(&b.epoch));
+
+            Ok(KeyData { states: results })
+        } else {
+            Err(StorageError::GetError("Not found".to_string()))
+        }
+    }
+
+    /// Retrieve a specific state for a given user
     async fn get_user_state(
         &self,
         username: &AkdKey,
         flag: ValueStateRetrievalFlag,
     ) -> Result<ValueState, StorageError> {
-        if let Some(intermediate) = self.user_data_read_handle.get(username) {
-            match flag {
-                ValueStateRetrievalFlag::MaxEpoch =>
-                // retrieve by max epoch
-                {
-                    if let Some(value) = intermediate.iter().max_by(|a, b| a.epoch.cmp(&b.epoch)) {
-                        return Ok(value.clone());
-                    }
+        let intermediate = self.get_user_data(username).await?.states;
+        match flag {
+            ValueStateRetrievalFlag::MaxEpoch =>
+            // retrieve by max epoch
+            {
+                if let Some(value) = intermediate.iter().max_by(|a, b| a.epoch.cmp(&b.epoch)) {
+                    return Ok(value.clone());
                 }
-                ValueStateRetrievalFlag::MinEpoch =>
-                // retrieve by min epoch
-                {
-                    if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
-                        return Ok(value.clone());
-                    }
+            }
+            ValueStateRetrievalFlag::MinEpoch =>
+            // retrieve by min epoch
+            {
+                if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
+                    return Ok(value.clone());
                 }
-                _ =>
-                // search for specific property
-                {
-                    let mut tracked_epoch = 0u64;
-                    let mut tracker = None;
-                    for kvp in intermediate.iter() {
-                        match flag {
-                            ValueStateRetrievalFlag::SpecificVersion(version)
-                                if version == kvp.version =>
-                            {
-                                return Ok(kvp.clone())
-                            }
-                            ValueStateRetrievalFlag::LeqEpoch(epoch) if epoch == kvp.epoch => {
-                                return Ok(kvp.clone());
-                            }
-                            ValueStateRetrievalFlag::LeqEpoch(epoch) if kvp.epoch < epoch => {
-                                match tracked_epoch {
-                                    0u64 => {
-                                        tracked_epoch = kvp.epoch;
+            }
+            _ =>
+            // search for specific property
+            {
+                let mut tracked_epoch = 0u64;
+                let mut tracker = None;
+                for kvp in intermediate.iter() {
+                    match flag {
+                        ValueStateRetrievalFlag::SpecificVersion(version)
+                            if version == kvp.version =>
+                        {
+                            return Ok(kvp.clone())
+                        }
+                        ValueStateRetrievalFlag::LeqEpoch(epoch) if epoch == kvp.epoch => {
+                            return Ok(kvp.clone());
+                        }
+                        ValueStateRetrievalFlag::LeqEpoch(epoch) if kvp.epoch < epoch => {
+                            match tracked_epoch {
+                                0u64 => {
+                                    tracked_epoch = kvp.epoch;
+                                    tracker = Some(kvp.clone());
+                                }
+                                other_epoch => {
+                                    if kvp.epoch > other_epoch {
                                         tracker = Some(kvp.clone());
-                                    }
-                                    other_epoch => {
-                                        if kvp.epoch > other_epoch {
-                                            tracker = Some(kvp.clone());
-                                            tracked_epoch = kvp.epoch;
-                                        }
+                                        tracked_epoch = kvp.epoch;
                                     }
                                 }
                             }
-                            ValueStateRetrievalFlag::SpecificEpoch(epoch) if epoch == kvp.epoch => {
-                                return Ok(kvp.clone())
-                            }
-                            _ => continue,
                         }
+                        ValueStateRetrievalFlag::SpecificEpoch(epoch) if epoch == kvp.epoch => {
+                            return Ok(kvp.clone())
+                        }
+                        _ => continue,
                     }
+                }
 
-                    if let Some(r) = tracker {
-                        return Ok(r);
-                    }
+                if let Some(r) = tracker {
+                    return Ok(r);
                 }
             }
         }
-        Result::Err(StorageError::GetError(String::from("Not found")))
+        Err(StorageError::GetError(String::from("Not found")))
+    }
+
+    async fn get_user_states(
+        &self,
+        usernames: &[AkdKey],
+        flag: ValueStateRetrievalFlag,
+    ) -> Result<HashMap<AkdKey, ValueState>, StorageError> {
+        let mut map = HashMap::new();
+        for username in usernames.iter() {
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(AkdKey(result.username.0.clone()), result);
+            }
+        }
+        Ok(map)
+    }
+
+    async fn get_user_state_versions(
+        &self,
+        keys: &[AkdKey],
+        flag: ValueStateRetrievalFlag,
+    ) -> Result<HashMap<AkdKey, u64>, StorageError> {
+        let mut map = HashMap::new();
+        for username in keys.iter() {
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(AkdKey(result.username.0.clone()), result.version);
+            }
+        }
+        Ok(map)
     }
 }
 

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -155,28 +155,10 @@ impl V1Storage for AsyncInMemoryDatabase {
                         return Ok(value.clone());
                     }
                 }
-                ValueStateRetrievalFlag::MaxVersion =>
-                // retrieve the max version
-                {
-                    if let Some(value) =
-                        intermediate.iter().max_by(|a, b| a.version.cmp(&b.version))
-                    {
-                        return Ok(value.clone());
-                    }
-                }
                 ValueStateRetrievalFlag::MinEpoch =>
                 // retrieve by min epoch
                 {
                     if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
-                        return Ok(value.clone());
-                    }
-                }
-                ValueStateRetrievalFlag::MinVersion =>
-                // retrieve the min version
-                {
-                    if let Some(value) =
-                        intermediate.iter().min_by(|a, b| a.version.cmp(&b.version))
-                    {
                         return Ok(value.clone());
                     }
                 }
@@ -455,28 +437,10 @@ impl V1Storage for AsyncInMemoryDbWithCache {
                         return Ok(value.clone());
                     }
                 }
-                ValueStateRetrievalFlag::MaxVersion =>
-                // retrieve the max version
-                {
-                    if let Some(value) =
-                        intermediate.iter().max_by(|a, b| a.version.cmp(&b.version))
-                    {
-                        return Ok(value.clone());
-                    }
-                }
                 ValueStateRetrievalFlag::MinEpoch =>
                 // retrieve by min epoch
                 {
                     if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
-                        return Ok(value.clone());
-                    }
-                }
-                ValueStateRetrievalFlag::MinVersion =>
-                // retrieve the min version
-                {
-                    if let Some(value) =
-                        intermediate.iter().min_by(|a, b| a.version.cmp(&b.version))
-                    {
                         return Ok(value.clone());
                     }
                 }

--- a/src/storage/memory/newdb.rs
+++ b/src/storage/memory/newdb.rs
@@ -374,8 +374,9 @@ impl V2Storage for AsyncInMemoryDatabase {
     ) -> Result<HashMap<AkdKey, ValueState>, StorageError> {
         let mut map = HashMap::new();
         for username in usernames.iter() {
-            let result = self.get_user_state(username, flag).await?;
-            map.insert(AkdKey(result.username.0.clone()), result);
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(AkdKey(result.username.0.clone()), result);
+            }
         }
         Ok(map)
     }
@@ -387,8 +388,9 @@ impl V2Storage for AsyncInMemoryDatabase {
     ) -> Result<HashMap<AkdKey, u64>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
-            let result = self.get_user_state(username, flag).await?;
-            map.insert(AkdKey(result.username.0.clone()), result.version);
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(AkdKey(result.username.0.clone()), result.version);
+            }
         }
         Ok(map)
     }

--- a/src/storage/memory/newdb.rs
+++ b/src/storage/memory/newdb.rs
@@ -379,4 +379,17 @@ impl V2Storage for AsyncInMemoryDatabase {
         }
         Ok(map)
     }
+
+    async fn get_user_state_versions(
+        &self,
+        keys: &[AkdKey],
+        flag: ValueStateRetrievalFlag,
+    ) -> Result<HashMap<AkdKey, u64>, StorageError> {
+        let mut map = HashMap::new();
+        for username in keys.iter() {
+            let result = self.get_user_state(username, flag).await?;
+            map.insert(AkdKey(result.username.0.clone()), result.version);
+        }
+        Ok(map)
+    }
 }

--- a/src/storage/memory/newdb.rs
+++ b/src/storage/memory/newdb.rs
@@ -316,24 +316,10 @@ impl V2Storage for AsyncInMemoryDatabase {
                     return Ok(value.clone());
                 }
             }
-            ValueStateRetrievalFlag::MaxVersion =>
-            // retrieve the max version
-            {
-                if let Some(value) = intermediate.iter().max_by(|a, b| a.version.cmp(&b.version)) {
-                    return Ok(value.clone());
-                }
-            }
             ValueStateRetrievalFlag::MinEpoch =>
             // retrieve by min epoch
             {
                 if let Some(value) = intermediate.iter().min_by(|a, b| a.epoch.cmp(&b.epoch)) {
-                    return Ok(value.clone());
-                }
-            }
-            ValueStateRetrievalFlag::MinVersion =>
-            // retrieve the min version
-            {
-                if let Some(value) = intermediate.iter().min_by(|a, b| a.version.cmp(&b.version)) {
                     return Ok(value.clone());
                 }
             }
@@ -379,5 +365,18 @@ impl V2Storage for AsyncInMemoryDatabase {
             }
         }
         Err(StorageError::GetError(String::from("Not found")))
+    }
+
+    async fn get_user_states(
+        &self,
+        usernames: &[AkdKey],
+        flag: ValueStateRetrievalFlag,
+    ) -> Result<HashMap<AkdKey, ValueState>, StorageError> {
+        let mut map = HashMap::new();
+        for username in usernames.iter() {
+            let result = self.get_user_state(username, flag).await?;
+            map.insert(AkdKey(result.username.0.clone()), result);
+        }
+        Ok(map)
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -227,11 +227,7 @@ pub trait V2Storage: Clone {
     _h: PhantomData<H>,
     */
     /// Build an azks instance from the properties
-    fn build_azks(
-        root: usize,
-        latest_epoch: u64,
-        num_nodes: usize,
-    ) -> crate::append_only_zks::Azks {
+    fn build_azks(root: u64, latest_epoch: u64, num_nodes: u64) -> crate::append_only_zks::Azks {
         crate::append_only_zks::Azks {
             root,
             latest_epoch,
@@ -256,9 +252,9 @@ pub trait V2Storage: Clone {
     fn build_history_tree_node(
         label_val: u64,
         label_len: u32,
-        location: usize,
+        location: u64,
         epochs: Vec<u64>,
-        parent: usize,
+        parent: u64,
         node_type: u8,
     ) -> crate::history_tree_node::HistoryTreeNode {
         crate::history_tree_node::HistoryTreeNode {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -162,7 +162,7 @@ pub trait V2Storage: Clone {
     /// Retrieve a flag determining if there is a transaction active
     async fn is_transaction_active(&self) -> bool;
 
-    /// V1Storage a record in the data layer
+    /// Set a record in the data layer
     async fn set(&self, record: DbRecord) -> Result<(), StorageError>;
 
     /// Set multiple records in transactional operation
@@ -188,7 +188,7 @@ pub trait V2Storage: Clone {
     /// Add a user state element to the associated user
     async fn append_user_state(&self, value: &types::ValueState) -> Result<(), StorageError>;
 
-    /// Adds user states
+    /// Append user states to the storage medium
     async fn append_user_states(&self, values: Vec<types::ValueState>) -> Result<(), StorageError>;
 
     /// Retrieve the user data for a given user
@@ -272,30 +272,6 @@ pub trait V2Storage: Clone {
             node_type: crate::history_tree_node::NodeType::from_u8(node_type),
         }
     }
-
-    /*HistoryNodeState(crate::node_state::HistoryNodeState<H, S>),*/
-
-    // /*
-    // pub dummy_marker: DummyChildState,
-    // pub location: usize,
-    // pub label: NodeLabel,
-    // pub hash_val: Vec<u8>,
-    // pub epoch_version: u64,
-    // pub(crate) _h: PhantomData<H>,
-    // pub(crate) _s: PhantomData<S>,
-    // */
-    // /// Build a history child state from the properties
-    // fn build_history_child_state<H>(dummy_marker: u8, location: usize, label_val: u64, label_len: u32, hash_val: Vec<u8>, epoch_version: u64)
-    // -> crate::node_state::HistoryChildState::<H> {
-    //     crate::node_state::HistoryChildState::<H> {
-    //         dummy_marker: crate::node_state::DummyChildState::from_u8(dummy_marker),
-    //         location,
-    //         label: crate::node_state::NodeLabel { val: label_val, len: label_len },
-    //         hash_val,
-    //         epoch_version,
-    //         _h: PhantomData,
-    //     }
-    // }
 
     /*
     pub struct NodeStateKey(pub(crate) NodeLabel, pub(crate) usize);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -686,8 +686,9 @@ impl<S: V1Storage + Send + Sync> V2Storage for V2FromV1StorageWrapper<S> {
     ) -> Result<HashMap<types::AkdKey, types::ValueState>, StorageError> {
         let mut map = HashMap::new();
         for username in usernames.iter() {
-            let result = self.get_user_state(username, flag).await?;
-            map.insert(types::AkdKey(result.username.0.clone()), result);
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(types::AkdKey(result.username.0.clone()), result);
+            }
         }
         Ok(map)
     }
@@ -699,8 +700,9 @@ impl<S: V1Storage + Send + Sync> V2Storage for V2FromV1StorageWrapper<S> {
     ) -> Result<HashMap<types::AkdKey, u64>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
-            let result = self.get_user_state(username, flag).await?;
-            map.insert(types::AkdKey(result.username.0.clone()), result.version);
+            if let Ok(result) = self.get_user_state(username, flag).await {
+                map.insert(types::AkdKey(result.username.0.clone()), result.version);
+            }
         }
         Ok(map)
     }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -16,7 +16,7 @@ use crate::node_state::NodeLabel;
 use crate::storage::memory::AsyncInMemoryDatabase;
 use crate::storage::mysql::{AsyncMySqlDatabase, MySqlCacheOptions};
 use crate::storage::types::*;
-use crate::storage::{V1Storage, V2Storage};
+use crate::storage::V2Storage;
 
 type Azks = crate::append_only_zks::Azks;
 type HistoryTreeNode = crate::history_tree_node::HistoryTreeNode;
@@ -25,16 +25,10 @@ type HistoryTreeNode = crate::history_tree_node::HistoryTreeNode;
 
 #[tokio::test]
 #[serial]
-async fn test_v1_in_memory_db() {
-    let db = AsyncInMemoryDatabase::new();
-    async_test_get_and_set_item(&db).await;
-    async_test_user_data(&db).await;
-}
-
-#[tokio::test]
-#[serial]
 async fn test_v1_to_v2_db_wrapper() {
-    let mut db = crate::storage::V2FromV1StorageWrapper::new(AsyncInMemoryDatabase::new());
+    let mut db = crate::storage::V2FromV1StorageWrapper::new(
+        crate::storage::memory::AsyncInMemoryDbWithCache::new(),
+    );
     async_test_new_get_and_set_item(&db).await;
     async_test_new_user_data(&db).await;
     async_test_transaction(&mut db).await;
@@ -44,7 +38,7 @@ async fn test_v1_to_v2_db_wrapper() {
 #[tokio::test]
 #[serial]
 async fn test_v2_in_memory_db() {
-    let mut db = crate::storage::memory::newdb::AsyncInMemoryDatabase::new();
+    let mut db = AsyncInMemoryDatabase::new();
     async_test_new_get_and_set_item(&db).await;
     async_test_new_user_data(&db).await;
     async_test_transaction(&mut db).await;
@@ -570,200 +564,4 @@ async fn async_test_new_user_data<S: V2Storage + Sync + Send>(storage: &S) {
 
     let data = storage.get_user_data(&sample_state_2.username).await;
     assert_eq!(4, data.unwrap().states.len());
-}
-
-// *** Helper Functions *** //
-
-async fn async_test_get_and_set_item<S: V1Storage>(storage: &S) {
-    let rand_string: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(30)
-        .map(char::from)
-        .collect();
-    let value: Vec<u8> = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(30)
-        .map(char::from)
-        .collect::<String>()
-        .as_bytes()
-        .to_vec();
-
-    let set_result = storage
-        .set(rand_string.clone(), StorageType::Azks, &value)
-        .await;
-    assert_eq!(Ok(()), set_result);
-
-    let storage_bytes = storage.get(rand_string, StorageType::Azks).await;
-    assert_eq!(Ok(value), storage_bytes);
-
-    let fake_key = "abc123".to_owned();
-    let missing = storage.get(fake_key, StorageType::Azks).await;
-    assert_eq!(
-        Err(StorageError::GetError(String::from("Not found"))),
-        missing
-    );
-
-    let all_azks = storage.get_all(StorageType::Azks, None).await;
-    assert_eq!(1, all_azks.unwrap().len());
-}
-
-async fn async_test_user_data<S: V1Storage>(storage: &S) {
-    let rand_user: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(30)
-        .map(char::from)
-        .collect();
-    let rand_value: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(1028)
-        .map(char::from)
-        .collect();
-    let mut sample_state = ValueState {
-        plaintext_val: Values(rand_value.clone()),
-        version: 1u64,
-        label: NodeLabel {
-            val: 1u64,
-            len: 1u32,
-        },
-        epoch: 1u64,
-        username: AkdKey(rand_user.clone()),
-    };
-    let mut sample_state_2 = sample_state.clone();
-    let username = AkdKey(rand_user);
-    let username_2 = AkdKey("test_user".to_string());
-    sample_state_2.username = username_2.clone();
-
-    let result = storage.append_user_state(&username, &sample_state).await;
-    assert_eq!(Ok(()), result);
-
-    sample_state.version = 2u64;
-    sample_state.epoch = 123u64;
-    let result = storage.append_user_state(&username, &sample_state).await;
-    assert_eq!(Ok(()), result);
-
-    sample_state.version = 3u64;
-    sample_state.epoch = 456u64;
-    let result = storage.append_user_state(&username, &sample_state).await;
-    assert_eq!(Ok(()), result);
-
-    let data = storage.get_user_data(&username).await.unwrap();
-    assert_eq!(3, data.states.len());
-
-    let versions = data
-        .states
-        .into_iter()
-        .map(|state| state.version)
-        .collect::<Vec<_>>();
-    assert_eq!(vec![1, 2, 3], versions);
-
-    // At this point the DB has structure (for MySQL):
-    /*
-    mysql> USE default;
-    Reading table information for completion of table and column names
-    You can turn off this feature to get a quicker startup with -A
-
-    Database changed
-    mysql> SHOW TABLES;
-    +-------------------+
-    | Tables_in_default |
-    +-------------------+
-    | data              |
-    | user_data         |
-    +-------------------+
-    2 rows in set (0.00 sec)
-
-    mysql> SELECT * FROM user_data;
-    +--------------------------------+-------+---------+----------------+----------------+-------------------+
-    | username                       | epoch | version | node_label_val | node_label_len | data              |
-    +--------------------------------+-------+---------+----------------+----------------+-------------------+
-    | do3zfiXa0IUKznscp06jtc6KfHJudy |     1 |       1 |              1 |              1 | 8owmLSoZi...B9pu8 |
-    | do3zfiXa0IUKznscp06jtc6KfHJudy |   123 |       2 |              1 |              1 | 8owmLSoZi...B9pu8 |
-    | do3zfiXa0IUKznscp06jtc6KfHJudy |   456 |       3 |              1 |              1 | 8owmLSoZi...B9pu8 |
-    +--------------------------------+-------+---------+----------------+----------------+-------------------+
-    3 rows in set (0.00 sec)
-    */
-
-    let specific_result = storage
-        .get_user_state(&username, ValueStateRetrievalFlag::SpecificVersion(2))
-        .await;
-    assert_eq!(
-        Ok(ValueState {
-            epoch: 123,
-            version: 2,
-            label: NodeLabel { val: 1, len: 1 },
-            plaintext_val: Values(rand_value.clone()),
-            username: username.clone(),
-        }),
-        specific_result
-    );
-
-    let missing_result = storage
-        .get_user_state(&username, ValueStateRetrievalFlag::SpecificVersion(100))
-        .await;
-    assert_eq!(
-        Err(StorageError::GetError(String::from("Not found"))),
-        missing_result
-    );
-
-    let specific_result = storage
-        .get_user_state(&username, ValueStateRetrievalFlag::SpecificEpoch(123))
-        .await;
-    assert_eq!(
-        Ok(ValueState {
-            epoch: 123,
-            version: 2,
-            label: NodeLabel { val: 1, len: 1 },
-            plaintext_val: Values(rand_value.clone()),
-            username: username.clone(),
-        }),
-        specific_result
-    );
-
-    let specific_result = storage
-        .get_user_state(&username, ValueStateRetrievalFlag::MinEpoch)
-        .await;
-    assert_eq!(
-        Ok(ValueState {
-            epoch: 1,
-            version: 1,
-            label: NodeLabel { val: 1, len: 1 },
-            plaintext_val: Values(rand_value.clone()),
-            username: username.clone(),
-        }),
-        specific_result
-    );
-
-    let specific_result = storage
-        .get_user_state(&username, ValueStateRetrievalFlag::MaxEpoch)
-        .await;
-    assert_eq!(
-        Ok(ValueState {
-            epoch: 456,
-            version: 3,
-            label: NodeLabel { val: 1, len: 1 },
-            plaintext_val: Values(rand_value.clone()),
-            username: username.clone(),
-        }),
-        specific_result
-    );
-
-    // Vector operations
-
-    let mut vector_of_states = vec![(username_2.clone(), sample_state_2.clone())];
-    sample_state_2.version = 2;
-    sample_state_2.epoch = 234;
-    vector_of_states.push((username_2.clone(), sample_state_2.clone()));
-
-    sample_state_2.version = 3;
-    sample_state_2.epoch = 345;
-    vector_of_states.push((username_2.clone(), sample_state_2.clone()));
-    sample_state_2.version = 4;
-    sample_state_2.epoch = 456;
-    vector_of_states.push((username_2.clone(), sample_state_2.clone()));
-
-    let result = storage.append_user_states(vector_of_states).await;
-    assert_eq!(Ok(()), result);
-
-    let data = storage.get_user_data(&username_2).await.unwrap();
-    assert_eq!(4, data.states.len());
 }

--- a/src/storage/transaction.rs
+++ b/src/storage/transaction.rs
@@ -69,7 +69,7 @@ impl Transaction {
 
     /// Start a transaction in the storage layer
     pub(crate) async fn begin_transaction(&mut self) -> bool {
-        debug!("BEGIN begin transaction");
+        trace!("BEGIN begin transaction");
         let mut guard = self.state.write().await;
         let out = if (*guard).active {
             false
@@ -77,12 +77,13 @@ impl Transaction {
             (*guard).active = true;
             true
         };
-        debug!("END begin transaction");
+        trace!("END begin transaction");
         out
     }
 
     /// Commit a transaction in the storage layer
     pub(crate) async fn commit_transaction(&mut self) -> Result<Vec<DbRecord>, StorageError> {
+        trace!("BEGIN commit transaction");
         let mut guard = self.state.write().await;
 
         if !(*guard).active {
@@ -97,12 +98,13 @@ impl Transaction {
         (*guard).mods.clear();
 
         (*guard).active = false;
+        trace!("END commit transaction");
         Ok(records)
     }
 
     /// Rollback a transaction
     pub(crate) async fn rollback_transaction(&mut self) -> Result<(), StorageError> {
-        debug!("BEGIN rollback transaction");
+        trace!("BEGIN rollback transaction");
         let mut guard = self.state.write().await;
 
         if !(*guard).active {
@@ -115,20 +117,20 @@ impl Transaction {
         (*guard).mods.clear();
         (*guard).active = false;
 
-        debug!("END rollback transaction");
+        trace!("END rollback transaction");
         Ok(())
     }
 
     /// Retrieve a flag determining if there is a transaction active
     pub(crate) async fn is_transaction_active(&self) -> bool {
-        debug!("BEGIN is transaction active");
+        trace!("BEGIN is transaction active");
         let out = self.state.read().await.active;
-        debug!("END is transaction active");
+        trace!("END is transaction active");
         out
     }
 
     pub(crate) async fn get<St: Storable>(&self, key: &St::Key) -> Option<DbRecord> {
-        debug!("BEGIN transaction get {:?}", key);
+        trace!("BEGIN transaction get {:?}", key);
         let bin_id = St::get_full_binary_key_id(key);
 
         let guard = self.state.read().await;
@@ -136,18 +138,18 @@ impl Transaction {
         if out.is_some() {
             *(self.num_reads.write().await) += 1;
         }
-        debug!("END transaction get");
+        trace!("END transaction get");
         out
     }
 
     pub(crate) async fn set(&self, record: &DbRecord) {
-        debug!("BEGIN transaction set");
+        trace!("BEGIN transaction set");
         let bin_id = record.get_full_binary_id();
 
         let mut guard = self.state.write().await;
         (*guard).mods.insert(bin_id, record.clone());
 
         *(self.num_writes.write().await) += 1;
-        debug!("END transaction set");
+        trace!("END transaction set");
     }
 }

--- a/src/storage/transaction.rs
+++ b/src/storage/transaction.rs
@@ -28,6 +28,9 @@ pub struct Transaction {
     num_writes: Arc<tokio::sync::RwLock<u64>>,
 }
 
+unsafe impl Send for Transaction {}
+unsafe impl Sync for Transaction {}
+
 impl std::fmt::Debug for Transaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "a lone transaction")

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -120,7 +120,7 @@ pub struct KeyData {
 }
 
 /// Used to retrieve a value's state, for a given key
-#[derive(std::fmt::Debug)]
+#[derive(std::fmt::Debug, Clone, Copy)]
 pub enum ValueStateRetrievalFlag {
     /// Specific version
     SpecificVersion(u64),
@@ -130,12 +130,8 @@ pub enum ValueStateRetrievalFlag {
     LeqEpoch(u64),
     /// State at the latest epoch
     MaxEpoch,
-    /// State at the latest version
-    MaxVersion,
     /// State at the earliest epoch
     MinEpoch,
-    /// Earliest version
-    MinVersion,
 }
 
 // == New Data Retrieval Logic == //

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,12 +34,8 @@ type InMemoryDb = storage::memory::AsyncInMemoryDatabase;
 #[tokio::test]
 async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeError> {
     let ep = 1;
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(ep),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
         HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
@@ -70,12 +66,8 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
     let ep = 1;
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(ep),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
         HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
@@ -127,12 +119,8 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
     let mut ep = 1;
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(ep),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
         HistoryChildState::new::<Blake3>(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
@@ -204,12 +192,8 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
     let mut ep = 1;
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(ep),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
         HistoryChildState::new::<Blake3>(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
@@ -281,12 +265,8 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
     let init_ep = 0;
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(init_ep),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(init_ep)).await?;
 
     for ep in 0u64..3u64 {
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
@@ -362,31 +342,13 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
     let mut rng = OsRng;
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(0u64),
-    )
-    .await?;
-    let new_leaf = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b0u64, 1u32),
-        1,
-        &[0u8],
-        0,
-        0,
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
+    let new_leaf =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b0u64, 1u32), 1, &[0u8], 0, 0).await?;
 
-    let leaf_1 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b1u64, 1u32),
-        2,
-        &[1u8],
-        0,
-        0,
-    )
-    .await?;
+    let leaf_1 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b1u64, 1u32), 2, &[1u8], 0, 0).await?;
     root.write_to_storage(&db).await?;
 
     let mut num_nodes = 1;
@@ -425,41 +387,17 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
     let mut rng = OsRng;
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(0u64),
-    )
-    .await?;
-    let new_leaf = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b00u64, 2u32),
-        1,
-        &[0u8],
-        0,
-        1,
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
+    let new_leaf =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b00u64, 2u32), 1, &[0u8], 0, 1).await?;
 
-    let leaf_1 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b11u64, 2u32),
-        2,
-        &[1u8],
-        0,
-        2,
-    )
-    .await?;
+    let leaf_1 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b11u64, 2u32), 2, &[1u8], 0, 2).await?;
 
-    let leaf_2 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b10u64, 2u32),
-        3,
-        &[1u8, 1u8],
-        0,
-        3,
-    )
-    .await?;
+    let leaf_2 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b10u64, 2u32), 3, &[1u8, 1u8], 0, 3)
+            .await?;
 
     let leaf_0_hash = Blake3::merge(&[
         Blake3::merge(&[Blake3::hash(&[]), Blake3::hash(&[0b0u8])]),
@@ -520,51 +458,21 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
     let mut rng = OsRng;
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(0u64),
-    )
-    .await?;
-    let new_leaf = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b000u64, 3u32),
-        1,
-        &[0u8],
-        0,
-        0,
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
+    let new_leaf =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b000u64, 3u32), 1, &[0u8], 0, 0).await?;
 
-    let leaf_1 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b111u64, 3u32),
-        2,
-        &[1u8],
-        0,
-        0,
-    )
-    .await?;
+    let leaf_1 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b111u64, 3u32), 2, &[1u8], 0, 0).await?;
 
-    let leaf_2 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b100u64, 3u32),
-        3,
-        &[1u8, 1u8],
-        0,
-        0,
-    )
-    .await?;
+    let leaf_2 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b100u64, 3u32), 3, &[1u8, 1u8], 0, 0)
+            .await?;
 
-    let leaf_3 = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        NodeLabel::new(0b010u64, 3u32),
-        4,
-        &[0u8, 1u8],
-        0,
-        0,
-    )
-    .await?;
+    let leaf_3 =
+        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b010u64, 3u32), 4, &[0u8, 1u8], 0, 0)
+            .await?;
 
     let leaf_0_hash = Blake3::merge(&[
         Blake3::merge(&[Blake3::hash(&[]), Blake3::hash(&[0b0u8])]),
@@ -637,18 +545,14 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError>
     let mut rng = OsRng;
     let mut azks_id = vec![0u8; 32];
     rng.fill_bytes(&mut azks_id);
-    let db = crate::storage::V2FromV1StorageWrapper::new(InMemoryDb::new());
-    let mut root = get_empty_root::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
-        &db,
-        Option::Some(0u64),
-    )
-    .await?;
+    let db = InMemoryDb::new();
+    let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     root.write_to_storage(&db).await?;
     let mut num_nodes = 1;
     let mut leaves = Vec::<HistoryTreeNode>::new();
     let mut leaf_hashes = Vec::new();
     for i in 0u64..8u64 {
-        let new_leaf = get_leaf_node::<Blake3, crate::storage::V2FromV1StorageWrapper<InMemoryDb>>(
+        let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(i.clone(), 3u32),
             leaves.len(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -555,7 +555,7 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError>
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(i.clone(), 3u32),
-            leaves.len(),
+            leaves.len() as u64,
             &i.to_ne_bytes(),
             0,
             7 - i,


### PR DESCRIPTION
This PR contains more IO improvements where we disable cache-cleaning during a transaction. The logic behind this is that we're doing high IO work and will likely be re-reading a lot of nodes frequently (especially at the higher levels of the tree), that we shouldn't clear the cache until the transaction is completed.

+ Migrated to a pure v2 storage impl in-memory database.

+ Batch retrieval of value state version information so with a single db query we can retrieve all user versions in a publish operation. The large the batch size, the more performant this will be (i.e. for 100K users it's 1 op vs 100K ops).