### PR TITLE
Fix MySQL tests

### DIFF
--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -1221,7 +1221,7 @@ impl Storage for AsyncMySqlDatabase {
                 ValueStateRetrievalFlag::MinEpoch => statement_text += " ORDER BY `epoch` ASC",
                 ValueStateRetrievalFlag::LeqEpoch(epoch) => {
                     params_map.push(("the_epoch", Value::from(epoch)));
-                    statement_text += " AND `epoch` <= :the_epoch";
+                    statement_text += " AND `epoch` <= :the_epoch ORDER BY `epoch` DESC";
                 }
             }
 

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -224,7 +224,7 @@ impl MySqlStorable for DbRecord {
             StorageType::HistoryNodeState => {
                 Some(
                     format!(
-                        "CREATE TEMPORARY TABLE `{}`(`label_len` INT UNSIGNED NOT NULL, `label_val` BIGINT UNSIGNED NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, PRIMARY KEY(`label_len`, `label_val`, `epoch`))",
+                        "CREATE TEMPORARY TABLE `{}`(`label_len` INT UNSIGNED NOT NULL, `label_val` VARBINARY(32) NOT NULL, `epoch` BIGINT UNSIGNED NOT NULL, PRIMARY KEY(`label_len`, `label_val`, `epoch`))",
                         TEMP_IDS_TABLE
                     )
                 )
@@ -232,7 +232,7 @@ impl MySqlStorable for DbRecord {
             StorageType::HistoryTreeNode => {
                 Some(
                     format!(
-                        "CREATE TEMPORARY TABLE `{}`(`label_len` INT UNSIGNED NOT NULL, `label_val` BIGINT UNSIGNED NOT NULL, PRIMARY KEY(`label_len`, `label_val`))",
+                        "CREATE TEMPORARY TABLE `{}`(`label_len` INT UNSIGNED NOT NULL, `label_val` VARBINARY(32) NOT NULL, PRIMARY KEY(`label_len`, `label_val`))",
                         TEMP_IDS_TABLE
                     )
                 )


### PR DESCRIPTION
MySQL tests were failing initially due to type mismatch in database tables. This PR includes the fix @slawlor suggested in Issue #156. 

After that fix, I started seeing hash lookup proof verification failures and tracked it down to [this](https://github.com/novifinancial/akd/commit/0604caae0adcd561ebe39406b5779f71b081fe83) commit and eventually to incorrect user state retrieval on the MySQL end when `LeqEpoch` is used. The issue is fixed by ordering the user state descending since the max value is needed.