### PR TITLE
Change the types of AkdLabel and AkdValue to be an array of bytes.

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -392,7 +392,7 @@ impl Azks {
                 .await?
                 .child_states
                 .iter()
-                .map(|x| x.clone())
+                .cloned()
             {
                 match child_node_state {
                     None => {

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -158,7 +158,7 @@ impl fmt::Display for AzksError {
 #[derive(Debug)]
 pub enum DirectoryError {
     /// Looked up a user not in the directory
-    NonExistentUser(String, u64),
+    NonExistentUser(Vec<u8>, u64),
     /// Lookup proof did not verify
     VerifyLookupProof(String),
     /// Key-History proof did not verify
@@ -178,7 +178,7 @@ impl fmt::Display for DirectoryError {
                 )
             }
             Self::NonExistentUser(uname, ep) => {
-                write!(f, "The user {} did not exist at the epoch {}", uname, ep)
+                write!(f, "The user {:?} did not exist at the epoch {}", uname, ep)
             }
             Self::VerifyKeyHistoryProof(err_string) => {
                 write!(f, "{}", err_string)

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -63,8 +63,8 @@
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // commit the latest changes
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!          (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!          (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!       .await;
 //! };
 //! ```
@@ -86,11 +86,11 @@
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel("hello".to_string())).await;
+//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel(Vec::from("hello"))).await;
 //! };
 //! ```
 //! ## Verifying a lookup proof
@@ -109,17 +109,17 @@
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel("hello".to_string())).await.unwrap();
+//!     let lookup_proof = akd.lookup::<Blake3_256<BaseElement>>(AkdLabel(Vec::from("hello"))).await.unwrap();
 //!     let current_azks = akd.retrieve_current_azks().await.unwrap();
 //!     // Get the latest commitment, i.e. azks root hash
 //!     let root_hash = akd.get_root_hash::<Blake3_256<BaseElement>>(&current_azks).await.unwrap();
 //!     client::lookup_verify::<Blake3_256<BaseElement>>(
 //!     root_hash,
-//!     AkdLabel("hello".to_string()),
+//!     AkdLabel(Vec::from("hello")),
 //!     lookup_proof,
 //!     ).unwrap();
 //! };
@@ -143,11 +143,11 @@
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel("hello".to_string())).await;
+//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel(Vec::from("hello"))).await;
 //! };
 //! ```
 //! ## Verifying a key history proof
@@ -166,18 +166,18 @@
 //! let db = AsyncInMemoryDatabase::new();
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Generate latest proof
-//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel("hello".to_string())).await.unwrap();
+//!     let history_proof = akd.key_history::<Blake3_256<BaseElement>>(&AkdLabel(Vec::from("hello"))).await.unwrap();
 //!     let current_azks = akd.retrieve_current_azks().await.unwrap();
 //!     // Get the azks root hashes at the required epochs
 //!     let (root_hashes, previous_root_hashes) = akd::directory::get_key_history_hashes::<_, Blake3_256<BaseElement>>(&akd, &history_proof).await.unwrap();
 //!     key_history_verify::<Blake3_256<BaseElement>>(
 //!     root_hashes,
 //!     previous_root_hashes,
-//!     AkdLabel("hello".to_string()),
+//!     AkdLabel(Vec::from("hello")),
 //!     history_proof,
 //!     ).unwrap();
 //! };
@@ -200,12 +200,12 @@
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Commit to the second epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello3".to_string()), AkdValue("world3".to_string())),
-//!         (AkdLabel("hello4".to_string()), AkdValue("world4".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello3")), AkdValue(Vec::from("world3"))),
+//!         (AkdLabel(Vec::from("hello4")), AkdValue(Vec::from("world4"))),], false)
 //!          .await.unwrap();
 //!     // Generate audit proof for the evolution from epoch 1 to epoch 2.
 //!     let audit_proof = akd.audit::<Blake3_256<BaseElement>>(1u64, 2u64).await.unwrap();
@@ -228,12 +228,12 @@
 //! async {
 //!     let mut akd = Directory::<_>::new::<Blake3_256<BaseElement>>(&db).await.unwrap();
 //!     // Commit to the first epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello".to_string()), AkdValue("world".to_string())),
-//!         (AkdLabel("hello2".to_string()), AkdValue("world2".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello")), AkdValue(Vec::from("world"))),
+//!         (AkdLabel(Vec::from("hello2")), AkdValue(Vec::from("world2"))),], false)
 //!          .await.unwrap();
 //!     // Commit to the second epoch
-//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel("hello3".to_string()), AkdValue("world3".to_string())),
-//!         (AkdLabel("hello4".to_string()), AkdValue("world4".to_string())),], false)
+//!     akd.publish::<Blake3_256<BaseElement>>(vec![(AkdLabel(Vec::from("hello3")), AkdValue(Vec::from("world3"))),
+//!         (AkdLabel(Vec::from("hello4")), AkdValue(Vec::from("world4"))),], false)
 //!          .await.unwrap();
 //!     // Generate audit proof for the evolution from epoch 1 to epoch 2.
 //!     let audit_proof = akd.audit::<Blake3_256<BaseElement>>(1u64, 2u64).await.unwrap();

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct AsyncInMemoryDatabase {
     db: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, DbRecord>>>,
-    user_info: Arc<tokio::sync::RwLock<HashMap<String, Vec<ValueState>>>>,
+    user_info: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, Vec<ValueState>>>>,
     trans: Transaction,
 }
 
@@ -314,7 +314,7 @@ pub struct AsyncInMemoryDbWithCache {
     cache: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, DbRecord>>>,
     stats: Arc<tokio::sync::RwLock<HashMap<String, usize>>>,
 
-    user_info: Arc<tokio::sync::RwLock<HashMap<String, Vec<ValueState>>>>,
+    user_info: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, Vec<ValueState>>>>,
     trans: Transaction,
 }
 

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -193,8 +193,8 @@ pub trait Storage: Clone {
     */
     /// Build a user state from the properties
     fn build_user_state(
-        username: String,
-        plaintext_val: String,
+        username: Vec<u8>,
+        plaintext_val: Vec<u8>,
         version: u64,
         label_len: u32,
         label_val: u64,

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -12,7 +12,7 @@ use crate::history_tree_node::*;
 use crate::node_state::*;
 use crate::storage::types::*;
 use crate::storage::Storage;
-use rand::distributions::Alphanumeric;
+use rand::distributions::Standard;
 use rand::{thread_rng, Rng};
 use tokio::time::{Duration, Instant};
 
@@ -132,13 +132,13 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     }
 
     // === ValueState storage === //
-    let key = ValueStateKey("test".to_string(), 1);
+    let key = ValueStateKey(Vec::from("test"), 1);
     let value = ValueState {
-        username: AkdLabel("test".to_string()),
+        username: AkdLabel(Vec::from("test")),
         epoch: 1,
         label: NodeLabel::new(1, 1),
         version: 1,
-        plaintext_val: AkdValue("abc123".to_string()),
+        plaintext_val: AkdValue(Vec::from("abc123")),
     };
     let set_result = storage.set(DbRecord::ValueState(value.clone())).await;
     assert_eq!(Ok(()), set_result);
@@ -156,15 +156,9 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
 }
 
 async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
-    let mut rand_users: Vec<String> = vec![];
+    let mut rand_users: Vec<Vec<u8>> = vec![];
     for _ in 0..20 {
-        rand_users.push(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(30)
-                .map(char::from)
-                .collect(),
-        );
+        rand_users.push(thread_rng().sample_iter(&Standard).take(30).collect());
     }
 
     let mut data = Vec::new();
@@ -320,15 +314,9 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
 }
 
 async fn test_transactions<S: Storage + Sync + Send>(storage: &mut S) {
-    let mut rand_users: Vec<String> = vec![];
+    let mut rand_users: Vec<Vec<u8>> = vec![];
     for _ in 0..20 {
-        rand_users.push(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(30)
-                .map(char::from)
-                .collect(),
-        );
+        rand_users.push(thread_rng().sample_iter(&Standard).take(30).collect());
     }
 
     let mut data = Vec::new();
@@ -391,16 +379,8 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &mut S) {
 }
 
 async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
-    let rand_user: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(30)
-        .map(char::from)
-        .collect();
-    let rand_value: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(1028)
-        .map(char::from)
-        .collect();
+    let rand_user: Vec<u8> = thread_rng().sample_iter(&Standard).take(30).collect();
+    let rand_value: Vec<u8> = thread_rng().sample_iter(&Standard).take(1028).collect();
     let mut sample_state = ValueState {
         plaintext_val: AkdValue(rand_value.clone()),
         version: 1u64,
@@ -412,7 +392,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
         username: AkdLabel(rand_user),
     };
     let mut sample_state_2 = sample_state.clone();
-    sample_state_2.username = AkdLabel("test_user".to_string());
+    sample_state_2.username = AkdLabel(Vec::from("test_user"));
 
     let result = storage
         .set(DbRecord::ValueState(sample_state.clone()))

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -27,16 +27,16 @@ pub enum StorageType {
 
 /// The keys for this key-value store
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AkdLabel(pub String);
+pub struct AkdLabel(pub Vec<u8>);
 
 /// The types of value used in the key-value pairs of a AKD
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct AkdValue(pub String);
+pub struct AkdValue(pub Vec<u8>);
 
 /// State for a value at a given version for that key
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ValueStateKey(pub String, pub u64);
+pub struct ValueStateKey(pub Vec<u8>, pub u64);
 
 /// The state of the value for a given key, starting at a particular epoch.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
@@ -71,10 +71,7 @@ impl crate::storage::Storable for ValueState {
         for byte in &epoch_bytes {
             result.push(*byte);
         }
-        let uname_bytes = key.0.as_bytes();
-        for byte in uname_bytes {
-            result.push(*byte);
-        }
+        result.extend(key.0.iter());
 
         result
     }
@@ -85,11 +82,8 @@ impl crate::storage::Storable for ValueState {
         }
         let epoch_bytes: [u8; 8] = bin[1..=8].try_into().expect("Slice with incorrect length");
         let epoch = u64::from_be_bytes(epoch_bytes);
-        if let Ok(username) = std::str::from_utf8(&bin[9..]) {
-            Ok(ValueStateKey(username.to_string(), epoch))
-        } else {
-            Err("Invalid string format".to_string())
-        }
+        let username = Vec::from(&bin[9..]);
+        Ok(ValueStateKey(username, epoch))
     }
 }
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -355,8 +355,8 @@ impl<'a> AsyncMySqlDatabase {
         // User data table
         let command = "CREATE TABLE IF NOT EXISTS `".to_owned()
             + TABLE_USER
-            + "` (`username` VARCHAR(256) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, `version` BIGINT UNSIGNED NOT NULL,"
-            + " `node_label_val` BIGINT UNSIGNED NOT NULL, `node_label_len` INT UNSIGNED NOT NULL, `data` VARCHAR(2000),"
+            + "` (`username` VARBINARY(256) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, `version` BIGINT UNSIGNED NOT NULL,"
+            + " `node_label_val` BIGINT UNSIGNED NOT NULL, `node_label_len` INT UNSIGNED NOT NULL, `data` VARBINARY(2000),"
             + " PRIMARY KEY(`username`, `epoch`))";
         tx.query_drop(command).await?;
 
@@ -1261,7 +1261,7 @@ impl Storage for AsyncMySqlDatabase {
             debug!("Creating the temporary search username's table");
             let out = conn
                 .query_drop(
-                    "CREATE TEMPORARY TABLE `search_users`(`username` VARCHAR(256) NOT NULL, PRIMARY KEY (`username`))",
+                    "CREATE TEMPORARY TABLE `search_users`(`username` VARBINARY(256) NOT NULL, PRIMARY KEY (`username`))",
                 )
                 .await;
             self.check_for_infra_error(out)?;
@@ -1689,7 +1689,7 @@ impl MySqlStorable for DbRecord {
             StorageType::ValueState => {
                 Some(
                     format!(
-                        "CREATE TEMPORARY TABLE `{}`(`username` VARCHAR(256) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, PRIMARY KEY(`username`, `epoch`))",
+                        "CREATE TEMPORARY TABLE `{}`(`username` VARBINARY(256) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, PRIMARY KEY(`username`, `epoch`))",
                         TEMP_IDS_TABLE
                     )
                 )

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -55,7 +55,7 @@ pub(crate) fn format_log_record(io: &mut (dyn Write + Send), record: &Record) {
             if let Some(line) = record.line() {
                 format!(" ({}:{})", target_str, line)
             } else {
-                format!(" ({})", target_str.to_string())
+                format!(" ({})", target_str)
             }
         } else {
             "".to_string()

--- a/poc/src/commands.rs
+++ b/poc/src/commands.rs
@@ -119,7 +119,7 @@ impl Command {
             return None;
         }
         let (a, b) = (parts[1], parts[2]);
-        let cmd = DirectoryCommand::Publish(Vec::from(a), Vec::from(b));
+        let cmd = DirectoryCommand::Publish(String::from(a), String::from(b));
         Some(cmd)
     }
 
@@ -128,7 +128,7 @@ impl Command {
             return None;
         }
         let a = parts[1];
-        let cmd = DirectoryCommand::Lookup(Vec::from(a));
+        let cmd = DirectoryCommand::Lookup(String::from(a));
         Some(cmd)
     }
 
@@ -137,7 +137,7 @@ impl Command {
             return None;
         }
         let a = parts[1];
-        let cmd = DirectoryCommand::KeyHistory(Vec::from(a));
+        let cmd = DirectoryCommand::KeyHistory(String::from(a));
         Some(cmd)
     }
 

--- a/poc/src/commands.rs
+++ b/poc/src/commands.rs
@@ -119,7 +119,7 @@ impl Command {
             return None;
         }
         let (a, b) = (parts[1], parts[2]);
-        let cmd = DirectoryCommand::Publish(String::from(a), String::from(b));
+        let cmd = DirectoryCommand::Publish(Vec::from(a), Vec::from(b));
         Some(cmd)
     }
 
@@ -128,7 +128,7 @@ impl Command {
             return None;
         }
         let a = parts[1];
-        let cmd = DirectoryCommand::Lookup(String::from(a));
+        let cmd = DirectoryCommand::Lookup(Vec::from(a));
         Some(cmd)
     }
 
@@ -137,7 +137,7 @@ impl Command {
             return None;
         }
         let a = parts[1];
-        let cmd = DirectoryCommand::KeyHistory(String::from(a));
+        let cmd = DirectoryCommand::KeyHistory(Vec::from(a));
         Some(cmd)
     }
 

--- a/poc/src/logs.rs
+++ b/poc/src/logs.rs
@@ -35,7 +35,7 @@ impl ConsoleLogger {
                 if let Some(line) = record.line() {
                     format!(" ({}:{})", target_str, line)
                 } else {
-                    format!(" ({})", target_str.to_string())
+                    format!(" ({})", target_str)
                 }
             } else {
                 "".to_string()

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -14,7 +14,7 @@ use akd_mysql::mysql::{AsyncMySqlDatabase, MySqlCacheOptions};
 use clap::arg_enum;
 use commands::Command;
 use log::{debug, error, info, warn};
-use rand::distributions::Standard;
+use rand::distributions::Alphanumeric;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::convert::From;
@@ -208,12 +208,13 @@ async fn process_input(
                 println!("======= Benchmark operation requested ======= ");
                 println!("Beginning DB INSERT benchmark of {} users", num_users);
 
-                let mut values: Vec<Vec<u8>> = vec![];
+                let mut values: Vec<String> = vec![];
                 for i in 0..*num_users {
                     values.push(
                         StdRng::seed_from_u64(i)
-                            .sample_iter(&Standard)
+                            .sample_iter(&Alphanumeric)
                             .take(30)
+                            .map(char::from)
                             .collect(),
                     );
                 }
@@ -221,8 +222,8 @@ async fn process_input(
                 let mut data = Vec::new();
                 for value in values.iter() {
                     let state = akd_mysql::mysql::AsyncMySqlDatabase::build_user_state(
-                        value.clone(),
-                        value.clone(),
+                        Vec::from(value.as_bytes()),
+                        Vec::from(value.as_bytes()),
                         1u64,
                         1u32,
                         1u64,
@@ -261,19 +262,21 @@ async fn process_input(
                     num_users, num_updates_per_user
                 );
 
-                let users: Vec<Vec<u8>> = (1..=*num_users)
+                let users: Vec<String> = (1..=*num_users)
                     .map(|i| {
                         StdRng::seed_from_u64(i)
-                            .sample_iter(&Standard)
+                            .sample_iter(&Alphanumeric)
                             .take(256)
+                            .map(char::from)
                             .collect()
                     })
                     .collect();
-                let data: Vec<Vec<u8>> = (1..=*num_updates_per_user)
+                let data: Vec<String> = (1..=*num_updates_per_user)
                     .map(|i| {
                         StdRng::seed_from_u64(i)
-                            .sample_iter(&Standard)
+                            .sample_iter(&Alphanumeric)
                             .take(1024)
+                            .map(char::from)
                             .collect()
                     })
                     .collect();
@@ -282,7 +285,7 @@ async fn process_input(
 
                 let mut code = None;
                 for value in data {
-                    let user_data: Vec<(Vec<u8>, Vec<u8>)> = users
+                    let user_data: Vec<(String, String)> = users
                         .iter()
                         .map(|user| (user.clone(), value.clone()))
                         .collect();
@@ -332,16 +335,18 @@ async fn process_input(
                     num_users, num_lookups_per_user
                 );
 
-                let user_data: Vec<(Vec<u8>, Vec<u8>)> = (1..=*num_users)
+                let user_data: Vec<(String, String)> = (1..=*num_users)
                     .map(|i| {
                         (
                             StdRng::seed_from_u64(i)
-                                .sample_iter(&Standard)
+                                .sample_iter(&Alphanumeric)
                                 .take(256)
+                                .map(char::from)
                                 .collect(),
                             StdRng::seed_from_u64(i)
-                                .sample_iter(&Standard)
+                                .sample_iter(&Alphanumeric)
                                 .take(1024)
+                                .map(char::from)
                                 .collect(),
                         )
                     })


### PR DESCRIPTION
https://github.com/novifinancial/akd/issues/104

Previously, these values were traded around as `String` values for convenience of readability. This change moves these values to `Vec<u8>` to reflect that these are intended as arbitrary blobs of bytes.

The POC continues to traffic in strings since it's a demonstration meant for the command line, where the readability is more convenient.

**Testing**

```
% cargo test 
% cargo fmt
% cargo clippy
% cargo bench --features bench --no-run
```

```
% cd poc
% cargo run
Please enter a command
> [00:00:00.036] (70000fa7d000) INFO   Starting the verifiable directory host (directory_host:59)
publish banana green
[00:00:08.006] (70000f87a000) INFO   Retrieved 0 previous user versions of 1 requested (directory:98)
[00:00:08.006] (70000f87a000) INFO   Starting database insertion (directory:155)
[00:00:08.100] (70000f87a000) INFO   Preload of tree (10 objects loaded), took 0.093771548 s (append_only_zks:198)
[00:00:08.232] (70000e056000) INFO   Cache hit since last: 63, cached size: 18 items (timed_cache:52)
[00:00:08.232] (70000e056000) INFO   Transaction writes: 0, Transaction reads: 0 (transaction:78)
[00:00:08.239] (70000e056000) INFO   MySQL writes: 31, MySQL reads: 8, Time read: 0.118470512 s, Time write: 0.119331427 s
        Tree size: 7
        Node state count: 11
        Value state count: 3 (mysql:693)
Response: PUBLISHED 'banana' = 'green' in 0.256827742 s (epoch: 3, root hash: 487aa4a60b398ee51b90374a0865aac769d1222cfe6a023933b51edc732ca864)
Please enter a command
> publish banana yellow
[00:00:12.656] (70000f87a000) INFO   Retrieved 1 previous user versions of 1 requested (directory:98)
[00:00:12.656] (70000f87a000) INFO   Starting database insertion (directory:155)
[00:00:12.657] (70000f87a000) INFO   Preload of tree (6 objects loaded), took 0.000360711 s (append_only_zks:198)
[00:00:12.809] (70000e056000) INFO   Cache hit since last: 75, cached size: 28 items (timed_cache:52)
[00:00:12.810] (70000e056000) INFO   Transaction writes: 0, Transaction reads: 0 (transaction:78)
[00:00:12.815] (70000e056000) INFO   MySQL writes: 40, MySQL reads: 1, Time read: 0.01543748 s, Time write: 0.138823311 s
        Tree size: 11
        Node state count: 16
        Value state count: 4 (mysql:693)
Response: PUBLISHED 'banana' = 'yellow' in 0.174664147 s (epoch: 4, root hash: 6526a193ba85f40617cb2805f87df33d34405ffde8c3b84df8fe03067f86dc83)
Please enter a command
> lookup banana
Response: Lookup proof verified for user 'banana'
Please enter a command
> history banana
Response: GOT KEY HISTORY FOR 'banana'
Please enter a command
> x
[00:00:23.132] (10e138600) INFO   Exiting... (akd_app:439)
```