### PR TITLE
Pinning tokio to 1.10, not 1.10.2

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -22,7 +22,7 @@ keyed_priority_queue = "0.3"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
-tokio = { version = "1.10.2", features = ["full"] }
+tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -19,7 +19,7 @@ winter-math = "0.1"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
-tokio = { version = "1.10.2", features = ["full"] }
+tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.28.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,7 +11,7 @@ winter-math = "0.1"
 
 [dev-dependencies]
 log = { version = "0.4.8", features = ["kv_unstable"] }
-tokio = { version = "1.10.2", features = ["full"] }
+tokio = { version = "1.10", features = ["full"] }
 akd = { path = "../akd" }
 akd_mysql = { path = "../akd_mysql" }
 serial_test = "*"

--- a/poc/Cargo.toml
+++ b/poc/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 winter-crypto = "0.1"
 winter-math = "0.1"
-tokio = { version = "1.10.2", features = ["full"] }
+tokio = { version = "1.10", features = ["full"] }
 colored = "2.0.0"
 hex = "0.4.3"
 structopt = "0.3.13"


### PR DESCRIPTION
We should not specify the build # of tokio so we're flexible with upgrades.