### PR TITLE
Storage contract changes require 2x publishes

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.28.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.3.4" }
+akd = { path = "../akd", version = "^0.3.6" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Due to the change in the storage contract, there are delays in the time between publishing ```akd``` to crates.io and the new version being available to ```cargo``` to build ```akd_mysql```. Therefore we need to publish ```akd``` with the update, ```akd_mysql``` will fail, and we version bump both and publish again. The 2nd time crates.io has updated and the index is updated, ```akd_mysql``` can build.

See PRs tagged with ```publish_race``` to identify instances where this is needed.