### PR TITLE
Add test covering deletion of stale ValueStates

### DIFF
--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -38,6 +38,18 @@ impl AsyncInMemoryDatabase {
             trans: Transaction::new(),
         }
     }
+
+    /// Deletes all user state except the most recent for given labels
+    pub async fn clean_user_state(&self, keys: &[AkdLabel]) {
+        let mut guard = self.user_info.write().await;
+
+        for key in keys {
+            let username = key.0.clone();
+            let values = guard.entry(username).or_insert_with(Vec::new);
+            values.reverse();
+            values.truncate(1);
+        }
+    }
 }
 
 impl Default for AsyncInMemoryDatabase {


### PR DESCRIPTION
This PR adds a test verifying that stale `ValueState` records can be deleted from storage without affecting AKD functionality. The scenario under which this may happen is described in #130 under **1. Stale ValueStates**.