### PR TITLE
Correct publish pipeline for multi-package publish in workspace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,14 @@ jobs:
       env:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }}
     - name: Dry run publish akd
-      run: cargo publish --dry-run --manifest-path akd/Cargo.toml
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd
     - name: Publish akd
-      run: cargo publish --manifest-path akd/Cargo.toml
+      run: cargo publish --manifest-path Cargo.toml -p akd
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
     - name: Dry run publish akd_mysql
-      run: cargo publish --dry-run --manifest-path akd_mysql/Cargo.toml
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish akd_mysql
-      run: cargo publish --manifest-path akd_mysql/Cargo.toml
+      run: cargo publish --manifest-path Cargo.toml -p akd_mysql
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "S
 description = "An implementation of an auditable key directory"
 license = "MIT"
 edition = "2018"
-keywords = ["key-transparency", "akd", "verifiable-data-structures"]
+keywords = ["key-transparency", "akd"]
 repository = "https://github.com/novifinancial/akd"
 
 [features]

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -43,6 +43,7 @@ impl AkdKey {
 }
 
 /// The representation of a auditable key directory
+#[derive(Clone)]
 pub struct Directory<S> {
     current_epoch: u64,
     storage: S,

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "S
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT"
 edition = "2018"
-keywords = ["key-transparency", "akd", "verifiable-data-structures", "mysql"]
+keywords = ["key-transparency", "akd", "mysql", "akd-mysql"]
 repository = "https://github.com/novifinancial/akd"
 
 [features]


### PR DESCRIPTION
The publish pipeline was incorrectly specified. We should be using the ```-p``` flag to indicate the package within the workspace to publish. See [docs](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)

Also needed to add the ability to "clone" a ```Directory<S>``` for downstream usage (with async move patterns). A clone of the directory will simply be a pointer to the same storage layer, but with an independent transaction (if one is present at all).