### PR TITLE
Proof structs prefer vec of structs instead of paired vectors

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -91,16 +91,15 @@ impl Azks {
     pub async fn insert_leaf<S: Storage + Sync + Send, H: Hasher>(
         &mut self,
         storage: &S,
-        label: NodeLabel,
-        value: H::Digest,
+        node: Node<H>,
     ) -> Result<(), AkdError> {
         // Calls insert_single_leaf on the root node and updates the root and tree_nodes
         self.increment_epoch();
 
         let new_leaf = get_leaf_node::<H, S>(
             storage,
-            label,
-            value.as_bytes().as_ref(),
+            node.label,
+            node.hash.as_bytes().as_ref(),
             NodeLabel::root(),
             self.latest_epoch,
         )
@@ -119,7 +118,7 @@ impl Azks {
     pub async fn batch_insert_leaves<S: Storage + Sync + Send, H: Hasher>(
         &mut self,
         storage: &S,
-        insertion_set: Vec<(NodeLabel, H::Digest)>,
+        insertion_set: Vec<Node<H>>,
     ) -> Result<(), AkdError> {
         self.batch_insert_leaves_helper::<_, H>(storage, insertion_set, false)
             .await
@@ -128,7 +127,7 @@ impl Azks {
     async fn preload_nodes_for_insertion<S: Storage + Sync + Send, H: Hasher>(
         &self,
         storage: &S,
-        insertion_set: &[(NodeLabel, H::Digest)],
+        insertion_set: &[Node<H>],
     ) -> Result<u64, AkdError> {
         let mut load_count: u64 = 0;
         let mut current_nodes = vec![NodeKey(NodeLabel::root())];
@@ -136,7 +135,7 @@ impl Azks {
         let prefixes_set = crate::utils::build_prefixes_set(
             insertion_set
                 .iter()
-                .map(|(x, _)| *x)
+                .map(|n| n.label)
                 .collect::<Vec<NodeLabel>>()
                 .as_ref(),
         );
@@ -188,7 +187,7 @@ impl Azks {
     pub async fn batch_insert_leaves_helper<S: Storage + Sync + Send, H: Hasher>(
         &mut self,
         storage: &S,
-        insertion_set: Vec<(NodeLabel, H::Digest)>,
+        insertion_set: Vec<Node<H>>,
         append_only_usage: bool,
     ) -> Result<(), AkdError> {
         let tic = Instant::now();
@@ -209,12 +208,11 @@ impl Azks {
         let mut priorities: i32 = 0;
         let mut root_node =
             HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
-        for (label, value) in insertion_set {
+        for node in insertion_set {
             let new_leaf = if append_only_usage {
                 get_leaf_node_without_hashing::<H, S>(
                     storage,
-                    label,
-                    value,
+                    node,
                     NodeLabel::root(),
                     self.latest_epoch,
                 )
@@ -222,8 +220,8 @@ impl Azks {
             } else {
                 get_leaf_node::<H, S>(
                     storage,
-                    label,
-                    value.as_bytes().as_ref(),
+                    node.label,
+                    node.hash.as_bytes().as_ref(),
                     NodeLabel::root(),
                     self.latest_epoch,
                 )
@@ -236,7 +234,7 @@ impl Azks {
                 .await?;
             debug!("END insert leaf");
 
-            hash_q.push(label, priorities);
+            hash_q.push(node.label, priorities);
             priorities -= 1;
         }
 
@@ -293,8 +291,11 @@ impl Azks {
         let lcp_node: HistoryTreeNode =
             HistoryTreeNode::get_from_storage(storage, NodeKey(lcp_node_label)).await?;
         let longest_prefix = lcp_node.label;
-        let mut longest_prefix_children_labels = [NodeLabel::root(); ARITY];
-        let mut longest_prefix_children_values = [crate::utils::empty_node_hash::<H>(); ARITY];
+        // load with placeholder nodes, to be replaced in the loop below
+        let mut longest_prefix_children = [Node {
+            label: NodeLabel::root(),
+            hash: crate::utils::empty_node_hash::<H>(),
+        }; ARITY];
         let state = lcp_node.get_state_at_epoch(storage, epoch).await?;
 
         for (i, child) in state.child_states.iter().enumerate() {
@@ -305,18 +306,19 @@ impl Azks {
                 Some(child) => {
                     let unwrapped_child: HistoryTreeNode =
                         HistoryTreeNode::get_from_storage(storage, NodeKey(child.label)).await?;
-                    longest_prefix_children_labels[i] = unwrapped_child.label;
-                    longest_prefix_children_values[i] = unwrapped_child
-                        .get_value_without_label_at_epoch::<_, H>(storage, epoch)
-                        .await?;
+                    longest_prefix_children[i] = Node {
+                        label: unwrapped_child.label,
+                        hash: unwrapped_child
+                            .get_value_without_label_at_epoch::<_, H>(storage, epoch)
+                            .await?,
+                    };
                 }
             }
         }
         Ok(NonMembershipProof {
             label,
             longest_prefix,
-            longest_prefix_children_labels,
-            longest_prefix_children_values,
+            longest_prefix_children,
             longest_prefix_membership_proof,
         })
     }
@@ -356,20 +358,21 @@ impl Azks {
         node: HistoryTreeNode,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Result<AppendOnlyHelper<H::Digest>, AkdError> {
-        let mut unchanged = Vec::<(NodeLabel, H::Digest)>::new();
-        let mut leaves = Vec::<(NodeLabel, H::Digest)>::new();
+    ) -> Result<AppendOnlyHelper<H>, AkdError> {
+        let mut unchanged = Vec::<Node<H>>::new();
+        let mut leaves = Vec::<Node<H>>::new();
         if node.get_latest_epoch()? <= start_epoch {
             if node.is_root() {
                 // this is the case where the root is unchanged since the last epoch
                 return Ok((unchanged, leaves));
             }
 
-            unchanged.push((
-                node.label,
-                node.get_value_without_label_at_epoch::<_, H>(storage, node.get_latest_epoch()?)
+            unchanged.push(Node::<H> {
+                label: node.label,
+                hash: node
+                    .get_value_without_label_at_epoch::<_, H>(storage, node.get_latest_epoch()?)
                     .await?,
-            ));
+            });
             return Ok((unchanged, leaves));
         }
         if node.get_birth_epoch() > end_epoch {
@@ -377,11 +380,12 @@ impl Azks {
             return Ok((unchanged, leaves));
         }
         if node.is_leaf() {
-            leaves.push((
-                node.label,
-                node.get_value_without_label_at_epoch::<_, H>(storage, node.get_latest_epoch()?)
+            leaves.push(Node::<H> {
+                label: node.label,
+                hash: node
+                    .get_value_without_label_at_epoch::<_, H>(storage, node.get_latest_epoch()?)
                     .await?,
-            ));
+            });
         } else {
             for child_node_state in node
                 .get_state_at_epoch(storage, end_epoch)
@@ -461,8 +465,7 @@ impl Azks {
         epoch: u64,
     ) -> Result<(MembershipProof<H>, NodeLabel), AkdError> {
         let mut parent_labels = Vec::<NodeLabel>::new();
-        let mut sibling_labels = Vec::<[NodeLabel; ARITY - 1]>::new();
-        let mut sibling_hashes = Vec::<[H::Digest; ARITY - 1]>::new();
+        let mut siblings = Vec::<[Node<H>; ARITY - 1]>::new();
         let mut dirs = Vec::<Direction>::new();
         let mut curr_node: HistoryTreeNode =
             HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
@@ -474,8 +477,10 @@ impl Azks {
             parent_labels.push(curr_node.label);
             prev_node = curr_node.label;
             let curr_state = curr_node.get_state_at_epoch(storage, epoch).await?;
-            let mut labels = [NodeLabel::root(); ARITY - 1];
-            let mut hashes = [H::hash(&[0u8]); ARITY - 1];
+            let mut nodes = [Node::<H> {
+                label: NodeLabel::root(),
+                hash: H::hash(&[0u8]),
+            }; ARITY - 1];
             let mut count = 0;
             let direction = dir.ok_or_else(|| {
                 AkdError::HistoryTreeNode(HistoryTreeNodeError::NoDirection(
@@ -492,17 +497,17 @@ impl Azks {
                     HistoryTreeNodeError::NoDirection(curr_node.label.get_val(), None),
                 );
                 if i != dir.ok_or(no_direction_error)? {
-                    labels[count] =
-                        optional_history_child_state_to_label(&curr_state.child_states[i]);
-                    hashes[count] = to_digest::<H>(&optional_history_child_state_to_hash::<H>(
-                        &curr_state.child_states[i],
-                    ))
-                    .unwrap();
+                    nodes[count] = Node::<H> {
+                        label: optional_history_child_state_to_label(&curr_state.child_states[i]),
+                        hash: to_digest::<H>(&optional_history_child_state_to_hash::<H>(
+                            &curr_state.child_states[i],
+                        ))
+                        .unwrap(),
+                    };
                     count += 1;
                 }
             }
-            sibling_labels.push(labels);
-            sibling_hashes.push(hashes);
+            siblings.push(nodes);
             let new_curr_node: HistoryTreeNode = HistoryTreeNode::get_from_storage(
                 storage,
                 NodeKey(
@@ -522,8 +527,7 @@ impl Azks {
             curr_node = new_curr_node;
 
             parent_labels.pop();
-            sibling_labels.pop();
-            sibling_hashes.pop();
+            siblings.pop();
             dirs.pop();
         }
 
@@ -536,8 +540,7 @@ impl Azks {
                 label: curr_node.label,
                 hash_val,
                 parent_labels,
-                sibling_labels,
-                sibling_hashes,
+                siblings,
                 dirs,
             },
             prev_node,
@@ -545,7 +548,7 @@ impl Azks {
     }
 }
 
-type AppendOnlyHelper<D> = (Vec<(NodeLabel, D)>, Vec<(NodeLabel, D)>);
+type AppendOnlyHelper<H> = (Vec<Node<H>>, Vec<Node<H>>);
 
 #[cfg(test)]
 mod tests {
@@ -569,15 +572,16 @@ mod tests {
         let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
 
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let val = Blake3::hash(&input);
-            insertion_set.push((node, val));
-            azks1.insert_leaf::<_, Blake3>(&db, node, val).await?;
+            let hash = Blake3::hash(&input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set.push(node);
+            azks1.insert_leaf::<_, Blake3>(&db, node).await?;
         }
 
         let db2 = AsyncInMemoryDatabase::new();
@@ -602,15 +606,16 @@ mod tests {
         let mut rng = OsRng;
         let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set.push((node, input));
-            azks1.insert_leaf::<_, Blake3>(&db, node, input).await?;
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set.push(node);
+            azks1.insert_leaf::<_, Blake3>(&db, node).await?;
         }
 
         // Try randomly permuting
@@ -637,14 +642,15 @@ mod tests {
         let num_nodes = 10;
         let mut rng = OsRng;
 
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set.push(node);
         }
 
         // Try randomly permuting
@@ -655,7 +661,7 @@ mod tests {
             .await?;
 
         let proof = azks
-            .get_membership_proof(&db, insertion_set[0].0, 1)
+            .get_membership_proof(&db, insertion_set[0].label, 1)
             .await?;
 
         verify_membership::<Blake3>(azks.get_root_hash::<_, Blake3>(&db).await?, &proof)?;
@@ -668,14 +674,15 @@ mod tests {
         let num_nodes = 10;
         let mut rng = OsRng;
 
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set.push(node);
         }
 
         // Try randomly permuting
@@ -686,14 +693,13 @@ mod tests {
             .await?;
 
         let mut proof = azks
-            .get_membership_proof(&db, insertion_set[0].0, 1)
+            .get_membership_proof(&db, insertion_set[0].label, 1)
             .await?;
         let hash_val = Blake3::hash(&[0u8]);
         proof = MembershipProof::<Blake3> {
             label: proof.label,
             hash_val,
-            sibling_hashes: proof.sibling_hashes,
-            sibling_labels: proof.sibling_labels,
+            siblings: proof.siblings,
             parent_labels: proof.parent_labels,
             dirs: proof.dirs,
         };
@@ -709,12 +715,27 @@ mod tests {
     #[tokio::test]
     async fn test_membership_proof_intermediate() -> Result<(), AkdError> {
         let db = AsyncInMemoryDatabase::new();
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
-        insertion_set.push((NodeLabel::new(0b0, 64), Blake3::hash(&[])));
-        insertion_set.push((NodeLabel::new(0b1 << 63, 64), Blake3::hash(&[])));
-        insertion_set.push((NodeLabel::new(0b11 << 62, 64), Blake3::hash(&[])));
-        insertion_set.push((NodeLabel::new(0b01 << 62, 64), Blake3::hash(&[])));
-        insertion_set.push((NodeLabel::new(0b111 << 61, 64), Blake3::hash(&[])));
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
+        insertion_set.push(Node::<Blake3> {
+            label: NodeLabel::new(0b0, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set.push(Node::<Blake3> {
+            label: NodeLabel::new(0b1 << 63, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set.push(Node::<Blake3> {
+            label: NodeLabel::new(0b11 << 62, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set.push(Node::<Blake3> {
+            label: NodeLabel::new(0b01 << 62, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set.push(Node::<Blake3> {
+            label: NodeLabel::new(0b111 << 61, 64),
+            hash: Blake3::hash(&[]),
+        });
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set)
             .await?;
@@ -732,18 +753,19 @@ mod tests {
         let num_nodes = 10;
         let mut rng = OsRng;
 
-        let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set.push(node);
         }
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
-        let search_label = insertion_set[num_nodes - 1].0;
+        let search_label = insertion_set[num_nodes - 1].label;
         azks.batch_insert_leaves::<_, Blake3>(
             &db,
             insertion_set.clone()[0..num_nodes - 1].to_vec(),
@@ -764,14 +786,20 @@ mod tests {
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
-        let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
-        insertion_set_1.push((NodeLabel::new(0b0, 64), Blake3::hash(&[])));
+        let mut insertion_set_1: Vec<Node<Blake3>> = vec![];
+        insertion_set_1.push(Node::<Blake3> {
+            label: NodeLabel::new(0b0, 64),
+            hash: Blake3::hash(&[]),
+        });
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_1)
             .await?;
         let start_hash = azks.get_root_hash::<_, Blake3>(&db).await?;
 
-        let mut insertion_set_2: Vec<(NodeLabel, Blake3Digest)> = vec![];
-        insertion_set_2.push((NodeLabel::new(0b01 << 62, 64), Blake3::hash(&[])));
+        let mut insertion_set_2: Vec<Node<Blake3>> = vec![];
+        insertion_set_2.push(Node::<Blake3> {
+            label: NodeLabel::new(0b01 << 62, 64),
+            hash: Blake3::hash(&[]),
+        });
 
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_2)
             .await?;
@@ -788,16 +816,28 @@ mod tests {
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
-        let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
-        insertion_set_1.push((NodeLabel::new(0b0, 64), Blake3::hash(&[])));
-        insertion_set_1.push((NodeLabel::new(0b1 << 63, 64), Blake3::hash(&[])));
+        let mut insertion_set_1: Vec<Node<Blake3>> = vec![];
+        insertion_set_1.push(Node::<Blake3> {
+            label: NodeLabel::new(0b0, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set_1.push(Node::<Blake3> {
+            label: NodeLabel::new(0b1 << 63, 64),
+            hash: Blake3::hash(&[]),
+        });
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_1)
             .await?;
         let start_hash = azks.get_root_hash::<_, Blake3>(&db).await?;
 
-        let mut insertion_set_2: Vec<(NodeLabel, Blake3Digest)> = vec![];
-        insertion_set_2.push((NodeLabel::new(0b01 << 62, 64), Blake3::hash(&[])));
-        insertion_set_2.push((NodeLabel::new(0b111 << 61, 64), Blake3::hash(&[])));
+        let mut insertion_set_2: Vec<Node<Blake3>> = vec![];
+        insertion_set_2.push(Node::<Blake3> {
+            label: NodeLabel::new(0b01 << 62, 64),
+            hash: Blake3::hash(&[]),
+        });
+        insertion_set_2.push(Node::<Blake3> {
+            label: NodeLabel::new(0b111 << 61, 64),
+            hash: Blake3::hash(&[]),
+        });
 
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_2)
             .await?;
@@ -814,14 +854,15 @@ mod tests {
         let num_nodes = 10;
         let mut rng = OsRng;
 
-        let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set_1: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set_1.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set_1.push(node);
         }
 
         let db = AsyncInMemoryDatabase::new();
@@ -831,27 +872,29 @@ mod tests {
 
         let start_hash = azks.get_root_hash::<_, Blake3>(&db).await?;
 
-        let mut insertion_set_2: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set_2: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set_2.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set_2.push(node);
         }
 
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_2.clone())
             .await?;
 
-        let mut insertion_set_3: Vec<(NodeLabel, Blake3Digest)> = vec![];
+        let mut insertion_set_3: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {
-            let node = NodeLabel::random(&mut rng);
+            let label = NodeLabel::random(&mut rng);
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let input = Blake3Digest::new(input);
-            insertion_set_3.push((node, input));
+            let hash = Blake3Digest::new(input);
+            let node = Node::<Blake3> { label, hash };
+            insertion_set_3.push(node);
         }
 
         azks.batch_insert_leaves::<_, Blake3>(&db, insertion_set_3.clone())

--- a/akd/src/history_tree_node.rs
+++ b/akd/src/history_tree_node.rs
@@ -813,13 +813,12 @@ pub(crate) async fn get_leaf_node<H: Hasher, S: Storage + Sync + Send>(
 
 pub(crate) async fn get_leaf_node_without_hashing<H: Hasher, S: Storage + Sync + Send>(
     storage: &S,
-    label: NodeLabel,
-    value: H::Digest,
+    node: Node<H>,
     parent: NodeLabel,
     birth_epoch: u64,
 ) -> Result<HistoryTreeNode, HistoryTreeNodeError> {
-    let node = HistoryTreeNode {
-        label,
+    let history_node = HistoryTreeNode {
+        label: node.label,
         birth_epoch,
         last_epoch: birth_epoch,
         parent,
@@ -827,12 +826,12 @@ pub(crate) async fn get_leaf_node_without_hashing<H: Hasher, S: Storage + Sync +
     };
 
     let mut new_state: HistoryNodeState =
-        HistoryNodeState::new::<H>(NodeStateKey(node.label, birth_epoch));
-    new_state.value = from_digest::<H>(value)?;
+        HistoryNodeState::new::<H>(NodeStateKey(history_node.label, birth_epoch));
+    new_state.value = from_digest::<H>(node.hash)?;
 
     set_state_map(storage, new_state).await?;
 
-    Ok(node)
+    Ok(history_node)
 }
 
 pub(crate) async fn set_state_map<S: Storage + Sync + Send>(

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -20,6 +20,28 @@ use winter_crypto::Hasher;
 
 use rand::{CryptoRng, RngCore};
 
+/// Represents a node's label & associated hash
+#[derive(Debug)]
+pub struct Node<H: Hasher> {
+    /// the label associated with the accompanying hash
+    pub label: NodeLabel,
+    /// the hash associated to this label
+    pub hash: H::Digest,
+}
+
+// can't use #derive because it doesn't bind correctly
+// #derive and generics are not friendly; might make Debug weird too ...
+// see also:
+// https://users.rust-lang.org/t/why-does-deriving-clone-not-work-in-this-case-but-implementing-manually-does/29075
+// https://github.com/rust-lang/rust/issues/26925
+impl<H: Hasher> Copy for Node<H> {}
+
+impl<H: Hasher> Clone for Node<H> {
+    fn clone(&self) -> Node<H> {
+        *self
+    }
+}
+
 /// The NodeLabel struct represents the label for a HistoryTreeNode.
 /// Since the label itself may have any number of zeros pre-pended,
 /// just using a native type, unless it is a bit-vector, wouldn't work.

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -10,7 +10,7 @@
 
 use winter_crypto::Hasher;
 
-use crate::{node_state::NodeLabel, storage::types::Values, Direction, ARITY};
+use crate::{node_state::Node, node_state::NodeLabel, storage::types::Values, Direction, ARITY};
 
 /// Merkle proof of membership of a [`NodeLabel`] with a particular hash value
 /// in the tree at a given epoch.
@@ -22,10 +22,9 @@ pub struct MembershipProof<H: Hasher> {
     pub hash_val: H::Digest,
     /// The parent node labels
     pub parent_labels: Vec<NodeLabel>,
-    /// The sibling labels
-    pub sibling_labels: Vec<[NodeLabel; ARITY - 1]>,
+    /// The sibling label/digest tuples
+    pub siblings: Vec<[Node<H>; ARITY - 1]>,
     /// The node sibling hashes
-    pub sibling_hashes: Vec<[H::Digest; ARITY - 1]>,
     /// The directions
     pub dirs: Vec<Direction>,
 }
@@ -39,9 +38,7 @@ pub struct NonMembershipProof<H: Hasher> {
     /// The longest prefix in the tree
     pub longest_prefix: NodeLabel,
     /// The children of the longest prefix
-    pub longest_prefix_children_labels: [NodeLabel; ARITY],
-    /// The values of the longest prefix children
-    pub longest_prefix_children_values: [H::Digest; ARITY],
+    pub longest_prefix_children: [Node<H>; ARITY],
     /// The membership proof of the longest prefix
     pub longest_prefix_membership_proof: MembershipProof<H>,
 }
@@ -54,9 +51,9 @@ pub struct NonMembershipProof<H: Hasher> {
 #[derive(Debug, Clone)]
 pub struct AppendOnlyProof<H: Hasher> {
     /// The inserted nodes & digests
-    pub inserted: Vec<(NodeLabel, H::Digest)>,
+    pub inserted: Vec<Node<H>>,
     /// The unchanged nodes & digests
-    pub unchanged_nodes: Vec<(NodeLabel, H::Digest)>,
+    pub unchanged_nodes: Vec<Node<H>>,
 }
 
 /// Proof that a given label was at a particular state at the given epoch.


### PR DESCRIPTION
Previously, `MembershipProof` and `NonMembershipProof` held two vectors of equal lengths, one holding `NodeLabel` and one holding `Digest`. This change introduces a `Node` struct that pairs these together, allowing the proofs to hold a single vector of these pairs.

The `AppendOnlyProof` was holding a single vector of tuples and has likewise been converted to prefer the Node struct.

In general, all `NodeLabel`+`Digest` pairings are now using the `Node` struct. The only one remaining is `HistoryChildState::new` which appears only to be used in tests. As such, I've let it be for now, just to keep this work internally contained to the proofs.

Re: https://github.com/novifinancial/akd/issues/118

*Testing*

```
cargo test
```

```
cd poc
cargo run
> PUBLISH test test
# and a few other commands
```

```
cargo bench --features bench --no-run
```

*Other*

```
cargo fmt
cargo clippy
```

*Notes*

This is a bit busier than I'd like. I had a version that left a lot of the internal helper messages alone but it appears I squashed those commits together out of habit before putting this up. Well, it is what it is :)

_Updated to add `cargo bench` call, plus `fmt` and `clippy`._