### PR TITLE
Allow read operations during a publish

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -551,11 +551,7 @@ mod tests {
         let lookup_proof = akd.lookup(AkdLabel("hello".to_string())).await?;
         let current_azks = akd.retrieve_current_azks().await?;
         let root_hash = akd.get_root_hash::<Blake3>(&current_azks).await?;
-        lookup_verify::<Blake3_256<BaseElement>>(
-            root_hash,
-            AkdLabel("hello".to_string()),
-            lookup_proof,
-        )?;
+        lookup_verify::<Blake3>(root_hash, AkdLabel("hello".to_string()), lookup_proof)?;
         Ok(())
     }
 
@@ -645,7 +641,7 @@ mod tests {
         let history_proof = akd.key_history(&AkdLabel("hello".to_string())).await?;
         let (root_hashes, previous_root_hashes) =
             get_key_history_hashes(&akd, &history_proof).await?;
-        key_history_verify::<Blake3_256<BaseElement>>(
+        key_history_verify::<Blake3>(
             root_hashes,
             previous_root_hashes,
             AkdLabel("hello".to_string()),
@@ -655,7 +651,7 @@ mod tests {
         let history_proof = akd.key_history(&AkdLabel("hello2".to_string())).await?;
         let (root_hashes, previous_root_hashes) =
             get_key_history_hashes(&akd, &history_proof).await?;
-        key_history_verify::<Blake3_256<BaseElement>>(
+        key_history_verify::<Blake3>(
             root_hashes,
             previous_root_hashes,
             AkdLabel("hello2".to_string()),
@@ -665,7 +661,7 @@ mod tests {
         let history_proof = akd.key_history(&AkdLabel("hello3".to_string())).await?;
         let (root_hashes, previous_root_hashes) =
             get_key_history_hashes(&akd, &history_proof).await?;
-        key_history_verify::<Blake3_256<BaseElement>>(
+        key_history_verify::<Blake3>(
             root_hashes,
             previous_root_hashes,
             AkdLabel("hello3".to_string()),
@@ -675,7 +671,7 @@ mod tests {
         let history_proof = akd.key_history(&AkdLabel("hello4".to_string())).await?;
         let (root_hashes, previous_root_hashes) =
             get_key_history_hashes(&akd, &history_proof).await?;
-        key_history_verify::<Blake3_256<BaseElement>>(
+        key_history_verify::<Blake3>(
             root_hashes,
             previous_root_hashes,
             AkdLabel("hello4".to_string()),
@@ -772,7 +768,7 @@ mod tests {
         let current_azks = akd.retrieve_current_azks().await?;
 
         let audit_proof_1 = akd.audit(1, 2).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 1)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 2)
@@ -782,7 +778,7 @@ mod tests {
         .await?;
 
         let audit_proof_2 = akd.audit(1, 3).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 1)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 3)
@@ -792,7 +788,7 @@ mod tests {
         .await?;
 
         let audit_proof_3 = akd.audit(1, 4).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 1)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 4)
@@ -802,7 +798,7 @@ mod tests {
         .await?;
 
         let audit_proof_4 = akd.audit(1, 5).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 1)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 5)
@@ -812,7 +808,7 @@ mod tests {
         .await?;
 
         let audit_proof_5 = akd.audit(2, 3).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 2)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 3)
@@ -822,7 +818,7 @@ mod tests {
         .await?;
 
         let audit_proof_6 = akd.audit(2, 4).await?;
-        audit_verify::<Blake3_256<BaseElement>>(
+        audit_verify::<Blake3>(
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 2)
                 .await?,
             akd.get_root_hash_at_epoch::<Blake3>(&current_azks, 4)

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -885,7 +885,7 @@ mod tests {
         )
         .await?;
 
-        // Make the current a "checkpoint" to reset to later
+        // Make the current azks a "checkpoint" to reset to later
         let checkpoint_azks = akd.retrieve_current_azks().await.unwrap();
 
         // Publish for the third time

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -163,6 +163,8 @@ pub enum DirectoryError {
     VerifyLookupProof(String),
     /// Key-History proof did not verify
     VerifyKeyHistoryProof(String),
+    /// Tried to audit an invalid epoch range
+    InvalidEpoch(String),
     /// Error propagation
     Storage(StorageError),
 }
@@ -181,6 +183,9 @@ impl fmt::Display for DirectoryError {
                 write!(f, "The user {} did not exist at the epoch {}", uname, ep)
             }
             Self::VerifyKeyHistoryProof(err_string) => {
+                write!(f, "{}", err_string)
+            }
+            Self::InvalidEpoch(err_string) => {
                 write!(f, "{}", err_string)
             }
             Self::VerifyLookupProof(err_string) => {

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -107,7 +107,11 @@ impl Transaction {
         }
 
         // copy all the updated values out
-        let records = guard.mods.values().cloned().collect();
+        let mut records = guard.mods.values().cloned().collect::<Vec<_>>();
+
+        // sort according to transaction priority
+        records.sort_by_key(|r| r.transaction_priority());
+
         // flush the trans log
         (*guard).mods.clear();
 
@@ -167,5 +171,89 @@ impl Transaction {
 
         *(self.num_writes.write().await) += 1;
         debug!("END transaction set");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::append_only_zks::*;
+    use crate::history_tree_node::*;
+    use crate::node_state::*;
+    use crate::storage::types::*;
+    use rand::{rngs::OsRng, seq::SliceRandom};
+
+    #[tokio::test]
+    async fn test_commit_order() -> Result<(), StorageError> {
+        let azks = DbRecord::Azks(Azks {
+            num_nodes: 0,
+            latest_epoch: 0,
+        });
+        let node1 = DbRecord::HistoryTreeNode(HistoryTreeNode {
+            label: NodeLabel::new(0, 0),
+            birth_epoch: 1,
+            last_epoch: 1,
+            parent: NodeLabel::new(0, 0),
+            node_type: NodeType::Root,
+        });
+        let node2 = DbRecord::HistoryTreeNode(HistoryTreeNode {
+            label: NodeLabel::new(1, 1),
+            birth_epoch: 1,
+            last_epoch: 1,
+            parent: NodeLabel::new(0, 0),
+            node_type: NodeType::Leaf,
+        });
+        let node_state1 = DbRecord::HistoryNodeState(HistoryNodeState {
+            value: vec![],
+            child_states: [None, None],
+            key: NodeStateKey(NodeLabel::new(1, 1), 1),
+        });
+        let node_state2 = DbRecord::HistoryNodeState(HistoryNodeState {
+            value: vec![],
+            child_states: [None, None],
+            key: NodeStateKey(NodeLabel::new(1, 1), 2),
+        });
+        let value1 = DbRecord::ValueState(ValueState {
+            username: AkdLabel("test".to_string()),
+            epoch: 1,
+            label: NodeLabel::new(1, 1),
+            version: 1,
+            plaintext_val: AkdValue("abc123".to_string()),
+        });
+        let value2 = DbRecord::ValueState(ValueState {
+            username: AkdLabel("test".to_string()),
+            epoch: 2,
+            label: NodeLabel::new(1, 1),
+            version: 2,
+            plaintext_val: AkdValue("abc1234".to_string()),
+        });
+
+        let records = vec![azks, node1, node2, node_state1, node_state2, value1, value2];
+        let mut rng = OsRng;
+
+        for _ in 1..10 {
+            let mut txn = Transaction::new();
+            txn.begin_transaction().await;
+
+            // set values in a random order
+            let mut shuffled = records.clone();
+            shuffled.shuffle(&mut rng);
+            for record in shuffled {
+                txn.set(&record).await;
+            }
+
+            // ensure that commited records are in ascending priority
+            let mut running_priority = 0;
+            for record in txn.commit_transaction().await? {
+                let priority = record.transaction_priority();
+                if priority > running_priority {
+                    running_priority = priority;
+                } else if priority < running_priority {
+                    panic!("Transaction did not obey record priority when committing");
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -242,7 +242,7 @@ mod tests {
                 txn.set(&record).await;
             }
 
-            // ensure that commited records are in ascending priority
+            // ensure that committed records are in ascending priority
             let mut running_priority = 0;
             for record in txn.commit_transaction().await? {
                 let priority = record.transaction_priority();

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -168,6 +168,20 @@ impl DbRecord {
         }
     }
 
+    /// Returns the priority in which a record type in a transaction should be committed to storage.
+    /// A smaller value indicates higher priority in being written first.
+    /// An Azks record should always be updated last, so that any concurrent storage readers will
+    /// not see an increase in the current epoch until every other record for the new epoch has
+    /// been written to storage.
+    pub(crate) fn transaction_priority(&self) -> u8 {
+        match &self {
+            DbRecord::Azks(_) => 4,
+            DbRecord::HistoryNodeState(_) => 3,
+            DbRecord::HistoryTreeNode(_) => 1,
+            DbRecord::ValueState(_) => 2,
+        }
+    }
+
     /* Data Layer Builders */
 
     /// Build an azks instance from the properties

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -175,10 +175,8 @@ impl DbRecord {
     /// been written to storage.
     pub(crate) fn transaction_priority(&self) -> u8 {
         match &self {
-            DbRecord::Azks(_) => 4,
-            DbRecord::HistoryNodeState(_) => 3,
-            DbRecord::HistoryTreeNode(_) => 1,
-            DbRecord::ValueState(_) => 2,
+            DbRecord::Azks(_) => 2,
+            _ => 1,
         }
     }
 


### PR DESCRIPTION
This PR contains a series of changes that will allow multiple AKD instances (many readers and one writer) to safely access storage and perform operations. Reader operations are `Lookup`, `KeyHistory` and `Audit`, while the only write operation is `Publish`.

The main scenario this PR serves to handle is reading when the writer is in the middle of performing a `Publish`. Readers can choose to block on operations until the `Publish` is done, but that would introduce significant latency. Instead, I modify the reader's operations to ignore records in storage that are from an epoch that is not fully published.

We can tell that a publish is complete by having the writer update the `Azks` record last in the transaction. Until a reader sees an updated epoch in the `Azks` record, it will assume that the publish is not complete and ignore records from beyond the current `Azks` epoch.

Note: The commits are logically segregated and it might be easier to review them one-by-one.