### PR TITLE
Deprecate location field

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -100,7 +100,6 @@ impl Azks {
         let new_leaf = get_leaf_node::<H, S>(
             storage,
             label,
-            0,
             value.as_bytes().as_ref(),
             NodeLabel::root(),
             self.latest_epoch,
@@ -215,7 +214,6 @@ impl Azks {
                 get_leaf_node_without_hashing::<H, S>(
                     storage,
                     label,
-                    0,
                     value,
                     NodeLabel::root(),
                     self.latest_epoch,
@@ -225,7 +223,6 @@ impl Azks {
                 get_leaf_node::<H, S>(
                     storage,
                     label,
-                    0,
                     value.as_bytes().as_ref(),
                     NodeLabel::root(),
                     self.latest_epoch,

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -230,9 +230,6 @@ impl Azks {
                 .await?
             };
 
-            // TODO(evanau): Remove once certain it's correct
-            assert_eq!(new_leaf.label, label);
-
             debug!("BEGIN insert leaf");
             root_node
                 .insert_leaf::<_, H>(storage, new_leaf, self.latest_epoch, &mut self.num_nodes)

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -29,8 +29,6 @@ use keyed_priority_queue::{Entry, KeyedPriorityQueue};
 
 /// The default azks key
 pub const DEFAULT_AZKS_KEY: u8 = 1u8;
-/// The default location of the azks root
-pub const DEFAULT_AZKS_ROOT: u64 = 0;
 
 /// An append-only zero knowledge set, the data structure used to efficiently implement
 /// a auditable key directory.
@@ -104,13 +102,13 @@ impl Azks {
             label,
             0,
             value.as_bytes().as_ref(),
-            0,
+            NodeLabel::root(),
             self.latest_epoch,
         )
         .await?;
 
         let mut root_node =
-            HistoryTreeNode::get_from_storage(storage, NodeKey(DEFAULT_AZKS_ROOT)).await?;
+            HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         root_node
             .insert_single_leaf::<_, H>(storage, new_leaf, self.latest_epoch, &mut self.num_nodes)
             .await?;
@@ -134,7 +132,7 @@ impl Azks {
         insertion_set: &[(NodeLabel, H::Digest)],
     ) -> Result<u64, AkdError> {
         let mut load_count: u64 = 0;
-        let mut current_nodes = vec![NodeKey(DEFAULT_AZKS_ROOT)];
+        let mut current_nodes = vec![NodeKey(NodeLabel::root())];
 
         let prefixes_set = crate::utils::build_prefixes_set(
             insertion_set
@@ -177,7 +175,7 @@ impl Azks {
                         .await?;
 
                     if let Some(child) = child {
-                        current_nodes.push(NodeKey(child.location));
+                        current_nodes.push(NodeKey(child.label));
                     }
                 }
             }
@@ -208,20 +206,18 @@ impl Azks {
         self.increment_epoch();
         self.preload_nodes_for_insertion::<S, H>(storage, &insertion_set)
             .await?;
-        let mut hash_q = KeyedPriorityQueue::<u64, i32>::new();
+        let mut hash_q = KeyedPriorityQueue::<NodeLabel, i32>::new();
         let mut priorities: i32 = 0;
         let mut root_node =
-            HistoryTreeNode::get_from_storage(storage, NodeKey(DEFAULT_AZKS_ROOT)).await?;
+            HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         for (label, value) in insertion_set {
-            let new_leaf_loc = self.num_nodes;
-
             let new_leaf = if append_only_usage {
                 get_leaf_node_without_hashing::<H, S>(
                     storage,
                     label,
                     0,
                     value,
-                    0,
+                    NodeLabel::root(),
                     self.latest_epoch,
                 )
                 .await?
@@ -231,11 +227,14 @@ impl Azks {
                     label,
                     0,
                     value.as_bytes().as_ref(),
-                    0,
+                    NodeLabel::root(),
                     self.latest_epoch,
                 )
                 .await?
             };
+
+            // TODO(evanau): Remove once certain it's correct
+            assert_eq!(new_leaf.label, label);
 
             debug!("BEGIN insert leaf");
             root_node
@@ -243,17 +242,17 @@ impl Azks {
                 .await?;
             debug!("END insert leaf");
 
-            hash_q.push(new_leaf_loc, priorities);
+            hash_q.push(label, priorities);
             priorities -= 1;
         }
 
         while !hash_q.is_empty() {
-            let (next_node_loc, _) = hash_q
+            let (next_node_label, _) = hash_q
                 .pop()
                 .ok_or(AzksError::PopFromEmptyPriorityQueue(self.latest_epoch))?;
 
             let mut next_node: HistoryTreeNode =
-                HistoryTreeNode::get_from_storage(storage, NodeKey(next_node_loc)).await?;
+                HistoryTreeNode::get_from_storage(storage, NodeKey(next_node_label)).await?;
 
             next_node
                 .update_hash::<_, H>(storage, self.latest_epoch)
@@ -298,13 +297,13 @@ impl Azks {
         label: NodeLabel,
         epoch: u64,
     ) -> Result<NonMembershipProof<H>, AkdError> {
-        let (longest_prefix_membership_proof, lcp_node_id) = self
+        let (longest_prefix_membership_proof, lcp_node_label) = self
             .get_membership_proof_and_node(storage, label, epoch)
             .await?;
         let lcp_node: HistoryTreeNode =
-            HistoryTreeNode::get_from_storage(storage, NodeKey(lcp_node_id)).await?;
+            HistoryTreeNode::get_from_storage(storage, NodeKey(lcp_node_label)).await?;
         let longest_prefix = lcp_node.label;
-        let mut longest_prefix_children_labels = [NodeLabel::new(0, 0); ARITY];
+        let mut longest_prefix_children_labels = [NodeLabel::root(); ARITY];
         let mut longest_prefix_children_values = [crate::utils::empty_node_hash::<H>(); ARITY];
         let state = lcp_node.get_state_at_epoch(storage, epoch).await?;
 
@@ -315,7 +314,7 @@ impl Azks {
                 }
                 Some(child) => {
                     let unwrapped_child: HistoryTreeNode =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(child.location)).await?;
+                        HistoryTreeNode::get_from_storage(storage, NodeKey(child.label)).await?;
                     longest_prefix_children_labels[i] = unwrapped_child.label;
                     longest_prefix_children_values[i] = unwrapped_child
                         .get_value_without_label_at_epoch::<_, H>(storage, epoch)
@@ -350,7 +349,7 @@ impl Azks {
         // Suppose the epochs start_epoch and end_epoch exist in the set.
         // This function should return the proof that nothing was removed/changed from the tree
         // between these epochs.
-        let node = HistoryTreeNode::get_from_storage(storage, NodeKey(DEFAULT_AZKS_ROOT)).await?;
+        let node = HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         let (unchanged, leaves) = self
             .get_append_only_proof_helper::<_, H>(storage, node, start_epoch, end_epoch)
             .await?;
@@ -408,7 +407,7 @@ impl Azks {
                     Some(child_node_state) => {
                         let child_node = HistoryTreeNode::get_from_storage(
                             storage,
-                            NodeKey(child_node_state.location),
+                            NodeKey(child_node_state.label),
                         )
                         .await?;
                         let mut rec_output = self
@@ -447,7 +446,7 @@ impl Azks {
         epoch: u64,
     ) -> Result<H::Digest, HistoryTreeNodeError> {
         let root_node: HistoryTreeNode =
-            HistoryTreeNode::get_from_storage(storage, NodeKey(DEFAULT_AZKS_ROOT)).await?;
+            HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         root_node.get_value_at_epoch::<_, H>(storage, epoch).await
     }
 
@@ -462,7 +461,7 @@ impl Azks {
         self.latest_epoch = epoch;
     }
 
-    /// This function returns the node location for the node whose label is the longest common
+    /// This function returns the node label for the node whose label is the longest common
     /// prefix for the queried label. It also returns a membership proof for said label.
     /// This is meant to be used in both, getting membership proofs and getting non-membership proofs.
     pub async fn get_membership_proof_and_node<S: Storage + Sync + Send, H: Hasher>(
@@ -470,22 +469,22 @@ impl Azks {
         storage: &S,
         label: NodeLabel,
         epoch: u64,
-    ) -> Result<(MembershipProof<H>, u64), AkdError> {
+    ) -> Result<(MembershipProof<H>, NodeLabel), AkdError> {
         let mut parent_labels = Vec::<NodeLabel>::new();
         let mut sibling_labels = Vec::<[NodeLabel; ARITY - 1]>::new();
         let mut sibling_hashes = Vec::<[H::Digest; ARITY - 1]>::new();
         let mut dirs = Vec::<Direction>::new();
         let mut curr_node: HistoryTreeNode =
-            HistoryTreeNode::get_from_storage(storage, NodeKey(DEFAULT_AZKS_ROOT)).await?;
+            HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         let mut dir = curr_node.label.get_dir(label);
         let mut equal = label == curr_node.label;
-        let mut prev_node = 0;
+        let mut prev_node = NodeLabel::root();
         while !equal && dir.is_some() {
             dirs.push(dir);
             parent_labels.push(curr_node.label);
-            prev_node = curr_node.location;
+            prev_node = curr_node.label;
             let curr_state = curr_node.get_state_at_epoch(storage, epoch).await?;
-            let mut labels = [NodeLabel::new(0, 0); ARITY - 1];
+            let mut labels = [NodeLabel::root(); ARITY - 1];
             let mut hashes = [H::hash(&[0u8]); ARITY - 1];
             let mut count = 0;
             let direction = dir.ok_or(AkdError::NoDirectionError)?;
@@ -510,7 +509,7 @@ impl Azks {
                 storage,
                 NodeKey(
                     curr_node
-                        .get_child_location_at_epoch::<_, H>(storage, epoch, dir)
+                        .get_child_label_at_epoch::<_, H>(storage, epoch, dir)
                         .await?,
                 ),
             )

--- a/akd/src/history_tree_node.rs
+++ b/akd/src/history_tree_node.rs
@@ -59,15 +59,15 @@ pub struct HistoryTreeNode {
     pub location: u64,
     /// The epochs this node was updated
     pub epochs: Vec<u64>,
-    /// The location of this node's parent
-    pub parent: u64, // The root node is marked its own parent.
+    /// The label of this node's parent
+    pub parent: NodeLabel, // The root node is marked its own parent.
     /// The type of node: leaf root or interior.
     pub node_type: NodeType, // Leaf, Root or Interior
 }
 
-/// Represents the location (i.e. key) with which to find a node in storage.
+/// Wraps the label with which to find a node in storage.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, std::fmt::Debug)]
-pub struct NodeKey(pub u64);
+pub struct NodeKey(pub NodeLabel);
 
 impl Storable for HistoryTreeNode {
     type Key = NodeKey;
@@ -77,25 +77,33 @@ impl Storable for HistoryTreeNode {
     }
 
     fn get_id(&self) -> NodeKey {
-        NodeKey(self.location)
+        NodeKey(self.label)
     }
 
     fn get_full_binary_key_id(key: &NodeKey) -> Vec<u8> {
         let mut result = vec![StorageType::HistoryTreeNode as u8];
-        let id_bytes = key.0.to_be_bytes();
-        for item in &id_bytes {
-            result.push(*item);
+        let len_bytes = key.0.len.to_be_bytes();
+        for byte in &len_bytes {
+            result.push(*byte);
+        }
+        let parts = key.0.val.to_be_bytes();
+        for byte in &parts {
+            result.push(*byte);
         }
         result
     }
 
     fn key_from_full_binary(bin: &[u8]) -> Result<NodeKey, String> {
-        if bin.len() < 9 {
+        if bin.len() < 13 {
             return Err("Not enough bytes to form a proper key".to_string());
         }
 
-        let id_bytes: [u8; 8] = bin[1..=8].try_into().expect("Slice with incorrect length");
-        Ok(NodeKey(u64::from_be_bytes(id_bytes)))
+        let len_bytes: [u8; 4] = bin[1..=4].try_into().expect("Slice with incorrect length");
+        let val_bytes: [u8; 8] = bin[5..=12].try_into().expect("Slice with incorrect length");
+        let len = u32::from_be_bytes(len_bytes);
+        let val = u64::from_be_bytes(val_bytes);
+
+        Ok(NodeKey(NodeLabel::new(val, len)))
     }
 }
 
@@ -114,7 +122,7 @@ impl Clone for HistoryTreeNode {
 }
 
 impl HistoryTreeNode {
-    fn new(label: NodeLabel, location: u64, parent: u64, node_type: NodeType) -> Self {
+    fn new(label: NodeLabel, location: u64, parent: NodeLabel, node_type: NodeType) -> Self {
         HistoryTreeNode {
             label,
             location,
@@ -199,7 +207,6 @@ impl HistoryTreeNode {
             .get_longest_common_prefix_and_dirs(new_leaf.label);
 
         if self.is_root() {
-            new_leaf.location = *num_nodes;
             new_leaf.write_to_storage(storage).await?;
             *num_nodes += 1;
             // the root should always be instantiated with dummy children in the beginning
@@ -207,7 +214,7 @@ impl HistoryTreeNode {
                 .get_child_at_epoch::<_, H>(storage, self.get_latest_epoch()?, dir_leaf)
                 .await?;
             if child_state == None {
-                new_leaf.parent = self.location;
+                new_leaf.parent = self.label;
                 self.set_node_child::<_, H>(storage, epoch, dir_leaf, &new_leaf)
                     .await?;
                 self.write_to_storage(storage).await?;
@@ -216,12 +223,11 @@ impl HistoryTreeNode {
                 if hashing {
                     new_leaf.update_hash::<_, H>(storage, epoch).await?;
                     let mut new_self: HistoryTreeNode =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.label)).await?;
                     new_self.update_hash::<_, H>(storage, epoch).await?;
                     *self = new_self;
                 } else {
-                    *self =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                    *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.label)).await?;
                 }
 
                 return Ok(());
@@ -246,7 +252,7 @@ impl HistoryTreeNode {
                 let mut new_node = HistoryTreeNode::new(
                     lcs_label,
                     new_node_location,
-                    parent.location,
+                    parent.label,
                     NodeType::Interior,
                 );
                 new_node.epochs.push(epoch);
@@ -259,11 +265,11 @@ impl HistoryTreeNode {
                 *num_nodes += 1;
                 // Add this node in the correct dir and child node in the other direction
                 debug!("BEGIN update leaf location");
-                new_leaf.parent = new_node.location;
+                new_leaf.parent = new_node.label;
                 new_leaf.write_to_storage(storage).await?;
 
                 debug!("BEGIN update self");
-                self.parent = new_node.location;
+                self.parent = new_node.label;
                 self.write_to_storage(storage).await?;
 
                 debug!("BEGIN set node child new_node(new_leaf)");
@@ -284,8 +290,7 @@ impl HistoryTreeNode {
                     new_leaf.update_hash::<_, H>(storage, epoch).await?;
                     self.update_hash::<_, H>(storage, epoch).await?;
                     new_node =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(new_node.location))
-                            .await?;
+                        HistoryTreeNode::get_from_storage(storage, NodeKey(new_node.label)).await?;
                     new_node.update_hash::<_, H>(storage, epoch).await?;
                 }
                 debug!("BEGIN save new_node");
@@ -293,7 +298,7 @@ impl HistoryTreeNode {
                 debug!("BEGIN save parent");
                 parent.write_to_storage(storage).await?;
                 debug!("BEGIN retrieve new self");
-                *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.label)).await?;
                 debug!("END insert single leaf (dir_self = Some)");
                 Ok(())
             }
@@ -310,21 +315,19 @@ impl HistoryTreeNode {
 
                 debug!("BEGIN get child node from storage");
                 let mut child_node =
-                    HistoryTreeNode::get_from_storage(storage, NodeKey(child_st.location)).await?;
+                    HistoryTreeNode::get_from_storage(storage, NodeKey(child_st.label)).await?;
                 debug!("BEGIN insert single leaf helper");
                 child_node
                     .insert_single_leaf_helper::<_, H>(storage, new_leaf, epoch, num_nodes, hashing)
                     .await?;
                 if hashing {
                     debug!("BEGIN update hashes");
-                    *self =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                    *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.label)).await?;
                     self.update_hash::<_, H>(storage, epoch).await?;
                     self.write_to_storage(storage).await?;
                 } else {
                     debug!("BEGIN retrieve self");
-                    *self =
-                        HistoryTreeNode::get_from_storage(storage, NodeKey(self.location)).await?;
+                    *self = HistoryTreeNode::get_from_storage(storage, NodeKey(self.label)).await?;
                 }
                 debug!("END insert single leaf (dir_self = None)");
                 Ok(())
@@ -554,17 +557,17 @@ impl HistoryTreeNode {
         Ok(new_hash)
     }
 
-    pub(crate) async fn get_child_location_at_epoch<S: Storage + Sync + Send, H: Hasher>(
+    pub(crate) async fn get_child_label_at_epoch<S: Storage + Sync + Send, H: Hasher>(
         &self,
         storage: &S,
         epoch: u64,
         dir: Direction,
-    ) -> Result<u64, HistoryTreeNodeError> {
+    ) -> Result<NodeLabel, HistoryTreeNodeError> {
         Ok(self
             .get_child_at_epoch::<_, H>(storage, epoch, dir)
             .await?
             .ok_or_else(|| HistoryTreeNodeError::NoChildInTreeAtEpoch(epoch, dir.unwrap()))?
-            .location)
+            .label)
     }
 
     // gets value at current epoch
@@ -739,7 +742,7 @@ pub(crate) fn optional_history_child_state_to_label(
 ) -> NodeLabel {
     match input {
         Some(child_state) => child_state.label,
-        None => NodeLabel::new(0, 0),
+        None => NodeLabel::root(),
     }
 }
 
@@ -747,7 +750,7 @@ pub(crate) async fn get_empty_root<H: Hasher, S: Storage + Send + Sync>(
     storage: &S,
     ep: Option<u64>,
 ) -> Result<HistoryTreeNode, HistoryTreeNodeError> {
-    let mut node = HistoryTreeNode::new(NodeLabel::new(0u64, 0u32), 0, 0, NodeType::Root);
+    let mut node = HistoryTreeNode::new(NodeLabel::root(), 0, NodeLabel::root(), NodeType::Root);
     if let Some(epoch) = ep {
         node.epochs.push(epoch);
         let new_state: HistoryNodeState =
@@ -763,7 +766,7 @@ pub(crate) async fn get_leaf_node<H: Hasher, S: Storage + Sync + Send>(
     label: NodeLabel,
     location: u64,
     value: &[u8],
-    parent: u64,
+    parent: NodeLabel,
     birth_epoch: u64,
 ) -> Result<HistoryTreeNode, HistoryTreeNodeError> {
     let node = HistoryTreeNode {
@@ -788,7 +791,7 @@ pub(crate) async fn get_leaf_node_without_hashing<H: Hasher, S: Storage + Sync +
     label: NodeLabel,
     location: u64,
     value: H::Digest,
-    parent: u64,
+    parent: NodeLabel,
     birth_epoch: u64,
 ) -> Result<HistoryTreeNode, HistoryTreeNodeError> {
     let node = HistoryTreeNode {

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -33,8 +33,13 @@ pub struct NodeLabel {
 }
 
 impl NodeLabel {
+    /// Creates a new NodeLabel representing the root.
+    pub const fn root() -> Self {
+        Self::new(0, 0)
+    }
+
     /// Creates a new NodeLabel with the given value and len.
-    pub fn new(val: u64, len: u32) -> Self {
+    pub const fn new(val: u64, len: u32) -> Self {
         NodeLabel { val, len }
     }
 
@@ -71,7 +76,7 @@ impl NodeLabel {
             return *self;
         }
         if len == 0 {
-            return Self::new(0, 0);
+            return Self::root();
         }
         Self::new(self.val >> (self.len - len), len)
     }
@@ -215,7 +220,7 @@ impl Storable for HistoryNodeState {
         let val = u64::from_be_bytes(val_bytes);
         let epoch = u64::from_be_bytes(epoch_bytes);
 
-        Ok(NodeStateKey(NodeLabel { len, val }, epoch))
+        Ok(NodeStateKey(NodeLabel::new(val, len), epoch))
     }
 }
 

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -126,7 +126,6 @@ pub trait Storage: Clone {
 
     /*
     pub label: NodeLabel,
-    pub location: u64,
     pub epochs: Vec<u64>,
     pub parent: NodeLabel,
     // Just use usize and have the 0th position be empty and that can be the parent of root. This makes things simpler.
@@ -140,7 +139,6 @@ pub trait Storage: Clone {
     fn build_history_tree_node(
         label_val: u64,
         label_len: u32,
-        location: u64,
         epochs: Vec<u64>,
         parent_label_val: u64,
         parent_label_len: u32,
@@ -148,7 +146,6 @@ pub trait Storage: Clone {
     ) -> HistoryTreeNode {
         HistoryTreeNode {
             label: NodeLabel::new(label_val, label_len),
-            location,
             epochs,
             parent: NodeLabel::new(parent_label_val, parent_label_len),
             node_type: NodeType::from_u8(node_type),

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -7,8 +7,11 @@
 
 //! Storage module for a auditable key directory
 
+use crate::append_only_zks::Azks;
 use crate::errors::StorageError;
-use crate::storage::types::{DbRecord, StorageType};
+use crate::history_tree_node::{HistoryTreeNode, NodeType};
+use crate::node_state::{HistoryChildState, HistoryNodeState, NodeLabel, NodeStateKey};
+use crate::storage::types::{AkdKey, DbRecord, StorageType, ValueState, Values};
 use crate::ARITY;
 
 use async_trait::async_trait;
@@ -114,8 +117,8 @@ pub trait Storage: Clone {
     _h: PhantomData<H>,
     */
     /// Build an azks instance from the properties
-    fn build_azks(latest_epoch: u64, num_nodes: u64) -> crate::append_only_zks::Azks {
-        crate::append_only_zks::Azks {
+    fn build_azks(latest_epoch: u64, num_nodes: u64) -> Azks {
+        Azks {
             latest_epoch,
             num_nodes,
         }
@@ -125,7 +128,7 @@ pub trait Storage: Clone {
     pub label: NodeLabel,
     pub location: u64,
     pub epochs: Vec<u64>,
-    pub parent: u64,
+    pub parent: NodeLabel,
     // Just use usize and have the 0th position be empty and that can be the parent of root. This makes things simpler.
     pub node_type: NodeType,
     // Note that the NodeType along with the parent/children being options
@@ -139,18 +142,16 @@ pub trait Storage: Clone {
         label_len: u32,
         location: u64,
         epochs: Vec<u64>,
-        parent: u64,
+        parent_label_val: u64,
+        parent_label_len: u32,
         node_type: u8,
-    ) -> crate::history_tree_node::HistoryTreeNode {
-        crate::history_tree_node::HistoryTreeNode {
-            label: crate::node_state::NodeLabel {
-                val: label_val,
-                len: label_len,
-            },
+    ) -> HistoryTreeNode {
+        HistoryTreeNode {
+            label: NodeLabel::new(label_val, label_len),
             location,
             epochs,
-            parent,
-            node_type: crate::history_tree_node::NodeType::from_u8(node_type),
+            parent: NodeLabel::new(parent_label_val, parent_label_len),
+            node_type: NodeType::from_u8(node_type),
         }
     }
 
@@ -163,21 +164,15 @@ pub trait Storage: Clone {
     /// Build a history node state from the properties
     fn build_history_node_state(
         value: Vec<u8>,
-        child_states: [Option<crate::node_state::HistoryChildState>; ARITY],
+        child_states: [Option<HistoryChildState>; ARITY],
         label_len: u32,
         label_val: u64,
         epoch: u64,
-    ) -> crate::node_state::HistoryNodeState {
-        crate::node_state::HistoryNodeState {
+    ) -> HistoryNodeState {
+        HistoryNodeState {
             value,
             child_states,
-            key: crate::node_state::NodeStateKey(
-                crate::node_state::NodeLabel {
-                    val: label_val,
-                    len: label_len,
-                },
-                epoch,
-            ),
+            key: NodeStateKey(NodeLabel::new(label_val, label_len), epoch),
         }
     }
 
@@ -195,16 +190,13 @@ pub trait Storage: Clone {
         label_len: u32,
         label_val: u64,
         epoch: u64,
-    ) -> crate::storage::types::ValueState {
-        crate::storage::types::ValueState {
-            plaintext_val: crate::storage::types::Values(plaintext_val),
+    ) -> ValueState {
+        ValueState {
+            plaintext_val: Values(plaintext_val),
             version,
-            label: crate::node_state::NodeLabel {
-                val: label_val,
-                len: label_len,
-            },
+            label: NodeLabel::new(label_val, label_len),
             epoch,
-            username: crate::storage::types::AkdKey(username),
+            username: AkdKey(username),
         }
     }
 }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -76,17 +76,17 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     // === HistoryTreeNode storage === //
 
     let node = HistoryTreeNode {
-        label: NodeLabel { val: 13, len: 1 },
+        label: NodeLabel::new(13, 4),
         location: 234,
         epochs: vec![123u64, 234u64, 345u64],
-        parent: 1,
+        parent: NodeLabel::new(1, 1),
         node_type: NodeType::Leaf,
     };
     let mut node2 = node.clone();
-    node2.location = 123;
+    node2.label = NodeLabel::new(16, 4);
 
-    let key = NodeKey(234);
-    let key2 = NodeKey(123);
+    let key = NodeKey(NodeLabel::new(13, 4));
+    let key2 = NodeKey(NodeLabel::new(16, 4));
 
     let set_result = storage.set(DbRecord::HistoryTreeNode(node.clone())).await;
     assert_eq!(Ok(()), set_result);
@@ -97,7 +97,6 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     let get_result = storage.get::<HistoryTreeNode>(key).await;
     if let Ok(DbRecord::HistoryTreeNode(got_node)) = get_result {
         assert_eq!(got_node.label, node.label);
-        assert_eq!(got_node.location, node.location);
         assert_eq!(got_node.parent, node.parent);
         assert_eq!(got_node.node_type, node.node_type);
         assert_eq!(got_node.epochs, node.epochs);
@@ -111,7 +110,7 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     }
 
     // === HistoryNodeState storage === //
-    let key = NodeStateKey(NodeLabel { len: 1, val: 1 }, 1);
+    let key = NodeStateKey(NodeLabel::new(1, 1), 1);
     let node_state = HistoryNodeState {
         value: vec![],
         child_states: [None, None],
@@ -136,7 +135,7 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     let value = ValueState {
         username: AkdKey("test".to_string()),
         epoch: 1,
-        label: NodeLabel { len: 1, val: 1 },
+        label: NodeLabel::new(1, 1),
         version: 1,
         plaintext_val: Values("abc123".to_string()),
     };
@@ -477,7 +476,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         Ok(ValueState {
             epoch: 123,
             version: 2,
-            label: NodeLabel { val: 1, len: 1 },
+            label: NodeLabel::new(1, 1),
             plaintext_val: Values(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
@@ -492,7 +491,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             ValueState {
                 epoch: 123,
                 version: 2,
-                label: NodeLabel { val: 1, len: 1 },
+                label: NodeLabel::new(1, 1),
                 plaintext_val: Values(rand_value.clone()),
                 username: sample_state.username.clone(),
             },
@@ -523,7 +522,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         Ok(ValueState {
             epoch: 123,
             version: 2,
-            label: NodeLabel { val: 1, len: 1 },
+            label: NodeLabel::new(1, 1),
             plaintext_val: Values(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
@@ -537,7 +536,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         Ok(ValueState {
             epoch: 1,
             version: 1,
-            label: NodeLabel { val: 1, len: 1 },
+            label: NodeLabel::new(1, 1),
             plaintext_val: Values(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
@@ -551,7 +550,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         Ok(ValueState {
             epoch: 456,
             version: 3,
-            label: NodeLabel { val: 1, len: 1 },
+            label: NodeLabel::new(1, 1),
             plaintext_val: Values(rand_value.clone()),
             username: sample_state.username.clone(),
         }),

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -77,7 +77,6 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
 
     let node = HistoryTreeNode {
         label: NodeLabel::new(13, 4),
-        location: 234,
         epochs: vec![123u64, 234u64, 345u64],
         parent: NodeLabel::new(1, 1),
         node_type: NodeType::Leaf,

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -35,7 +35,7 @@ async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeErro
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
     root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()))
         .await?;
@@ -64,9 +64,9 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
-        HistoryChildState::new::<Blake3>(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()),)
@@ -114,9 +114,9 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
-        HistoryChildState::new::<Blake3>(2, NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1))
@@ -134,9 +134,9 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
     ep = 2;
 
     let child_hist_node_3: HistoryChildState =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     let child_hist_node_4: HistoryChildState =
-        HistoryChildState::new::<Blake3>(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_3.clone()),)
@@ -184,9 +184,9 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
     let child_hist_node_1 =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
     let child_hist_node_2: HistoryChildState =
-        HistoryChildState::new::<Blake3>(2, NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()),)
@@ -204,9 +204,9 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
     ep = 2;
 
     let child_hist_node_3: HistoryChildState =
-        HistoryChildState::new::<Blake3>(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
     let child_hist_node_4: HistoryChildState =
-        HistoryChildState::new::<Blake3>(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
+        HistoryChildState::new::<Blake3>(NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_3.clone()),)
             .await
@@ -254,15 +254,13 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(init_ep)).await?;
 
-    for ep in 0u64..3u64 {
+    for ep in 0..3 {
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
-            ep.try_into().unwrap(),
             NodeLabel::new(0b1u64 << ep.clone(), ep.try_into().unwrap()),
             Blake3::hash(&[0u8]),
             2 * ep,
         );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
-            ep.try_into().unwrap(),
             NodeLabel::new(0, ep.clone().try_into().unwrap()),
             Blake3::hash(&[0u8]),
             2 * ep,
@@ -277,7 +275,6 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
     let ep_existing = 0u64;
 
     let child_hist_node_1 = HistoryChildState::new::<Blake3>(
-        0,
         NodeLabel::new(
             0b1u64 << ep_existing.clone(),
             ep_existing.try_into().unwrap(),
@@ -286,7 +283,6 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
         2 * ep_existing,
     );
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
-        0,
         NodeLabel::new(0, ep_existing.clone().try_into().unwrap()),
         Blake3::hash(&[0u8]),
         2 * ep_existing,
@@ -330,7 +326,6 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
     let new_leaf = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b0u64, 1u32),
-        1,
         &[0u8],
         NodeLabel::root(),
         0,
@@ -340,7 +335,6 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
     let leaf_1 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b1u64, 1u32),
-        2,
         &[1u8],
         NodeLabel::root(),
         0,
@@ -388,7 +382,6 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
     let new_leaf = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b00u64, 2u32),
-        1,
         &[0u8],
         NodeLabel::root(),
         1,
@@ -398,7 +391,6 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
     let leaf_1 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b11u64, 2u32),
-        2,
         &[1u8],
         NodeLabel::root(),
         2,
@@ -408,7 +400,6 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
     let leaf_2 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b10u64, 2u32),
-        3,
         &[1u8, 1u8],
         NodeLabel::root(),
         3,
@@ -476,7 +467,6 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
     let new_leaf = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b000u64, 3u32),
-        1,
         &[0u8],
         NodeLabel::root(),
         0,
@@ -486,7 +476,6 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
     let leaf_1 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b111u64, 3u32),
-        2,
         &[1u8],
         NodeLabel::root(),
         0,
@@ -496,7 +485,6 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
     let leaf_2 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b100u64, 3u32),
-        3,
         &[1u8, 1u8],
         NodeLabel::root(),
         0,
@@ -506,7 +494,6 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
     let leaf_3 = get_leaf_node::<Blake3, _>(
         &db,
         NodeLabel::new(0b010u64, 3u32),
-        4,
         &[0u8, 1u8],
         NodeLabel::root(),
         0,
@@ -591,7 +578,6 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError>
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(i.clone(), 3u32),
-            leaves.len() as u64,
             &i.to_ne_bytes(),
             NodeLabel::root(),
             7 - i,

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -327,11 +327,25 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
 async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
-    let new_leaf =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b0u64, 1u32), 1, &[0u8], 0, 0).await?;
+    let new_leaf = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b0u64, 1u32),
+        1,
+        &[0u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
 
-    let leaf_1 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b1u64, 1u32), 2, &[1u8], 0, 0).await?;
+    let leaf_1 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b1u64, 1u32),
+        2,
+        &[1u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
     root.write_to_storage(&db).await?;
 
     let mut num_nodes = 1;
@@ -371,15 +385,35 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
 async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
-    let new_leaf =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b00u64, 2u32), 1, &[0u8], 0, 1).await?;
+    let new_leaf = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b00u64, 2u32),
+        1,
+        &[0u8],
+        NodeLabel::root(),
+        1,
+    )
+    .await?;
 
-    let leaf_1 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b11u64, 2u32), 2, &[1u8], 0, 2).await?;
+    let leaf_1 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b11u64, 2u32),
+        2,
+        &[1u8],
+        NodeLabel::root(),
+        2,
+    )
+    .await?;
 
-    let leaf_2 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b10u64, 2u32), 3, &[1u8, 1u8], 0, 3)
-            .await?;
+    let leaf_2 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b10u64, 2u32),
+        3,
+        &[1u8, 1u8],
+        NodeLabel::root(),
+        3,
+    )
+    .await?;
 
     let leaf_0_hash = Blake3::merge(&[
         Blake3::merge(&[Blake3::hash(&[]), Blake3::hash(&[0b0u8])]),
@@ -439,19 +473,45 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
 async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTreeNodeError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
-    let new_leaf =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b000u64, 3u32), 1, &[0u8], 0, 0).await?;
+    let new_leaf = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b000u64, 3u32),
+        1,
+        &[0u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
 
-    let leaf_1 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b111u64, 3u32), 2, &[1u8], 0, 0).await?;
+    let leaf_1 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b111u64, 3u32),
+        2,
+        &[1u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
 
-    let leaf_2 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b100u64, 3u32), 3, &[1u8, 1u8], 0, 0)
-            .await?;
+    let leaf_2 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b100u64, 3u32),
+        3,
+        &[1u8, 1u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
 
-    let leaf_3 =
-        get_leaf_node::<Blake3, _>(&db, NodeLabel::new(0b010u64, 3u32), 4, &[0u8, 1u8], 0, 0)
-            .await?;
+    let leaf_3 = get_leaf_node::<Blake3, _>(
+        &db,
+        NodeLabel::new(0b010u64, 3u32),
+        4,
+        &[0u8, 1u8],
+        NodeLabel::root(),
+        0,
+    )
+    .await?;
 
     let leaf_0_hash = Blake3::merge(&[
         Blake3::merge(&[Blake3::hash(&[]), Blake3::hash(&[0b0u8])]),
@@ -533,7 +593,7 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError>
             NodeLabel::new(i.clone(), 3u32),
             leaves.len() as u64,
             &i.to_ne_bytes(),
-            0,
+            NodeLabel::root(),
             7 - i,
         )
         .await?;

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -7,7 +7,7 @@
 
 // 1. Create a hashmap of all prefixes of all elements of the insertion set
 // 2. For each node in current_nodes set, check if each child is in prefix hashmap
-// 3. If so, add child loc to batch set
+// 3. If so, add child label to batch set
 
 use crate::node_state::NodeLabel;
 use std::collections::HashSet;


### PR DESCRIPTION
We currently identify a `HistoryTreeNode` with its `location` attribute, a unique unsigned integer assigned once at its birth. However, a node's `label` is also unique and remains unchanged once created, and is the source of truth when it comes to identifying a node.

This PR removes the `location` field and uses `label` as the identifier of a node. Consequently, `parent` pointers in `HistoryNodeState` have been updated to use labels as well.

## Benchmarks
Execution times remain in the same range. Each benchmark was run 3 times, with the database flushed between runs.

### Publishing
```console
evanau@evanau-mbp akd % cargo run -- bench-publish 1000 10
```

**Execution Time (ms)**
||On bf80938 | This PR|
|---|---|---|
|Run 1|76950| 77457|
|Run 2|77404| 77779|
|Run 3|77287| 80436|
|Average|77213| 78557|


### Lookup
The lookup benchmark from #110 was cherry-picked to run this test.

```console
evanau@evanau-mbp poc % cargo run -- bench-lookup 1000 10
```

**Execution Time (ms)**
||On bf80938 | This PR|
|---|---|---|
|Run 1| 66930| 63996|
|Run 2| 65538| 63699|
|Run 3| 70868| 60915|
|Average| 67778| 62870|

<!--

On bf80938:
```console
evanau@evanau-mbp poc % cargo run -- bench-publish 1000 10
...
Benchmark output: Inserted 1000 users with 10 updates/user
Execution time: 80840 ms
Time-per-user (avg): 80840 µs
Time-per-op (avg): 8084 µs
```
This PR:
```console
evanau@evanau-mbp poc % cargo run -- bench-publish 1000 10
...
Benchmark output: Inserted 1000 users with 10 updates/user
Execution time: 84197 ms
Time-per-user (avg): 84197 µs
Time-per-op (avg): 8419 µs
```

### Lookup
The lookup benchmark from #110 was cherry-picked to run this test.


On bf80938:
```console
evanau@evanau-mbp poc % cargo run -- bench-lookup 1000 10 
...
Benchmark output: Looked up and verified 1000 users with 10 lookups/user
Execution time: 79594 ms
Time-per-user (avg): 79594 µs
Time-per-op (avg): 7959 µs
```

This PR:
```console
evanau@evanau-mbp poc % cargo run -- bench-lookup 1000 10
...
Benchmark output: Looked up and verified 1000 users with 10 lookups/user
Execution time: 68825 ms
Time-per-user (avg): 68825 µs
Time-per-op (avg): 6882 µs
``` 
-->