### PR TITLE
Add (and run) the script that waits for akd to be published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
     - name: Run the script that waits for AKD to be published
-      run: ./.github/workflows/wait-for-akd-publish.sh
+      run: bash ./.github/workflows/wait-for-akd-publish.sh
     - name: Dry run publish AKD_MYSQL
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish crate akd_mysql

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
       run: cargo publish --manifest-path Cargo.toml -p akd
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Run the script that waits for AKD to be published
+      run: ./.github/workflows/wait-for-akd-publish.sh
     - name: Dry run publish AKD_MYSQL
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish crate akd_mysql

--- a/.github/workflows/wait-for-akd-publish.sh
+++ b/.github/workflows/wait-for-akd-publish.sh
@@ -1,0 +1,45 @@
+# Finds expected version of a crate in another crate's Cargo.toml file
+get_crate_expected_version_number()
+{
+    local crate_name=$1
+    local crate_to_look_for_version=$2
+
+    local cargo_toml_file="$crate_name/Cargo.toml"
+    local expected_version=$(grep "$crate_to_look_for_version = " $cargo_toml_file | tr -d '{^}' | awk -F '[,:=]' '{print $5}')
+    echo $expected_version
+}
+
+# Get published versions of a crate from https://github.com/rust-lang/crates.io-index/
+get_crate_published_versions()
+{
+    local crate_index_url=$1
+
+    local published_versions=$(
+        curl -sS "$crate_index_url" | jq .vers
+    )
+    echo "$published_versions"
+}
+
+# Wait for a specific akd version to be published to crates.io.
+# See https://github.com/novifinancial/akd/issues/116.
+# Must be run in the project root folder.
+akd_version_expected=$(get_crate_expected_version_number "akd_mysql" "akd")
+echo "AKD expected version in AKD_MYSQL:" $akd_version_expected
+wait_time=1
+while sleep $wait_time;
+do
+    akd_versions_published=$(
+        get_crate_published_versions "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/3/a/akd"
+    )
+    echo "AKD published versions:" $akd_versions_published
+    # Check whether published versions contain the expected version
+    if [[ $akd_versions_published == *"$akd_version_expected"* ]]; then
+        echo "Expected version has been published."
+        break
+    fi
+    echo "Expected version has not been published. Retrying after a wait."
+    wait_time=$((wait_time+1))
+    if [[ $wait_time == 42 ]]; then
+        break
+    fi
+done

--- a/.github/workflows/wait-for-akd-publish.sh
+++ b/.github/workflows/wait-for-akd-publish.sh
@@ -40,6 +40,7 @@ do
     echo "Expected version has not been published. Retrying after a wait."
     wait_time=$((wait_time+1))
     if [[ $wait_time == 42 ]]; then
+	echo "Gave up."
         break
     fi
 done

--- a/.github/workflows/wait-for-akd-publish.sh
+++ b/.github/workflows/wait-for-akd-publish.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Finds expected version of a crate in another crate's Cargo.toml file
 get_crate_expected_version_number()
 {


### PR DESCRIPTION
- The script first finds the expected version of AKD in the AKD_MYSQL's Cargo.toml file and queries the published crates index to see whether the expected version has been published.
- If not, the script waits with an increasing wait time for each retry.
- After the expected version is published, the publish process continues.