### PR TITLE
Removing dummy children

### DIFF
--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -185,8 +185,6 @@ impl Azks {
         self.increment_epoch();
         self.preload_nodes_for_insertion::<S, H>(storage, insertion_set.clone())
             .await?;
-        println!("***********************PRELOADED***************************");
-        storage.log_metrics(log::Level::Info).await;
         let mut hash_q = KeyedPriorityQueue::<u64, i32>::new();
         let mut priorities: i32 = 0;
         let mut root_node = HistoryTreeNode::get_from_storage(storage, NodeKey(self.root)).await?;
@@ -217,10 +215,6 @@ impl Azks {
             hash_q.push(new_leaf_loc, priorities);
             priorities -= 1;
         }
-
-        println!("***********************PRIORITY QUEUE FILLED***************************");
-        storage.log_metrics(log::Level::Info).await;
-        println!("***********************************************************************");
 
         while !hash_q.is_empty() {
             let (next_node_loc, _) = hash_q

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -280,7 +280,7 @@ impl Azks {
             HistoryTreeNode::get_from_storage(storage, NodeKey(lcp_node_id)).await?;
         let longest_prefix = lcp_node.label;
         let mut longest_prefix_children_labels = [NodeLabel::new(0, 0); ARITY];
-        let mut longest_prefix_children_values = [H::hash(&[0u8; 1]); ARITY]; // FIXME: this needs to be put in function
+        let mut longest_prefix_children_values = [crate::utils::empty_node_hash::<H>(); ARITY];
         let state = lcp_node.get_state_at_epoch(storage, epoch).await?;
 
         for (i, child) in state.child_states.iter().enumerate() {

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -135,7 +135,7 @@ impl Azks {
                 .as_ref(),
         );
 
-        while current_nodes.len() > 0 {
+        while !current_nodes.is_empty() {
             let nodes = HistoryTreeNode::batch_get_from_storage(storage, current_nodes).await?;
 
             current_nodes = Vec::<NodeKey>::new();
@@ -164,12 +164,8 @@ impl Azks {
                             Direction::Some(dir),
                         )
                         .await?;
-
-                    match child {
-                        Some(child) => {
-                            current_nodes.push(NodeKey(child.location));
-                        }
-                        None => {}
+                    if let Some(child) = child {
+                        current_nodes.push(NodeKey(child.location));
                     }
                 }
             }

--- a/src/history_tree_node.rs
+++ b/src/history_tree_node.rs
@@ -731,7 +731,7 @@ pub(crate) fn optional_history_child_state_to_hash<H: Hasher>(
 ) -> Vec<u8> {
     match input {
         Some(child_state) => child_state.hash_val.clone(),
-        None => from_digest::<H>(H::hash(&[0u8])).unwrap(),
+        None => from_digest::<H>(crate::utils::empty_node_hash::<H>()).unwrap(),
     }
 }
 

--- a/src/history_tree_node.rs
+++ b/src/history_tree_node.rs
@@ -207,7 +207,7 @@ impl HistoryTreeNode {
             let child_state = self
                 .get_child_at_epoch::<_, H>(storage, self.get_latest_epoch()?, dir_leaf)
                 .await?;
-            if child_state.dummy_marker == DummyChildState::Dummy {
+            if child_state == None {
                 new_leaf.parent = self.location;
                 self.set_node_child::<_, H>(storage, epoch, dir_leaf, &new_leaf)
                     .await?;
@@ -281,7 +281,7 @@ impl HistoryTreeNode {
                     .set_node_child::<_, H>(storage, epoch, self_dir_in_parent, &new_node)
                     .await?;
                 if hashing {
-                    println!("BEGIN update hashes");
+                    trace!("BEGIN update hashes");
                     new_leaf.update_hash::<_, H>(storage, epoch).await?;
                     self.update_hash::<_, H>(storage, epoch).await?;
                     new_node =
@@ -303,40 +303,32 @@ impl HistoryTreeNode {
                 trace!("BEGIN get child at epoch");
                 let child_st = self
                     .get_child_at_epoch::<_, H>(storage, self.get_latest_epoch()?, dir_leaf)
-                    .await?;
+                    .await?
+                    .ok_or(HistoryTreeNodeError::NoChildInTreeAtEpoch(
+                        self.get_latest_epoch()?,
+                        dir_leaf.unwrap(),
+                    ))?;
 
-                match child_st.dummy_marker {
-                    DummyChildState::Dummy => {
-                        Err(HistoryTreeNodeError::CompressionError(self.label))
-                    }
-                    DummyChildState::Real => {
-                        trace!("BEGIN get child node from storage");
-                        let mut child_node =
-                            HistoryTreeNode::get_from_storage(storage, NodeKey(child_st.location))
-                                .await?;
-                        trace!("BEGIN insert single leaf helper");
-                        child_node
-                            .insert_single_leaf_helper::<_, H>(
-                                storage, new_leaf, epoch, num_nodes, hashing,
-                            )
-                            .await?;
-                        if hashing {
-                            trace!("BEGIN update hashes");
-                            *self =
-                                HistoryTreeNode::get_from_storage(storage, NodeKey(self.location))
-                                    .await?;
-                            self.update_hash::<_, H>(storage, epoch).await?;
-                            self.write_to_storage(storage).await?;
-                        } else {
-                            trace!("BEGIN retrieve self");
-                            *self =
-                                HistoryTreeNode::get_from_storage(storage, NodeKey(self.location))
-                                    .await?;
-                        }
-                        trace!("END insert single leaf (dir_self = None)");
-                        Ok(())
-                    }
+                trace!("BEGIN get child node from storage");
+                let mut child_node =
+                    HistoryTreeNode::get_from_storage(storage, NodeKey(child_st.location)).await?;
+                trace!("BEGIN insert single leaf helper");
+                child_node
+                    .insert_single_leaf_helper::<_, H>(storage, new_leaf, epoch, num_nodes, hashing)
+                    .await?;
+                if hashing {
+                    trace!("BEGIN update hashes");
+                    *self =
+                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                    self.update_hash::<_, H>(storage, epoch).await?;
+                    self.write_to_storage(storage).await?;
+                } else {
+                    trace!("BEGIN retrieve self");
+                    *self =
+                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
                 }
+                trace!("END insert single leaf (dir_self = None)");
+                Ok(())
             }
         }
     }
@@ -390,11 +382,9 @@ impl HistoryTreeNode {
         for child_index in 0..ARITY {
             new_hash = H::merge(&[
                 new_hash,
-                to_digest::<H>(
-                    &epoch_node_state
-                        .get_child_state_in_dir(child_index)
-                        .hash_val,
-                )
+                to_digest::<H>(&optional_history_child_state_to_hash::<H>(
+                    &epoch_node_state.get_child_state_in_dir(child_index),
+                ))
                 .unwrap(),
             ]);
         }
@@ -410,38 +400,38 @@ impl HistoryTreeNode {
         new_hash_val: H::Digest,
     ) -> Result<(), HistoryTreeNodeError> {
         if self.is_root() {
-            Ok(())
-        } else {
-            let parent =
-                &mut HistoryTreeNode::get_from_storage(storage, NodeKey(self.parent)).await?;
+            return Ok(());
+        }
 
-            if parent.get_latest_epoch()? < epoch {
-                let (_, dir_self, _) = parent.label.get_longest_common_prefix_and_dirs(self.label);
-                parent
-                    .set_node_child::<_, H>(storage, epoch, dir_self, self)
-                    .await?;
-                parent.write_to_storage(storage).await?;
-                *parent = HistoryTreeNode::get_from_storage(storage, NodeKey(self.parent)).await?;
-            }
+        let parent = &mut HistoryTreeNode::get_from_storage(storage, NodeKey(self.parent)).await?;
+        if parent.get_latest_epoch()? < epoch {
+            let (_, dir_self, _) = parent.label.get_longest_common_prefix_and_dirs(self.label);
+            parent
+                .set_node_child::<_, H>(storage, epoch, dir_self, self)
+                .await?;
+            parent.write_to_storage(storage).await?;
+            *parent = HistoryTreeNode::get_from_storage(storage, NodeKey(self.parent)).await?;
+        }
 
-            match get_state_map(storage, parent, epoch).await {
-                Err(_) => Err(HistoryTreeNodeError::ParentNextEpochInvalid(epoch)),
-                Ok(parent_state) => match parent.get_direction_at_ep(storage, self, epoch).await? {
-                    None => Err(HistoryTreeNodeError::HashUpdateOnlyAllowedAfterNodeInsertion),
-                    Some(s_dir) => {
-                        let mut parent_updated_state = parent_state;
-                        let mut self_child_state =
-                            parent_updated_state.get_child_state_in_dir(s_dir);
-                        self_child_state.hash_val = from_digest::<H>(new_hash_val)?;
-                        parent_updated_state.child_states[s_dir] = self_child_state;
-                        parent_updated_state.key = NodeStateKey(parent.label, epoch);
-                        set_state_map(storage, parent_updated_state).await?;
-                        parent.write_to_storage(storage).await?;
+        match get_state_map(storage, parent, epoch).await {
+            Err(_) => Err(HistoryTreeNodeError::ParentNextEpochInvalid(epoch)),
+            Ok(parent_state) => match parent.get_direction_at_ep(storage, self, epoch).await? {
+                None => Err(HistoryTreeNodeError::HashUpdateOnlyAllowedAfterNodeInsertion),
+                Some(s_dir) => {
+                    let mut parent_updated_state = parent_state;
+                    let mut self_child_state =
+                        parent_updated_state
+                            .get_child_state_in_dir(s_dir)
+                            .ok_or(HistoryTreeNodeError::NoChildInTreeAtEpoch(epoch, s_dir))?;
+                    self_child_state.hash_val = from_digest::<H>(new_hash_val)?;
+                    parent_updated_state.child_states[s_dir] = Some(self_child_state);
+                    parent_updated_state.key = NodeStateKey(parent.label, epoch);
+                    set_state_map(storage, parent_updated_state).await?;
+                    parent.write_to_storage(storage).await?;
 
-                        Ok(())
-                    }
-                },
-            }
+                    Ok(())
+                }
+            },
         }
     }
 
@@ -507,7 +497,7 @@ impl HistoryTreeNode {
                 mut child_states,
                 key: _,
             }) => {
-                child_states[dir] = child_node;
+                child_states[dir] = Some(child_node.clone());
                 set_state_map(
                     storage,
                     HistoryNodeState {
@@ -559,7 +549,8 @@ impl HistoryTreeNode {
         let children = self.get_state_at_epoch(storage, epoch).await?.child_states;
         let mut new_hash = H::hash(&[]);
         for child in children.iter().take(ARITY) {
-            new_hash = H::merge(&[new_hash, to_digest::<H>(&child.hash_val).unwrap()]);
+            let hash_val = optional_history_child_state_to_hash::<H>(child);
+            new_hash = H::merge(&[new_hash, to_digest::<H>(&hash_val).unwrap()]);
         }
         Ok(new_hash)
     }
@@ -573,6 +564,10 @@ impl HistoryTreeNode {
         Ok(self
             .get_child_at_epoch::<_, H>(storage, epoch, dir)
             .await?
+            .ok_or(HistoryTreeNodeError::NoChildInTreeAtEpoch(
+                epoch,
+                dir.unwrap(),
+            ))?
             .location)
     }
 
@@ -598,16 +593,19 @@ impl HistoryTreeNode {
         node: &Self,
         ep: u64,
     ) -> Result<Direction, HistoryTreeNodeError> {
-        let mut outcome: Direction = None;
         let state_at_ep = self.get_state_at_epoch(storage, ep).await?;
         for node_index in 0..ARITY {
             let node_val = state_at_ep.get_child_state_in_dir(node_index);
-            let node_label = node_val.label;
-            if node_label == node.label {
-                outcome = Some(node_index)
-            }
+            match node_val {
+                Some(node_val) => {
+                    if node_val.label == node.label {
+                        return Ok(Some(node_index));
+                    }
+                },
+                None => {},
+            };
         }
-        Ok(outcome)
+        Ok(None)
     }
 
     pub(crate) fn is_root(&self) -> bool {
@@ -625,7 +623,7 @@ impl HistoryTreeNode {
         storage: &S,
         epoch: u64,
         direction: Direction,
-    ) -> Result<HistoryChildState, HistoryTreeNodeError> {
+    ) -> Result<Option<HistoryChildState>, HistoryTreeNodeError> {
         match direction {
             Direction::None => Err(HistoryTreeNodeError::DirectionIsNone),
             Direction::Some(dir) => {
@@ -650,7 +648,7 @@ impl HistoryTreeNode {
         storage: &S,
         epoch: u64,
         direction: Direction,
-    ) -> Result<HistoryChildState, HistoryTreeNodeError> {
+    ) -> Result<Option<HistoryChildState>, HistoryTreeNodeError> {
         match direction {
             Direction::None => Err(HistoryTreeNodeError::DirectionIsNone),
             Direction::Some(dir) => Ok(get_state_map(storage, self, epoch)
@@ -705,7 +703,6 @@ impl HistoryTreeNode {
         storage: &S,
     ) -> Result<HistoryChildState, HistoryTreeNodeError> {
         Ok(HistoryChildState {
-            dummy_marker: DummyChildState::Real,
             location: self.location,
             label: self.label,
             hash_val: from_digest::<H>(H::merge(&[
@@ -722,7 +719,6 @@ impl HistoryTreeNode {
         storage: &S,
     ) -> Result<HistoryChildState, HistoryTreeNodeError> {
         Ok(HistoryChildState {
-            dummy_marker: DummyChildState::Real,
             location: self.location,
             label: self.label,
             hash_val: from_digest::<H>(H::merge(&[
@@ -735,6 +731,22 @@ impl HistoryTreeNode {
 }
 
 /////// Helpers //////
+
+pub(crate) fn optional_history_child_state_to_hash<H: Hasher>(input: &Option<HistoryChildState>) -> Vec<u8> {
+    match input {
+        Some(child_state) => child_state.hash_val.clone(),
+        None => from_digest::<H>(H::hash(&[0u8])).unwrap(),
+    }
+}
+
+pub(crate) fn optional_history_child_state_to_label(
+    input: &Option<HistoryChildState>,
+) -> NodeLabel {
+    match input {
+        Some(child_state) => child_state.label,
+        None => NodeLabel::new(0, 0),
+    }
+}
 
 pub(crate) async fn get_empty_root<H: Hasher, S: V2Storage + Send + Sync>(
     storage: &S,

--- a/src/node_state.rs
+++ b/src/node_state.rs
@@ -141,7 +141,7 @@ pub struct HistoryNodeState {
     /// The hash at this node state
     pub value: Vec<u8>,
     /// The states of the children at this time
-    pub child_states: Vec<HistoryChildState>,
+    pub child_states: [Option<HistoryChildState>; ARITY],
     /// A unique key
     pub key: NodeStateKey,
 }
@@ -201,16 +201,16 @@ unsafe impl Sync for HistoryNodeState {}
 impl HistoryNodeState {
     /// Creates a new [HistoryNodeState]
     pub fn new<H: Hasher>(key: NodeStateKey) -> Self {
-        let children = vec![HistoryChildState::new_dummy::<H>(); ARITY];
+        const INIT: Option<HistoryChildState> = None;
         HistoryNodeState {
             value: from_digest::<H>(H::hash(&[0u8])).unwrap(),
-            child_states: children,
+            child_states: [INIT; ARITY],
             key,
         }
     }
 
     /// Returns a copy of the child state, in the calling HistoryNodeState in the given direction.
-    pub(crate) fn get_child_state_in_dir(&self, dir: usize) -> HistoryChildState {
+    pub(crate) fn get_child_state_in_dir(&self, dir: usize) -> Option<HistoryChildState> {
         self.child_states[dir].clone()
     }
 }
@@ -232,19 +232,10 @@ impl fmt::Display for HistoryNodeState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "\tvalue = {:?}", self.value).unwrap();
         for i in 0..ARITY {
-            writeln!(f, "\tchildren {}: {:#}", i, self.child_states[i]).unwrap();
+            writeln!(f, "\tchildren {}: {:?}", i, self.child_states[i]).unwrap();
         }
         write!(f, "")
     }
-}
-
-///  Marks whether a child state is real
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Eq)]
-pub enum DummyChildState {
-    /// If this child is dummy. Usually for children of leaves
-    Dummy,
-    /// If this child is real
-    Real,
 }
 
 /// This struct represents the state of the child of a node at a given epoch
@@ -253,8 +244,6 @@ pub enum DummyChildState {
 /// In particular, the children of a leaf node are dummies.
 #[derive(Debug, Serialize, Deserialize, Eq)]
 pub struct HistoryChildState {
-    ///  Tells you whether this child is a dummy
-    pub dummy_marker: DummyChildState,
     /// Says where the child node with this label is located
     pub location: u64,
     /// Child node's label
@@ -280,24 +269,10 @@ impl HistoryChildState {
     /// Instantiates a new [HistoryChildState] with given label and hash val.
     pub fn new<H: Hasher>(loc: u64, label: NodeLabel, hash_val: H::Digest, ep: u64) -> Self {
         HistoryChildState {
-            dummy_marker: DummyChildState::Real,
             location: loc,
             label,
             hash_val: from_digest::<H>(hash_val).unwrap(),
             epoch_version: ep,
-        }
-    }
-
-    /// Creates a dummy [HistoryChildState] to signify a node not having children.
-    /// Used elsewhere to instantiate a leaf node of the
-    /// [crate::history_tree_node::HistoryTreeNode] type.
-    pub fn new_dummy<H: Hasher>() -> Self {
-        HistoryChildState {
-            dummy_marker: DummyChildState::Dummy,
-            location: 0,
-            label: NodeLabel::new(0, 0),
-            hash_val: from_digest::<H>(H::hash(&[0u8])).unwrap(),
-            epoch_version: 0,
         }
     }
 }
@@ -305,7 +280,6 @@ impl HistoryChildState {
 impl Clone for HistoryChildState {
     fn clone(&self) -> Self {
         Self {
-            dummy_marker: self.dummy_marker,
             location: self.location,
             label: self.label,
             hash_val: self.hash_val.clone(),
@@ -316,8 +290,7 @@ impl Clone for HistoryChildState {
 
 impl PartialEq for HistoryChildState {
     fn eq(&self, other: &Self) -> bool {
-        self.dummy_marker == other.dummy_marker
-            && self.location == other.location
+        self.location == other.location
             && self.label == other.label
             && self.hash_val == other.hash_val
             && self.epoch_version == other.epoch_version

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,6 +9,7 @@
 
 use crate::errors::StorageError;
 use crate::storage::types::{DbRecord, StorageType};
+use crate::ARITY;
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
@@ -278,7 +279,7 @@ pub trait V2Storage: Clone {
     /// Build a history node state from the properties
     fn build_history_node_state(
         value: Vec<u8>,
-        child_states: Vec<crate::node_state::HistoryChildState>,
+        child_states: [Option<crate::node_state::HistoryChildState>; ARITY],
         label_len: u32,
         label_val: u64,
         epoch: u64,

--- a/src/storage/mysql/mod.rs
+++ b/src/storage/mysql/mod.rs
@@ -13,6 +13,7 @@ use crate::storage::types::{
     AkdKey, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
 };
 use crate::storage::{Storable, V2Storage};
+use crate::ARITY;
 type LocalTransaction = crate::storage::transaction::Transaction;
 use async_trait::async_trait;
 use log::{debug, error, info, trace, warn};
@@ -1895,8 +1896,8 @@ impl MySqlStorable for DbRecord {
                     row.take_opt(4),
                 ) {
                     let child_states_bin_vec: Vec<u8> = child_states;
-                    let child_states_decoded: Vec<crate::node_state::HistoryChildState> =
-                        bincode::deserialize(&child_states_bin_vec).unwrap();
+                    let child_states_decoded: [Option<crate::node_state::HistoryChildState>;
+                        ARITY] = bincode::deserialize(&child_states_bin_vec).unwrap();
                     let node_state = AsyncMySqlDatabase::build_history_node_state(
                         value,
                         child_states_decoded,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,7 +48,7 @@ async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeErro
         .map_err(|_| panic!("Child not set in test_set_child_without_hash_at_root"))
         .unwrap();
     assert!(
-        set_child == child_hist_node_1,
+        set_child == Some(child_hist_node_1),
         "Child in direction is not equal to the set value"
     );
     assert!(
@@ -90,7 +90,7 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
         .await;
     match set_child_1 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_1,
+            child_st == Some(child_hist_node_1),
             "Child in 1 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -101,7 +101,7 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
         .await;
     match set_child_2 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_2,
+            child_st == Some(child_hist_node_2),
             "Child in 0 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -163,7 +163,7 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
         .await;
     match set_child_1 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_3,
+            child_st == Some(child_hist_node_3),
             "Child in 1 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -174,7 +174,7 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
         .await;
     match set_child_2 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_4,
+            child_st == Some(child_hist_node_4),
             "Child in 0 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -235,7 +235,7 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
         .await;
     match set_child_1 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_1,
+            child_st == Some(child_hist_node_1),
             "Child in 1 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -246,7 +246,7 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
         .await;
     match set_child_2 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_2,
+            child_st == Some(child_hist_node_2),
             "Child in 0 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -311,7 +311,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
         .await;
     match set_child_1 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_1,
+            child_st == Some(child_hist_node_1),
             "Child in 1 is not equal to the set value = {:?}",
             child_st
         ),
@@ -323,7 +323,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
         .await;
     match set_child_2 {
         Ok(child_st) => assert!(
-            child_st == child_hist_node_2,
+            child_st == Some(child_hist_node_2),
             "Child in 0 is not equal to the set value"
         ),
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
@@ -352,11 +352,13 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
     root.write_to_storage(&db).await?;
 
     let mut num_nodes = 1;
-
     root.insert_single_leaf::<_, Blake3>(&db, new_leaf.clone(), 0, &mut num_nodes)
         .await?;
+
+    println!("X1.5");
     root.insert_single_leaf::<_, Blake3>(&db, leaf_1.clone(), 0, &mut num_nodes)
         .await?;
+    println!("X2");
 
     let root_val = root.get_value::<_, Blake3>(&db).await?;
 
@@ -377,7 +379,7 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
         ]),
         hash_label::<Blake3>(root.label),
     ]);
-    assert!(root_val == expected, "Root hash not equal to expected");
+    assert_eq!(root_val, expected, "Root hash not equal to expected");
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@
 
 use crate::node_state::NodeLabel;
 use std::collections::HashSet;
+use winter_crypto::Hasher;
 
 // Builds a set of all prefixes of the input labels
 pub(crate) fn build_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
@@ -21,4 +22,8 @@ pub(crate) fn build_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
         }
     }
     prefixes_set
+}
+
+pub(crate) fn empty_node_hash<H: Hasher>() -> H::Digest {
+    H::hash(&[0u8; 1])
 }


### PR DESCRIPTION
This removes the "dummy" vs "real" state for child nodes, in favor of using Some/None (where None represents a dummy child)