### PR TITLE
Update directory publish API to return epoch and hash

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -168,13 +168,12 @@ impl<S: Storage + Sync + Send> Directory<S> {
         }
 
         let root_hash = current_azks.get_root_hash::<_, H>(&self.storage).await?;
-        let result = EpochHash(self.current_epoch, root_hash);
 
         self.current_epoch = next_epoch;
 
         self.storage.log_metrics(log::Level::Info).await;
 
-        Ok(result)
+        Ok(EpochHash(self.current_epoch, root_hash))
         // At the moment the tree root is not being written anywhere. Eventually we
         // want to change this to call a write operation to post to a blockchain or some such thing
     }

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -14,9 +14,7 @@ use crate::proof_structs::*;
 
 use crate::errors::{AkdError, DirectoryError, HistoryTreeNodeError, StorageError};
 
-use crate::storage::types::{
-    AkdKey, DbRecord, EpochHash, ValueState, ValueStateRetrievalFlag, Values,
-};
+use crate::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
 use crate::storage::Storage;
 
 use log::{debug, error, info};
@@ -25,6 +23,10 @@ use rand::{CryptoRng, RngCore};
 use std::collections::HashMap;
 use std::marker::{Send, Sync};
 use winter_crypto::Hasher;
+
+/// Root hash of the tree and its associated epoch
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct EpochHash<H: Hasher>(pub u64, pub H::Digest);
 
 impl Values {
     /// Gets a random value for a AKD

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -14,7 +14,9 @@ use crate::proof_structs::*;
 
 use crate::errors::{AkdError, DirectoryError, HistoryTreeNodeError, StorageError};
 
-use crate::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values, EpochHash};
+use crate::storage::types::{
+    AkdKey, DbRecord, EpochHash, ValueState, ValueStateRetrievalFlag, Values,
+};
 use crate::storage::Storage;
 
 use log::{debug, error, info};
@@ -165,13 +167,8 @@ impl<S: Storage + Sync + Send> Directory<S> {
             }
         }
 
-        let root_hash = current_azks
-            .get_root_hash::<_, H>(&self.storage)
-            .await?;
-        let result = EpochHash(
-            self.current_epoch,
-            root_hash
-        );
+        let root_hash = current_azks.get_root_hash::<_, H>(&self.storage).await?;
+        let result = EpochHash(self.current_epoch, root_hash);
 
         self.current_epoch = next_epoch;
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -66,7 +66,7 @@ impl<S: Storage + Sync + Send> Directory<S> {
         })
     }
 
-    /// Updates the directory to inclulde the updated key-value pairs.
+    /// Updates the directory to include the updated key-value pairs.
     pub async fn publish<H: Hasher>(
         &mut self,
         updates: Vec<(AkdKey, Values)>,

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -14,7 +14,7 @@ use crate::proof_structs::*;
 
 use crate::errors::{AkdError, DirectoryError, HistoryTreeNodeError, StorageError};
 
-use crate::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+use crate::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values, EpochHash};
 use crate::storage::Storage;
 
 use log::{debug, error, info};
@@ -71,7 +71,7 @@ impl<S: Storage + Sync + Send> Directory<S> {
         &mut self,
         updates: Vec<(AkdKey, Values)>,
         use_transaction: bool,
-    ) -> Result<(), AkdError> {
+    ) -> Result<EpochHash<H>, AkdError> {
         let mut update_set = Vec::<(NodeLabel, H::Digest)>::new();
         let mut user_data_update_set = Vec::<ValueState>::new();
         let next_epoch = self.current_epoch + 1;
@@ -165,11 +165,19 @@ impl<S: Storage + Sync + Send> Directory<S> {
             }
         }
 
+        let root_hash = current_azks
+            .get_root_hash::<_, H>(&self.storage)
+            .await?;
+        let result = EpochHash(
+            self.current_epoch,
+            root_hash
+        );
+
         self.current_epoch = next_epoch;
 
         self.storage.log_metrics(log::Level::Info).await;
 
