### PR TITLE
[akd_mysql] Relative path dependency requires a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ To learn more about contributing to this project, [see this document](./CONTRIBU
 License
 -------
 
-This project is [licensed](./LICENSE) under either Apache 2.0 or MIT, at your option.
+This project is licensed under either [Apache 2.0](./LICENSE-APACHE) or [MIT](./LICENSE-MIT), at your option.

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -3,12 +3,11 @@ name = "akd"
 version = "0.3.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 keywords = ["key-transparency", "akd"]
 repository = "https://github.com/novifinancial/akd"
 readme = "../README.md"
-license-file = "../LICENSE-MIT"
 
 [features]
 bench = []

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "akd"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT"
 edition = "2018"
 keywords = ["key-transparency", "akd"]
 repository = "https://github.com/novifinancial/akd"
+readme = "../README.md"
+license-file = "../LICENSE-MIT"
 
 [features]
 bench = []

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -3,11 +3,10 @@ name = "akd_mysql"
 version = "0.3.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 keywords = ["key-transparency", "akd", "mysql", "akd-mysql"]
 repository = "https://github.com/novifinancial/akd"
-license-file = "../LICENSE-MIT"
 
 [features]
 bench = []

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.10.2", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.28.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd" }
+akd = { path = "../akd", version = "0.3.0" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "akd_mysql"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT"
 edition = "2018"
 keywords = ["key-transparency", "akd", "mysql", "akd-mysql"]
 repository = "https://github.com/novifinancial/akd"
+license-file = "../LICENSE-MIT"
 
 [features]
 bench = []

--- a/akd_mysql/README.md
+++ b/akd_mysql/README.md
@@ -1,0 +1,45 @@
+## akd ![Build Status](https://github.com/novifinancial/akd/workflows/CI/badge.svg)
+
+An implementation of a MySQL storage layer for the auditable key directory (also known as a verifiable registry).
+
+Auditable key directories can be used to help provide key transparency for end-to-end encrypted
+messaging.
+
+This implementation is based off of the protocol described in
+[SEEMless: Secure End-to-End Encrypted Messaging with less trust](https://eprint.iacr.org/2018/607).
+
+This library provides an implementation of the ```Storage``` trait for a MySQL database.
+
+⚠️ **Warning**: This implementation has not been audited and is not ready for a production application. Use at your own risk!
+
+Documentation
+-------------
+
+The API can be found [here](https://docs.rs/akd_mysql/) along with an example for usage.
+
+Installation
+------------
+
+Add the following line to the dependencies of your `Cargo.toml`:
+
+```
+akd_mysql = "0.3"
+```
+
+### Minimum Supported Rust Version
+
+Rust **1.51** or higher.
+
+Contributors
+------------
+
+The authors of this code are
+Jasleen Malvai ([@jasleen1](https://github.com/jasleen1)),
+Kevin Lewi ([@kevinlewi](https://github.com/kevinlewi)), and
+Sean Lawlor ([@slawlor](https://github.com/slawlor)).
+To learn more about contributing to this project, [see this document](./CONTRIBUTING.md).
+
+License
+-------
+
+This project is [licensed](./LICENSE) under either Apache 2.0 or MIT, at your option.

--- a/akd_mysql/README.md
+++ b/akd_mysql/README.md
@@ -37,9 +37,9 @@ The authors of this code are
 Jasleen Malvai ([@jasleen1](https://github.com/jasleen1)),
 Kevin Lewi ([@kevinlewi](https://github.com/kevinlewi)), and
 Sean Lawlor ([@slawlor](https://github.com/slawlor)).
-To learn more about contributing to this project, [see this document](./CONTRIBUTING.md).
+To learn more about contributing to this project, [see this document](../CONTRIBUTING.md).
 
 License
 -------
 
-This project is [licensed](./LICENSE) under either Apache 2.0 or MIT, at your option.
+This project is licensed under either [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT), at your option.


### PR DESCRIPTION
Just a tweak to allow publish to reference the right version when the package is on crates.io