### PR TITLE
Adding test for empty tree hash

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -392,7 +392,7 @@ impl Azks {
                 .await?
                 .child_states
                 .iter()
-                .map(|x| x.clone())
+                .cloned()
             {
                 match child_node_state {
                     None => {

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -502,8 +502,22 @@ mod tests {
     use winter_math::fields::f128::BaseElement;
     type Blake3 = Blake3_256<BaseElement>;
 
-    // FIXME: #[test]
-    #[allow(unused)]
+    #[tokio::test]
+    async fn test_empty_tree_root_hash() -> Result<(), AkdError> {
+        let db = AsyncInMemoryDatabase::new();
+        let akd = Directory::<_>::new::<Blake3>(&db).await?;
+
+        let current_azks = akd.retrieve_current_azks().await?;
+        let hash = akd.get_root_hash::<Blake3>(&current_azks).await?;
+
+        // Ensuring that the root hash of an empty tree is equal to the following constant
+        assert_eq!(
+            "2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213",
+            hex::encode(hash.as_bytes())
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_simple_publish() -> Result<(), AkdError> {
         let db = AsyncInMemoryDatabase::new();

--- a/poc/src/logs.rs
+++ b/poc/src/logs.rs
@@ -35,7 +35,7 @@ impl ConsoleLogger {
                 if let Some(line) = record.line() {
                     format!(" ({}:{})", target_str, line)
                 } else {
-                    format!(" ({})", target_str.to_string())
+                    format!(" ({})", target_str)
                 }
             } else {
                 "".to_string()


### PR DESCRIPTION
This simply adds a small test for checking that the root hash of an *empty* tree is equal to the same constant value (in this case, the hash of the NodeLabel (0,0) )