### PR TITLE
Future epochs provided don't throw errors

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -439,6 +439,13 @@ impl Azks {
         storage: &S,
         epoch: u64,
     ) -> Result<H::Digest, HistoryTreeNodeError> {
+        if self.latest_epoch < epoch {
+            // cannot retrieve information for future epoch
+            return Err(HistoryTreeNodeError::NonexistentAtEpoch(
+                NodeLabel::root(),
+                self.latest_epoch,
+            ));
+        }
         let root_node: HistoryTreeNode =
             HistoryTreeNode::get_from_storage(storage, NodeKey(NodeLabel::root())).await?;
         root_node.get_value_at_epoch::<_, H>(storage, epoch).await
@@ -905,6 +912,21 @@ mod tests {
         let proof = azks.get_append_only_proof(&db, 1, 3).await?;
 
         verify_append_only::<Blake3>(proof, start_hash, end_hash).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn future_epoch_throws_error() -> Result<(), AkdError> {
+        let db = AsyncInMemoryDatabase::new();
+        let azks = Azks::new::<_, Blake3>(&db).await?;
+
+        let out = azks.get_root_hash_at_epoch::<_, Blake3>(&db, 123).await;
+
+        let expected = Err::<_, HistoryTreeNodeError>(HistoryTreeNodeError::NonexistentAtEpoch(
+            NodeLabel::root(),
+            0,
+        ));
+        assert_eq!(expected, out);
         Ok(())
     }
 }

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for AkdError {
 }
 
 /// Errors thrown by HistoryTreeNodes
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum HistoryTreeNodeError {
     /// No direction provided for the node.
     /// Second parameter is the label of the child attempted to be set


### PR DESCRIPTION
At the moment, giving a future epoch just silently truncates and returns the "latest" root hash, when it should return an error stating that the epoch is invalid. This PR adds an error to protect against this so it throws a ```HistroryTreeNode::NonexistantAtEpoch(root_node_label, latest_epoch)``` error.