### PR TITLE
We need to first publish AKD so it's available in crates.io to build …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,12 @@ jobs:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }}
     - name: Dry run publish AKD
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd
-    - name: Dry run publish AKD_MYSQL
-      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish crate akd
       run: cargo publish --manifest-path Cargo.toml -p akd
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish AKD_MYSQL
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish crate akd_mysql
       run: cargo publish --manifest-path Cargo.toml -p akd_mysql
       env:


### PR DESCRIPTION
…AKD_MYSQL. Is a problem for contract breaks, so we need to be SURE akd_mysql builds (CI should protect this)