### PR TITLE
Adjusting visibility of publicly exposed records to all pub properties

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -16,25 +16,34 @@ use crate::{node_state::NodeLabel, storage::types::Values, Direction, ARITY};
 /// in the tree at a given epoch.
 #[derive(Debug, Clone)]
 pub struct MembershipProof<H: Hasher> {
-    pub(crate) label: NodeLabel,
-    pub(crate) hash_val: H::Digest,
-    pub(crate) parent_labels: Vec<NodeLabel>,
-    #[allow(dead_code)]
-    pub(crate) sibling_labels: Vec<[NodeLabel; ARITY - 1]>,
-    pub(crate) sibling_hashes: Vec<[H::Digest; ARITY - 1]>,
-    pub(crate) dirs: Vec<Direction>,
+    /// The node label
+    pub label: NodeLabel,
+    /// The hash of the value
+    pub hash_val: H::Digest,
+    /// The parent node labels
+    pub parent_labels: Vec<NodeLabel>,
+    /// The sibling labels
+    pub sibling_labels: Vec<[NodeLabel; ARITY - 1]>,
+    /// The node sibling hashes
+    pub sibling_hashes: Vec<[H::Digest; ARITY - 1]>,
+    /// The directions
+    pub dirs: Vec<Direction>,
 }
 
 /// Merkle Patricia proof of non-membership for a [`NodeLabel`] in the tree
 /// at a given epoch.
 #[derive(Debug, Clone)]
 pub struct NonMembershipProof<H: Hasher> {
-    #[allow(dead_code)]
-    pub(crate) label: NodeLabel,
-    pub(crate) longest_prefix: NodeLabel,
-    pub(crate) longest_prefix_children_labels: [NodeLabel; ARITY],
-    pub(crate) longest_prefix_children_values: [H::Digest; ARITY],
-    pub(crate) longest_prefix_membership_proof: MembershipProof<H>,
+    /// The label in question
+    pub label: NodeLabel,
+    /// The longest prefix in the tree
+    pub longest_prefix: NodeLabel,
+    /// The children of the longest prefix
+    pub longest_prefix_children_labels: [NodeLabel; ARITY],
+    /// The values of the longest prefix children
+    pub longest_prefix_children_values: [H::Digest; ARITY],
+    /// The membership proof of the longest prefix
+    pub longest_prefix_membership_proof: MembershipProof<H>,
 }
 
 /// Proof that no leaves were deleted from the initial epoch.
@@ -44,8 +53,10 @@ pub struct NonMembershipProof<H: Hasher> {
 /// as the leaves, it should result in the final root hash.
 #[derive(Debug, Clone)]
 pub struct AppendOnlyProof<H: Hasher> {
-    pub(crate) inserted: Vec<(NodeLabel, H::Digest)>,
-    pub(crate) unchanged_nodes: Vec<(NodeLabel, H::Digest)>,
+    /// The inserted nodes & digests
+    pub inserted: Vec<(NodeLabel, H::Digest)>,
+    /// The unchanged nodes & digests
+    pub unchanged_nodes: Vec<(NodeLabel, H::Digest)>,
 }
 
 /// Proof that a given label was at a particular state at the given epoch.
@@ -56,12 +67,18 @@ pub struct AppendOnlyProof<H: Hasher> {
 /// This proof is sent in response to a lookup query for a particular key.
 #[derive(Debug, Clone)]
 pub struct LookupProof<H: Hasher> {
-    pub(crate) epoch: u64,
-    pub(crate) plaintext_value: Values,
-    pub(crate) version: u64,
-    pub(crate) existence_proof: MembershipProof<H>,
-    pub(crate) marker_proof: MembershipProof<H>,
-    pub(crate) freshness_proof: NonMembershipProof<H>,
+    /// The epoch of this record
+    pub epoch: u64,
+    /// The plaintext value in question
+    pub plaintext_value: Values,
+    /// The version of the record
+    pub version: u64,
+    /// Record existence proof
+    pub existence_proof: MembershipProof<H>,
+    /// Existence at specific marker
+    pub marker_proof: MembershipProof<H>,
+    /// Freshness proof (non member at previous epoch)
+    pub freshness_proof: NonMembershipProof<H>,
 }
 
 /// A vector of UpdateProofs are sent as the proof to a history query for a particular key.
@@ -73,19 +90,27 @@ pub struct LookupProof<H: Hasher> {
 /// * the future marker versions did  not exist at this epoch.
 #[derive(Debug, Clone)]
 pub struct UpdateProof<H: Hasher> {
-    pub(crate) epoch: u64,
-    pub(crate) plaintext_value: Values,
-    pub(crate) version: u64,
-    pub(crate) existence_at_ep: MembershipProof<H>, // membership proof to show that the key was included in this epoch
-    pub(crate) previous_val_stale_at_ep: Option<MembershipProof<H>>, // proof that previous value was set to old at this epoch
-    pub(crate) non_existence_before_ep: Option<NonMembershipProof<H>>, // proof that this value didn't exist prior to this ep
-    pub(crate) non_existence_of_next_few: Vec<NonMembershipProof<H>>, // proof that the next few values did not exist at this time
-    pub(crate) non_existence_of_future_markers: Vec<NonMembershipProof<H>>, // proof that future markers did not exist
+    /// Epoch of this update
+    pub epoch: u64,
+    /// Value at this update
+    pub plaintext_value: Values,
+    /// Version at this update
+    pub version: u64,
+    /// Membership proof to show that the key was included in this epoch
+    pub existence_at_ep: MembershipProof<H>,
+    /// Proof that previous value was set to old at this epoch
+    pub previous_val_stale_at_ep: Option<MembershipProof<H>>,
+    /// Proof that this value didn't exist prior to this ep
+    pub non_existence_before_ep: Option<NonMembershipProof<H>>,
+    /// Proof that the next few values did not exist at this time
+    pub non_existence_of_next_few: Vec<NonMembershipProof<H>>,
+    /// Proof that future markers did not exist
+    pub non_existence_of_future_markers: Vec<NonMembershipProof<H>>,
 }
 
 /// This proof is just an array of [`UpdateProof`]s.
 #[derive(Debug, Clone)]
 pub struct HistoryProof<H: Hasher> {
-    #[allow(unused)]
-    pub(crate) proofs: Vec<UpdateProof<H>>,
+    /// The update proofs in the key history
+    pub proofs: Vec<UpdateProof<H>>,
 }

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -10,13 +10,13 @@ use winter_crypto::Hasher;
 use winter_utils::{Deserializable, Serializable, SliceReader};
 
 /// Converts from &[u8] to H::Digest
-pub(crate) fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, HistoryTreeNodeError> {
+pub fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, HistoryTreeNodeError> {
     H::Digest::read_from(&mut SliceReader::new(input))
         .map_err(|_| HistoryTreeNodeError::SerializationError)
 }
 
 /// Converts from H::Digest to Vec<u8>
-pub(crate) fn from_digest<H: Hasher>(input: H::Digest) -> Result<Vec<u8>, HistoryTreeNodeError> {
+pub fn from_digest<H: Hasher>(input: H::Digest) -> Result<Vec<u8>, HistoryTreeNodeError> {
     let mut output = vec![];
     input.write_into(&mut output);
     Ok(output)

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -24,7 +24,7 @@ fn single_insertion(c: &mut Criterion) {
 
     let mut rng: ThreadRng = thread_rng();
 
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let db = InMemoryDb::new();
 


### PR DESCRIPTION
We need all of the types which are publicly exposed to have completely ```pub``` properties (not ```pub(crate)```) because they will eventually be serialized over the wire and generally serializers will need to read the properties of these structs.