### PR TITLE
Minimum version required for inter-lib interop

### DIFF
--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.28.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "0.3" }
+akd = { path = "../akd", version = "^0.3.4" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
This fixes the broken CI pipeline