-        Ok(())
+        Ok(result)
         // At the moment the tree root is not being written anywhere. Eventually we
         // want to change this to call a write operation to post to a blockchain or some such thing
     }

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -12,8 +12,6 @@ use crate::storage::Storable;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
-use winter_crypto::Hasher;
-
 /// Various elements that can be stored
 #[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
 pub enum StorageType {
@@ -39,10 +37,6 @@ pub struct Values(pub String);
 /// State for a value at a given version for that key
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValueStateKey(pub String, pub u64);
-
-/// Root hash of the tree and its associated epoch
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct EpochHash<H: Hasher>(pub u64, pub H::Digest);
 
 /// The state of the value for a given key, starting at a particular epoch.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -12,6 +12,8 @@ use crate::storage::Storable;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
+use winter_crypto::Hasher;
+
 /// Various elements that can be stored
 #[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
 pub enum StorageType {
@@ -37,6 +39,10 @@ pub struct Values(pub String);
 /// State for a value at a given version for that key
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValueStateKey(pub String, pub u64);
+
+/// Root hash of the tree and its associated epoch
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EpochHash<H: Hasher>(pub u64, pub H::Digest);
 
 /// The state of the value for a given key, starting at a particular epoch.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -6,6 +6,7 @@
 // of this source tree.
 
 use akd::directory::Directory;
+use akd::directory::EpochHash;
 use akd::errors::AkdError;
 use akd::storage::types::*;
 use akd::storage::Storage;

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -67,9 +67,16 @@ where
                     .publish::<H>(vec![(AkdKey(a.clone()), Values(b.clone()))], false)
                     .await
                 {
-                    Ok(_) => {
+                    Ok(EpochHash(epoch, hash)) => {
                         let toc = Instant::now() - tic;
-                        let msg = format!("PUBLISHED '{}' = '{}' in {} s", a, b, toc.as_secs_f64());
+                        let msg = format!(
+                            "PUBLISHED '{}' = '{}' in {} s (epoch: {}, root hash: {})",
+                            a,
+                            b,
+                            toc.as_secs_f64(),
+                            epoch,
+                            hex::encode(hash)
+                        );
                         response.send(Ok(msg)).unwrap()
                     }
                     Err(error) => {

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -101,7 +101,7 @@ struct Cli {
     #[structopt(
         long = "multirow_size",
         short = "m",
-        name = "MySQL mutli-row insert size",
+        name = "MySQL multi-row insert size",
         default_value = "100"
     )]
     mysql_insert_depth: usize,


### PR DESCRIPTION
Update the directory publish API to return an epoch and hash on success.

The POC app is consequently updated to display the result to the CLI.

## Test Run
```console
$ cargo run        
   Compiling akd_app v0.1.0 (/Users/evanau/Projects/akd/poc)
    Finished dev [unoptimized + debuginfo] target(s) in 6.38s
     Running `/Users/evanau/Projects/akd/target/debug/akd_app`
Please enter a command
> [00:00:00.032] (7000023d7000) INFO   Starting the verifiable directory host (directory_host:57)
PUBLISH test test
[00:00:10.662] (7000009b0000) INFO   Retrieved 1 previous user versions of 1 requested (directory:92)
[00:00:10.662] (7000009b0000) INFO   Starting database insertion (directory:143)
[00:00:10.764] (700001bcb000) INFO   Preload of tree (6 objects loaded), took 0.101717335 s (append_only_zks:195)
[00:00:10.954] (7000009b0000) INFO   Cache hit since last: 66, cached size: 17 items (timed_cache:52)
[00:00:10.954] (7000009b0000) INFO   Transaction writes: 0, Transaction reads: 0 (transaction:78)
[00:00:10.962] (7000009b0000) INFO   MySQL writes: 40, MySQL reads: 6, Time read: 0.132675114 s, Time write: 0.174001216 s
        Tree size: 9
        Node state count: 12
        Value state count: 3 (mysql:704)
Response: PUBLISHED 'test' = 'test' in 0.329670055 s (epoch: 2, root hash: 8074b1f261ce707fb3cb8927d5ba60fd98162addbb3592b7e50805683729d157)
```