### PR TITLE
Fix silently failing mysql tests

### DIFF
--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -599,7 +599,7 @@ impl<'a> AsyncMySqlDatabase {
                 }
             }
 
-            // Note that lines() returns the same number for lines with and without a final line ending.
+            // Note that lines().count() returns the same number for lines with and without a final line ending.
             let is_container_listed = std::str::from_utf8(&result.stdout).map(|str| str.lines().count() == NUM_LINES_EXPECTED);
             return is_container_listed.unwrap_or(false);
         }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -600,7 +600,8 @@ impl<'a> AsyncMySqlDatabase {
             }
 
             // Note that lines().count() returns the same number for lines with and without a final line ending.
-            let is_container_listed = std::str::from_utf8(&result.stdout).map(|str| str.lines().count() == NUM_LINES_EXPECTED);
+            let is_container_listed = std::str::from_utf8(&result.stdout)
+                .map(|str| str.lines().count() == NUM_LINES_EXPECTED);
             return is_container_listed.unwrap_or(false);
         }
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -590,6 +590,7 @@ impl<'a> AsyncMySqlDatabase {
             // 4bd11d9e28f2   ecac195d15af   "docker-entrypoint.s…"   4 minutes ago   Up 4 minutes   33060/tcp, 0.0.0.0:8001->3306/tcp, :::8001->3306/tcp   seemless-test-db
             //
             // so there should be 2 output lines assuming all is successful and the container is running.
+            const NUM_LINES_EXPECTED: usize = 2;
 
             let err = std::str::from_utf8(&result.stderr);
             if let Ok(error_message) = err {
@@ -598,8 +599,9 @@ impl<'a> AsyncMySqlDatabase {
                 }
             }
 
-            let lines = std::str::from_utf8(&result.stdout).map(|str| str.lines().count() > 2);
-            return lines.unwrap_or(false);
+            // Note that lines() returns the same number for lines with and without a final line ending.
+            let is_container_listed = std::str::from_utf8(&result.stdout).map(|str| str.lines().count() == NUM_LINES_EXPECTED);
+            return is_container_listed.unwrap_or(false);
         }
 
         // docker may have thrown an error, just fail


### PR DESCRIPTION
MySQL tests were silently failing due to output parser for docker container list expecting incorrect number of lines.

This PR fixes the issue. MySQL tests should run OK now.
