### PR TITLE
Standardize AKD label/value partners.

### DIFF
--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -15,7 +15,7 @@ use crate::{
     errors::{AkdError, AzksError, DirectoryError},
     node_state::{hash_label, NodeLabel},
     proof_structs::{HistoryProof, LookupProof, MembershipProof, NonMembershipProof, UpdateProof},
-    storage::types::AkdKey,
+    storage::types::AkdLabel,
     Direction, ARITY,
 };
 
@@ -94,7 +94,7 @@ pub fn verify_nonmembership<H: Hasher>(
 /// Verifies a lookup with respect to the root_hash
 pub fn lookup_verify<H: Hasher>(
     root_hash: H::Digest,
-    _akd_key: AkdKey,
+    _akd_key: AkdLabel,
     proof: LookupProof<H>,
 ) -> Result<(), AkdError> {
     let _epoch = proof.epoch;
@@ -145,7 +145,7 @@ pub fn lookup_verify<H: Hasher>(
 pub fn key_history_verify<H: Hasher>(
     root_hashes: Vec<H::Digest>,
     previous_root_hashes: Vec<Option<H::Digest>>,
-    uname: AkdKey,
+    uname: AkdLabel,
     proof: HistoryProof<H>,
 ) -> Result<(), AkdError> {
     for (count, update_proof) in proof.proofs.into_iter().enumerate() {
@@ -161,7 +161,7 @@ fn verify_single_update_proof<H: Hasher>(
     root_hash: H::Digest,
     previous_root_hash: Option<H::Digest>,
     proof: UpdateProof<H>,
-    uname: &AkdKey,
+    uname: &AkdLabel,
 ) -> Result<(), AkdError> {
     let epoch = proof.epoch;
     let _plaintext_value = &proof.plaintext_value;

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -33,7 +33,7 @@
 //! use winter_crypto::Hasher;
 //! use winter_crypto::hashers::Blake3_256;
 //! use winter_math::fields::f128::BaseElement;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! type Blake3 = Blake3_256<BaseElement>;
@@ -48,12 +48,12 @@
 //! ## Adding key-value pairs to the akd
 //! To add key-value pairs to the akd, we assume that the types of keys and the corresponding values are String.
 //! After adding key-value pairs to the akd's data structure, it also needs to be committed. To do this, after running the setup, as in the previous step,
-//! we use the `publish` function of an akd. The argument of publish is a vector of tuples of type (AkdKey(String), Values(String)). See below for example usage.
+//! we use the `publish` function of an akd. The argument of publish is a vector of tuples of type (AkdLabel(String), AkdValue(String)). See below for example usage.
 //! ```
 //! use winter_crypto::Hasher;
 //! use winter_crypto::hashers::Blake3_256;
 //! use winter_math::fields::f128::BaseElement;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! type Blake3 = Blake3_256<BaseElement>;
@@ -63,8 +63,8 @@
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // commit the latest changes
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!          (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!          (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!       .await;
 //! };
 //! ```
@@ -80,17 +80,17 @@
 //! use akd::directory::Directory;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //!use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdKey("hello".to_string())).await;
+//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel("hello".to_string())).await;
 //! };
 //! ```
 //! ## Verifying a lookup proof
@@ -103,23 +103,23 @@
 //! use akd::client;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
-//!use akd::storage::memory::AsyncInMemoryDatabase;
+//! use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdKey("hello".to_string())).await.unwrap();
+//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel("hello".to_string())).await.unwrap();
 //!     let current_azks = akd.retrieve_current_azks().await.unwrap();
 //!     // Get the latest commitment, i.e. azks root hash
 //!     let root_hash = akd.get_root_hash::<Blake3_256<BaseElement>>(&current_azks).await.unwrap();
 //!     client::lookup_verify::<Blake3_256<BaseElement>>(
 //!     root_hash,
-//!     AkdKey("hello".to_string()),
+//!     AkdLabel("hello".to_string()),
 //!     lookup_proof,
 //!     ).unwrap();
 //! };
@@ -137,17 +137,17 @@
 //! use akd::directory::Directory;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdKey("hello".to_string())).await;
+//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel("hello".to_string())).await;
 //! };
 //! ```
 //! ## Verifying a key history proof
@@ -160,24 +160,24 @@
 //! use akd::directory::Directory;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdKey("hello".to_string())).await.unwrap();
+//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel("hello".to_string())).await.unwrap();
 //!     let current_azks = akd.retrieve_current_azks().await.unwrap();
 //!     // Get the azks root hashes at the required epochs
 //!     let (root_hashes, previous_root_hashes) = akd::directory::get_key_history_hashes::<_, Blake3_256<BaseElement>>(&akd, &history_proof).await.unwrap();
 //!     key_history_verify::<Blake3_256<BaseElement>>(
 //!     root_hashes,
 //!     previous_root_hashes,
-//!     AkdKey("hello".to_string()),
+//!     AkdLabel("hello".to_string()),
 //!     history_proof,
 //!     ).unwrap();
 //! };
@@ -193,19 +193,19 @@
 //! use akd::directory::Directory;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Commit to the second epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello3".to_string()), Values("world3".to_string())),
-//!         (AkdKey("hello4".to_string()), Values("world4".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello3".to_string()), AkdValue("world3".to_string())),
+//!         (AkdLabel("hello4".to_string()), AkdValue("world4".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate audit proof for the evolution from epoch 1 to epoch 2.
 //!     let audit_proof = akd.audit::<Blake3_256<BaseElement>>(1u64, 2u64).await.unwrap();
@@ -221,19 +221,19 @@
 //! use akd::directory::Directory;
 //! type Blake3 = Blake3_256<BaseElement>;
 //! type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
-//! use akd::storage::types::{AkdKey, DbRecord, ValueState, ValueStateRetrievalFlag, Values};
+//! use akd::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 //! use akd::storage::Storage;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello".to_string()), Values("world".to_string())),
-//!         (AkdKey("hello2".to_string()), Values("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
+//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
 //!          .await.unwrap();
 //!     // Commit to the second epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdKey("hello3".to_string()), Values("world3".to_string())),
-//!         (AkdKey("hello4".to_string()), Values("world4".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello3".to_string()), AkdValue("world3".to_string())),
+//!         (AkdLabel("hello4".to_string()), AkdValue("world4".to_string())),], false)
 //!          .await.unwrap();
 //!     // Generate audit proof for the evolution from epoch 1 to epoch 2.
 //!     let audit_proof = akd.audit::<Blake3_256<BaseElement>>(1u64, 2u64).await.unwrap();

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -10,7 +10,7 @@
 
 use winter_crypto::Hasher;
 
-use crate::{node_state::Node, node_state::NodeLabel, storage::types::Values, Direction, ARITY};
+use crate::{node_state::Node, node_state::NodeLabel, storage::types::AkdValue, Direction, ARITY};
 
 /// Merkle proof of membership of a [`NodeLabel`] with a particular hash value
 /// in the tree at a given epoch.
@@ -67,7 +67,7 @@ pub struct LookupProof<H: Hasher> {
     /// The epoch of this record
     pub epoch: u64,
     /// The plaintext value in question
-    pub plaintext_value: Values,
+    pub plaintext_value: AkdValue,
     /// The version of the record
     pub version: u64,
     /// Record existence proof
@@ -90,7 +90,7 @@ pub struct UpdateProof<H: Hasher> {
     /// Epoch of this update
     pub epoch: u64,
     /// Value at this update
-    pub plaintext_value: Values,
+    pub plaintext_value: AkdValue,
     /// Version at this update
     pub version: u64,
     /// Membership proof to show that the key was included in this epoch

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -8,7 +8,7 @@
 use crate::errors::StorageError;
 use crate::storage::transaction::Transaction;
 use crate::storage::types::{
-    AkdKey, DbRecord, KeyData, StorageType, ValueState, ValueStateKey, ValueStateRetrievalFlag,
+    AkdLabel, DbRecord, KeyData, StorageType, ValueState, ValueStateKey, ValueStateRetrievalFlag,
 };
 use crate::storage::{Storable, Storage};
 use async_trait::async_trait;
@@ -174,7 +174,7 @@ impl Storage for AsyncInMemoryDatabase {
     }
 
     /// Retrieve the user data for a given user
-    async fn get_user_data(&self, username: &AkdKey) -> Result<KeyData, StorageError> {
+    async fn get_user_data(&self, username: &AkdLabel) -> Result<KeyData, StorageError> {
         let guard = self.user_info.read().await;
         if let Some(result) = guard.get(&username.0) {
             let mut results: Vec<ValueState> = result.to_vec();
@@ -190,7 +190,7 @@ impl Storage for AsyncInMemoryDatabase {
     /// Retrieve a specific state for a given user
     async fn get_user_state(
         &self,
-        username: &AkdKey,
+        username: &AkdLabel,
         flag: ValueStateRetrievalFlag,
     ) -> Result<ValueState, StorageError> {
         let intermediate = self.get_user_data(username).await?.states;
@@ -255,13 +255,13 @@ impl Storage for AsyncInMemoryDatabase {
 
     async fn get_user_state_versions(
         &self,
-        keys: &[AkdKey],
+        keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> Result<HashMap<AkdKey, u64>, StorageError> {
+    ) -> Result<HashMap<AkdLabel, u64>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
             if let Ok(result) = self.get_user_state(username, flag).await {
-                map.insert(AkdKey(result.username.0.clone()), result.version);
+                map.insert(AkdLabel(result.username.0.clone()), result.version);
             }
         }
         Ok(map)
@@ -552,7 +552,7 @@ impl Storage for AsyncInMemoryDbWithCache {
         Ok(map)
     }
 
-    async fn get_user_data(&self, username: &AkdKey) -> Result<KeyData, StorageError> {
+    async fn get_user_data(&self, username: &AkdLabel) -> Result<KeyData, StorageError> {
         let guard = self.user_info.read().await;
         if let Some(result) = guard.get(&username.0) {
             let mut results: Vec<ValueState> = result.to_vec();
@@ -567,7 +567,7 @@ impl Storage for AsyncInMemoryDbWithCache {
 
     async fn get_user_state(
         &self,
-        username: &AkdKey,
+        username: &AkdLabel,
         flag: ValueStateRetrievalFlag,
     ) -> Result<ValueState, StorageError> {
         let intermediate = self.get_user_data(username).await?.states;
@@ -632,13 +632,13 @@ impl Storage for AsyncInMemoryDbWithCache {
 
     async fn get_user_state_versions(
         &self,
-        keys: &[AkdKey],
+        keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> Result<HashMap<AkdKey, u64>, StorageError> {
+    ) -> Result<HashMap<AkdLabel, u64>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
             if let Ok(result) = self.get_user_state(username, flag).await {
-                map.insert(AkdKey(result.username.0.clone()), result.version);
+                map.insert(AkdLabel(result.username.0.clone()), result.version);
             }
         }
         Ok(map)

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -11,7 +11,7 @@ use crate::append_only_zks::Azks;
 use crate::errors::StorageError;
 use crate::history_tree_node::{HistoryTreeNode, NodeType};
 use crate::node_state::{HistoryChildState, HistoryNodeState, NodeLabel, NodeStateKey};
-use crate::storage::types::{AkdKey, DbRecord, StorageType, ValueState, Values};
+use crate::storage::types::{AkdLabel, AkdValue, DbRecord, StorageType, ValueState};
 use crate::ARITY;
 
 use async_trait::async_trait;
@@ -99,22 +99,24 @@ pub trait Storage: Clone {
     /* User data searching */
 
     /// Retrieve the user data for a given user
-    async fn get_user_data(&self, username: &types::AkdKey)
-        -> Result<types::KeyData, StorageError>;
+    async fn get_user_data(
+        &self,
+        username: &types::AkdLabel,
+    ) -> Result<types::KeyData, StorageError>;
 
     /// Retrieve a specific state for a given user
     async fn get_user_state(
         &self,
-        username: &types::AkdKey,
+        username: &types::AkdLabel,
         flag: types::ValueStateRetrievalFlag,
     ) -> Result<types::ValueState, StorageError>;
 
     /// Retrieve the user -> state version mapping in bulk. This is the same as get_user_states but with less data retrieved from the storage layer
     async fn get_user_state_versions(
         &self,
-        keys: &[types::AkdKey],
+        keys: &[types::AkdLabel],
         flag: types::ValueStateRetrievalFlag,
-    ) -> Result<HashMap<types::AkdKey, u64>, StorageError>;
+    ) -> Result<HashMap<types::AkdLabel, u64>, StorageError>;
 
     /* Data Layer Builders */
 
@@ -184,7 +186,7 @@ pub trait Storage: Clone {
     }
 
     /*
-    pub(crate) plaintext_val: Values, // This needs to be the plaintext value, to discuss
+    pub(crate) plaintext_val: AkdValue, // This needs to be the plaintext value, to discuss
     pub(crate) version: u64,          // to discuss
     pub(crate) label: NodeLabel,
     pub(crate) epoch: u64,
@@ -199,11 +201,11 @@ pub trait Storage: Clone {
         epoch: u64,
     ) -> ValueState {
         ValueState {
-            plaintext_val: Values(plaintext_val),
+            plaintext_val: AkdValue(plaintext_val),
             version,
             label: NodeLabel::new(label_val, label_len),
             epoch,
-            username: AkdKey(username),
+            username: AkdLabel(username),
         }
     }
 }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -134,11 +134,11 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     // === ValueState storage === //
     let key = ValueStateKey("test".to_string(), 1);
     let value = ValueState {
-        username: AkdKey("test".to_string()),
+        username: AkdLabel("test".to_string()),
         epoch: 1,
         label: NodeLabel::new(1, 1),
         version: 1,
-        plaintext_val: Values("abc123".to_string()),
+        plaintext_val: AkdValue("abc123".to_string()),
     };
     let set_result = storage.set(DbRecord::ValueState(value.clone())).await;
     assert_eq!(Ok(()), set_result);
@@ -173,14 +173,14 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
     for value in rand_users.iter() {
         for user in rand_users.iter() {
             data.push(DbRecord::ValueState(ValueState {
-                plaintext_val: Values(value.clone()),
+                plaintext_val: AkdValue(value.clone()),
                 version: epoch,
                 label: NodeLabel {
                     val: 1u64,
                     len: 1u32,
                 },
                 epoch,
-                username: AkdKey(user.clone()),
+                username: AkdLabel(user.clone()),
             }));
         }
         epoch += 1;
@@ -233,7 +233,10 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
         }
     }
 
-    let user_keys: Vec<_> = rand_users.iter().map(|user| AkdKey(user.clone())).collect();
+    let user_keys: Vec<_> = rand_users
+        .iter()
+        .map(|user| AkdLabel(user.clone()))
+        .collect();
     let got_all_min_states = storage
         .get_user_state_versions(&user_keys, ValueStateRetrievalFlag::MinEpoch)
         .await;
@@ -334,14 +337,14 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &mut S) {
     for value in rand_users.iter() {
         for user in rand_users.iter() {
             data.push(DbRecord::ValueState(ValueState {
-                plaintext_val: Values(value.clone()),
+                plaintext_val: AkdValue(value.clone()),
                 version: 1u64,
                 label: NodeLabel {
                     val: 1u64,
                     len: 1u32,
                 },
                 epoch,
-                username: AkdKey(user.clone()),
+                username: AkdLabel(user.clone()),
             }));
         }
         epoch += 1;
@@ -399,17 +402,17 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         .map(char::from)
         .collect();
     let mut sample_state = ValueState {
-        plaintext_val: Values(rand_value.clone()),
+        plaintext_val: AkdValue(rand_value.clone()),
         version: 1u64,
         label: NodeLabel {
             val: 1u64,
             len: 1u32,
         },
         epoch: 1u64,
-        username: AkdKey(rand_user),
+        username: AkdLabel(rand_user),
     };
     let mut sample_state_2 = sample_state.clone();
-    sample_state_2.username = AkdKey("test_user".to_string());
+    sample_state_2.username = AkdLabel("test_user".to_string());
 
     let result = storage
         .set(DbRecord::ValueState(sample_state.clone()))
@@ -478,7 +481,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             epoch: 123,
             version: 2,
             label: NodeLabel::new(1, 1),
-            plaintext_val: Values(rand_value.clone()),
+            plaintext_val: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -493,7 +496,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
                 epoch: 123,
                 version: 2,
                 label: NodeLabel::new(1, 1),
-                plaintext_val: Values(rand_value.clone()),
+                plaintext_val: AkdValue(rand_value.clone()),
                 username: sample_state.username.clone(),
             },
             state
@@ -524,7 +527,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             epoch: 123,
             version: 2,
             label: NodeLabel::new(1, 1),
-            plaintext_val: Values(rand_value.clone()),
+            plaintext_val: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -538,7 +541,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             epoch: 1,
             version: 1,
             label: NodeLabel::new(1, 1),
-            plaintext_val: Values(rand_value.clone()),
+            plaintext_val: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -552,7 +555,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             epoch: 456,
             version: 3,
             label: NodeLabel::new(1, 1),
-            plaintext_val: Values(rand_value.clone()),
+            plaintext_val: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -27,12 +27,12 @@ pub enum StorageType {
 
 /// The keys for this key-value store
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AkdKey(pub String);
+pub struct AkdLabel(pub String);
 
-/// The types of values used in the key-value pairs of a AKD
+/// The types of value used in the key-value pairs of a AKD
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct Values(pub String);
+pub struct AkdValue(pub String);
 
 /// State for a value at a given version for that key
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -43,7 +43,7 @@ pub struct ValueStateKey(pub String, pub u64);
 #[serde(bound = "")]
 pub struct ValueState {
     /// The plaintext value of the user information in the directory
-    pub plaintext_val: Values, // This needs to be the plaintext value, to discuss
+    pub plaintext_val: AkdValue, // This needs to be the plaintext value, to discuss
     /// The version of the user's value-state
     pub version: u64, // to discuss
     /// The Node Label
@@ -51,7 +51,7 @@ pub struct ValueState {
     /// The epoch this value state was published in
     pub epoch: u64,
     /// The username associated to this value state (username + epoch is the record key)
-    pub username: AkdKey,
+    pub username: AkdLabel,
 }
 
 impl crate::storage::Storable for ValueState {
@@ -95,8 +95,8 @@ impl crate::storage::Storable for ValueState {
 
 impl ValueState {
     pub(crate) fn new(
-        username: AkdKey,
-        plaintext_val: Values,
+        username: AkdLabel,
+        plaintext_val: AkdValue,
         version: u64,
         label: NodeLabel,
         epoch: u64,
@@ -115,7 +115,7 @@ impl ValueState {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub struct KeyData {
-    /// The vector of states of key data for a given AkdKey
+    /// The vector of states of key data for a given AkdLabel
     pub states: Vec<ValueState>,
 }
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -11,7 +11,7 @@ use akd::errors::StorageError;
 use akd::history_tree_node::{HistoryTreeNode, NodeKey};
 use akd::node_state::NodeLabel;
 use akd::storage::types::{
-    AkdKey, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
+    AkdLabel, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
 };
 use akd::storage::{Storable, Storage};
 use akd::ARITY;
@@ -1067,7 +1067,7 @@ impl Storage for AsyncMySqlDatabase {
 
     async fn get_user_data(
         &self,
-        username: &AkdKey,
+        username: &AkdLabel,
     ) -> core::result::Result<KeyData, StorageError> {
         // This is the same as previous logic under "get_all"
 
@@ -1104,8 +1104,8 @@ impl Storage for AsyncMySqlDatabase {
                             val: node_label_val.unwrap(),
                             len: node_label_len.unwrap(),
                         },
-                        plaintext_val: akd::storage::types::Values(data.unwrap()),
-                        username: akd::storage::types::AkdKey(username.unwrap()),
+                        plaintext_val: akd::storage::types::AkdValue(data.unwrap()),
+                        username: akd::storage::types::AkdLabel(username.unwrap()),
                     }
                 })
                 .await;
@@ -1148,7 +1148,7 @@ impl Storage for AsyncMySqlDatabase {
 
     async fn get_user_state(
         &self,
-        username: &AkdKey,
+        username: &AkdLabel,
         flag: ValueStateRetrievalFlag,
     ) -> core::result::Result<ValueState, StorageError> {
         *(self.num_reads.write().await) += 1;
@@ -1203,8 +1203,8 @@ impl Storage for AsyncMySqlDatabase {
                             val: node_label_val.unwrap(),
                             len: node_label_len.unwrap(),
                         },
-                        plaintext_val: akd::storage::types::Values(data.unwrap()),
-                        username: akd::storage::types::AkdKey(username.unwrap()),
+                        plaintext_val: akd::storage::types::AkdValue(data.unwrap()),
+                        username: akd::storage::types::AkdLabel(username.unwrap()),
                     }
                 })
                 .await;
@@ -1245,9 +1245,9 @@ impl Storage for AsyncMySqlDatabase {
 
     async fn get_user_state_versions(
         &self,
-        keys: &[AkdKey],
+        keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> core::result::Result<HashMap<AkdKey, u64>, StorageError> {
+    ) -> core::result::Result<HashMap<AkdLabel, u64>, StorageError> {
         *(self.num_reads.write().await) += 1;
 
         let mut results = HashMap::new();
@@ -1390,7 +1390,7 @@ impl Storage for AsyncMySqlDatabase {
                         if let (Some(Ok(username)), Some(Ok(version))) =
                             (row.take_opt(0), row.take_opt(1))
                         {
-                            acc.push((AkdKey(username), version))
+                            acc.push((AkdLabel(username), version))
                         }
                         acc
                     })
@@ -1404,7 +1404,7 @@ impl Storage for AsyncMySqlDatabase {
                         if let (Some(Ok(username)), Some(Ok(version))) =
                             (row.take_opt(0), row.take_opt(1))
                         {
-                            acc.push((AkdKey(username), version))
+                            acc.push((AkdLabel(username), version))
                         }
                         acc
                     })

--- a/examples/measurements.rs
+++ b/examples/measurements.rs
@@ -13,27 +13,27 @@ use akd::auditor::audit_verify;
 use akd::client::{key_history_verify, lookup_verify};
 use akd::directory::{get_key_history_hashes, Directory};
 use akd::storage::memory::AsyncInMemoryDbWithCache;
-use akd::storage::types::{AkdKey, Values};
+use akd::storage::types::{AkdLabel, AkdValue};
 
 use winter_crypto::hashers::Blake3_256;
 use winter_math::fields::f128::BaseElement;
 
-fn create_keys_and_values(num_insertions: usize, mut rng: ThreadRng) -> Vec<(AkdKey, Values)> {
-    let mut updates = Vec::<(AkdKey, Values)>::new();
+fn create_keys_and_values(num_insertions: usize, mut rng: ThreadRng) -> Vec<(AkdLabel, AkdValue)> {
+    let mut updates = Vec::<(AkdLabel, AkdValue)>::new();
     for _ in 0..num_insertions {
-        let akd_key = AkdKey::random(&mut rng);
-        let val = Values::random(&mut rng);
+        let akd_key = AkdLabel::random(&mut rng);
+        let val = AkdValue::random(&mut rng);
         updates.push((akd_key, val));
     }
     updates
 }
 
 fn create_random_subset_of_existing_keys(
-    existing_keys: Vec<AkdKey>,
+    existing_keys: Vec<AkdLabel>,
     subset_size: usize,
     mut rng: ThreadRng,
-) -> Vec<(AkdKey, Values)> {
-    let mut key_subset = Vec::<(AkdKey, Values)>::new();
+) -> Vec<(AkdLabel, AkdValue)> {
+    let mut key_subset = Vec::<(AkdLabel, AkdValue)>::new();
     let mut actual_subset_size = subset_size;
     if existing_keys.len() < subset_size {
         actual_subset_size = existing_keys.len();
@@ -43,7 +43,7 @@ fn create_random_subset_of_existing_keys(
         .choose_multiple(&mut rng, actual_subset_size);
     for i in 0..actual_subset_size {
         let username = sample[i].clone();
-        let val = Values::random(&mut rng);
+        let val = AkdValue::random(&mut rng);
         key_subset.push((username, val));
     }
     key_subset
@@ -53,7 +53,7 @@ fn create_random_subset_of_existing_keys(
 async fn main() {
     let num_init_insertions = 1000;
 
-    let mut existing_keys = Vec::<AkdKey>::new();
+    let mut existing_keys = Vec::<AkdLabel>::new();
 
     let db = AsyncInMemoryDbWithCache::new();
     let mut akd_dir = Directory::<_>::new::<Blake3_256<BaseElement>>(&db)
@@ -74,7 +74,7 @@ async fn main() {
         .clone()
         .iter()
         .map(|x| x.0.clone())
-        .collect::<Vec<AkdKey>>();
+        .collect::<Vec<AkdLabel>>();
     existing_keys.append(&mut new_keys);
 
     let num_new_insertions = 10;
@@ -99,7 +99,7 @@ async fn main() {
         .clone()
         .iter()
         .map(|x| x.0.clone())
-        .collect::<Vec<AkdKey>>();
+        .collect::<Vec<AkdLabel>>();
     existing_keys.append(&mut new_keys);
 
     let new_epochs = 5;
@@ -120,7 +120,7 @@ async fn main() {
             .clone()
             .iter()
             .map(|x| x.0.clone())
-            .collect::<Vec<AkdKey>>();
+            .collect::<Vec<AkdLabel>>();
         existing_keys.append(&mut new_keys);
     }
 

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -8,7 +8,7 @@ extern crate thread_id;
 // of this source tree.
 
 use akd::directory::Directory;
-use akd::storage::types::{AkdKey, Values};
+use akd::storage::types::{AkdLabel, AkdValue};
 use log::{info, Level, Metadata, Record};
 use once_cell::sync::OnceCell;
 use rand::distributions::Alphanumeric;
@@ -154,7 +154,7 @@ pub(crate) async fn directory_test_suite<S: akd::storage::Storage + Sync + Send>
             for i in 1..=3 {
                 let mut data = Vec::new();
                 for value in users.iter() {
-                    data.push((AkdKey(value.clone()), Values(format!("{}", i))));
+                    data.push((AkdLabel(value.clone()), AkdValue(format!("{}", i))));
                 }
 
                 if let Err(error) = dir.publish::<Blake3>(data, true).await {
@@ -169,7 +169,7 @@ pub(crate) async fn directory_test_suite<S: akd::storage::Storage + Sync + Send>
             let root_hash = dir.get_root_hash::<Blake3>(&azks).await.unwrap();
 
             for user in users.iter().choose_multiple(&mut rng, 10) {
-                let key = AkdKey(user.clone());
+                let key = AkdLabel(user.clone());
                 match dir.lookup::<Blake3>(key.clone()).await {
                     Err(error) => panic!("Error looking up user information {:?}", error),
                     Ok(proof) => {
@@ -183,7 +183,7 @@ pub(crate) async fn directory_test_suite<S: akd::storage::Storage + Sync + Send>
 
             // Perform 2 random history proofs on the published material
             for user in users.iter().choose_multiple(&mut rng, 2) {
-                let key = AkdKey(user.clone());
+                let key = AkdLabel(user.clone());
                 match dir.key_history::<Blake3>(&key).await {
                     Err(error) => panic!("Error performing key history retrieval {:?}", error),
                     Ok(proof) => {

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -66,7 +66,7 @@ where
             (DirectoryCommand::Publish(a, b), Some(response)) => {
                 let tic = Instant::now();
                 match directory
-                    .publish::<H>(vec![(AkdKey(a.clone()), Values(b.clone()))], false)
+                    .publish::<H>(vec![(AkdLabel(a.clone()), AkdValue(b.clone()))], false)
                     .await
                 {
                     Ok(EpochHash(epoch, hash)) => {
@@ -94,7 +94,7 @@ where
                     .publish::<H>(
                         batches
                             .into_iter()
-                            .map(|(key, value)| (AkdKey(key), Values(value)))
+                            .map(|(key, value)| (AkdLabel(key), AkdValue(value)))
                             .collect(),
                         with_trans,
                     )
@@ -112,13 +112,16 @@ where
                 }
             }
             (DirectoryCommand::Lookup(a), Some(response)) => {
-                match directory.lookup::<H>(AkdKey(a.clone())).await {
+                match directory.lookup::<H>(AkdLabel(a.clone())).await {
                     Ok(proof) => {
                         let hash = get_root_hash::<_, H>(directory, None).await;
                         match hash {
                             Some(Ok(root_hash)) => {
-                                let verification =
-                                    akd::client::lookup_verify(root_hash, AkdKey(a.clone()), proof);
+                                let verification = akd::client::lookup_verify(
+                                    root_hash,
+                                    AkdLabel(a.clone()),
+                                    proof,
+                                );
                                 if verification.is_err() {
                                     let msg = format!(
                                         "WARN: Lookup proof failed verification for '{}'",
@@ -143,7 +146,7 @@ where
                 }
             }
             (DirectoryCommand::KeyHistory(a), Some(response)) => {
-                match directory.key_history::<H>(&AkdKey(a.clone())).await {
+                match directory.key_history::<H>(&AkdLabel(a.clone())).await {
                     Ok(_proof) => {
                         let msg = format!("GOT KEY HISTORY FOR '{}'", a);
                         response.send(Ok(msg)).unwrap();


### PR DESCRIPTION
This renames:
* AkdKey => AkdLabel
* Values => AkdValue

This hews closer to the SEEMless terms "Label" and "Value" without treading too close to something like `NodeLabel`.

https://github.com/novifinancial/akd/issues/104

This commit represents essentially just a rename of the structs, dropped in place. This is the first part of issue 104 and is pretty low stakes. I want to consider it separate from the forthcoming `String` to `Vec<u8>` conversion which is a much hairier thread to pull.

**Testing**

```
% cargo test 
% cargo fmt
% cargo clippy
% cargo bench --features bench --no-run
```

```
% cd poc
% cargo run
Please enter a command
> [00:00:00.041] (70000fe41000) INFO   Starting the verifiable directory host (directory_host:59)
publish test1 test2
[00:00:06.137] (70000f432000) INFO   Retrieved 0 previous user versions of 1 requested (directory:98)
[00:00:06.137] (70000f432000) INFO   Starting database insertion (directory:155)
[00:00:06.229] (70000f432000) INFO   Preload of tree (14 objects loaded), took 0.091703745 s (append_only_zks:198)
[00:00:06.338] (70000e61d000) INFO   Cache hit since last: 84, cached size: 23 items (timed_cache:52)
[00:00:06.338] (70000e61d000) INFO   Transaction writes: 0, Transaction reads: 0 (transaction:78)
[00:00:06.343] (70000e61d000) INFO   MySQL writes: 39, MySQL reads: 10, Time read: 0.111147572 s, Time write: 0.098209911 s
        Tree size: 21
        Node state count: 35
        Value state count: 7 (mysql:693)
Response: PUBLISHED 'test1' = 'test2' in 0.224341848 s (epoch: 7, root hash: cacb8325c7dabdd0e697fcb1088a91be30473b961137ba2aa6dfbd7d0e938f5a)
Please enter a command
>
```