### PR TITLE
Add lean history validation to akd_client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,10 +17,6 @@
                     "--features=sha3_256,nostd",
                     "--no-default-features"
                 ],
-                "filter": {
-                    "name": "akd_client",
-                    "kind": "lib"
-                }
             },
             "args": [],
             "cwd": "${workspaceFolder}"

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -124,6 +124,9 @@ pub enum VerificationErrorType {
     /// An error occurred verifying the lookup proof
     LookupProof,
 
+    /// An error occurred verifying the history proof
+    HistoryProof,
+
     /// An error occurred verifying a VRF label
     Vrf,
 
@@ -156,6 +159,7 @@ impl Display for VerificationError {
             VerificationErrorType::NoDirection => "No Direction",
             VerificationErrorType::MembershipProof => "Membership Proof",
             VerificationErrorType::LookupProof => "Lookup Proof",
+            VerificationErrorType::HistoryProof => "History Proof",
             VerificationErrorType::Vrf => "VRF",
             VerificationErrorType::Unknown => "Unknown",
         };

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -184,20 +184,12 @@ where
             existence_vrf_proof: proof.existence_vrf_proof.clone(),
             existence_at_ep: convert_membership_proof(&proof.existence_at_ep),
             previous_val_vrf_proof: proof.previous_val_vrf_proof.clone(),
-            previous_val_stale_at_ep: if proof.previous_val_stale_at_ep.is_some() {
-                Some(convert_membership_proof(
-                    &proof.previous_val_stale_at_ep.clone().unwrap(),
-                ))
-            } else {
-                None
-            },
-            non_existence_before_ep: if proof.non_existence_before_ep.is_some() {
-                Some(convert_non_membership_proof(
-                    &proof.non_existence_before_ep.clone().unwrap(),
-                ))
-            } else {
-                None
-            },
+            previous_val_stale_at_ep: proof.previous_val_stale_at_ep.clone().map(|val| convert_membership_proof(
+                &val
+            )),
+            non_existence_before_ep: proof.non_existence_before_ep.clone().map(|val| convert_non_membership_proof(
+                &val
+            )),
             next_few_vrf_proofs: proof.next_few_vrf_proofs.clone(),
             non_existence_of_next_few: proof
                 .non_existence_of_next_few

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -184,12 +184,14 @@ where
             existence_vrf_proof: proof.existence_vrf_proof.clone(),
             existence_at_ep: convert_membership_proof(&proof.existence_at_ep),
             previous_val_vrf_proof: proof.previous_val_vrf_proof.clone(),
-            previous_val_stale_at_ep: proof.previous_val_stale_at_ep.clone().map(|val| convert_membership_proof(
-                &val
-            )),
-            non_existence_before_ep: proof.non_existence_before_ep.clone().map(|val| convert_non_membership_proof(
-                &val
-            )),
+            previous_val_stale_at_ep: proof
+                .previous_val_stale_at_ep
+                .clone()
+                .map(|val| convert_membership_proof(&val)),
+            non_existence_before_ep: proof
+                .non_existence_before_ep
+                .clone()
+                .map(|val| convert_non_membership_proof(&val)),
             next_few_vrf_proofs: proof.next_few_vrf_proofs.clone(),
             non_existence_of_next_few: proof
                 .non_existence_of_next_few

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -58,6 +58,32 @@ where
     }
 }
 
+fn to_digest_vec<H>(hash_vec: Vec<H::Digest>) -> Vec<crate::types::Digest>
+where
+    H: winter_crypto::Hasher,
+{
+    let mut digest_vec = Vec::<crate::types::Digest>::new();
+    for hash_elem in hash_vec {
+        digest_vec.push(to_digest::<H>(hash_elem));
+    }
+    digest_vec
+}
+
+fn to_digest_vec_opt<H>(hash_vec: Vec<Option<H::Digest>>) -> Vec<Option<crate::types::Digest>>
+where
+    H: winter_crypto::Hasher,
+{
+    let mut digest_vec_opt = Vec::<Option<crate::types::Digest>>::new();
+    for hash_elem in hash_vec {
+        if let Some(h) = hash_elem {
+            digest_vec_opt.push(Some(to_digest::<H>(h)));
+        } else {
+            digest_vec_opt.push(None);
+        }
+    }
+    digest_vec_opt
+}
+
 fn convert_label(proof: akd::node_state::NodeLabel) -> crate::types::NodeLabel {
     crate::types::NodeLabel {
         len: proof.len,
@@ -143,6 +169,55 @@ where
     }
 }
 
+fn convert_history_proof<H>(
+    history_proof: &akd::proof_structs::HistoryProof<H>,
+) -> crate::types::HistoryProof
+where
+    H: winter_crypto::Hasher,
+{
+    let mut res_update_proofs = Vec::<crate::types::UpdateProof>::new();
+    for proof in &history_proof.proofs {
+        let update_proof = crate::types::UpdateProof {
+            epoch: proof.epoch,
+            plaintext_value: proof.plaintext_value.0.as_bytes().to_vec(),
+            version: proof.version,
+            existence_vrf_proof: proof.existence_vrf_proof.clone(),
+            existence_at_ep: convert_membership_proof(&proof.existence_at_ep),
+            previous_val_vrf_proof: proof.previous_val_vrf_proof.clone(),
+            previous_val_stale_at_ep: if proof.previous_val_stale_at_ep.is_some() {
+                Some(convert_membership_proof(
+                    &proof.previous_val_stale_at_ep.clone().unwrap(),
+                ))
+            } else {
+                None
+            },
+            non_existence_before_ep: if proof.non_existence_before_ep.is_some() {
+                Some(convert_non_membership_proof(
+                    &proof.non_existence_before_ep.clone().unwrap(),
+                ))
+            } else {
+                None
+            },
+            next_few_vrf_proofs: proof.next_few_vrf_proofs.clone(),
+            non_existence_of_next_few: proof
+                .non_existence_of_next_few
+                .iter()
+                .map(|non_memb_proof| convert_non_membership_proof(&non_memb_proof))
+                .collect(),
+            future_marker_vrf_proofs: proof.future_marker_vrf_proofs.clone(),
+            non_existence_of_future_markers: proof
+                .non_existence_of_future_markers
+                .iter()
+                .map(|non_exist_markers| convert_non_membership_proof(&non_exist_markers))
+                .collect(),
+        };
+        res_update_proofs.push(update_proof);
+    }
+    crate::types::HistoryProof {
+        proofs: res_update_proofs,
+    }
+}
+
 // ===================================
 // Test cases
 // ===================================
@@ -191,6 +266,120 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
     assert!(matches!(akd_result, Ok(())));
     assert!(matches!(lean_result, Ok(())));
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_history_proof_multiple_epochs() -> Result<(), AkdError> {
+    let db = InMemoryDb::new();
+    let vrf = HardCodedAkdVRF {};
+    let akd = Directory::new::<Hash>(&db, &vrf, false).await?;
+    let vrf_pk = akd.get_public_key().await.unwrap();
+    let key = AkdLabel("label".to_string());
+    let key_bytes = key.0.as_bytes().to_vec();
+    const EPOCHS: usize = 10;
+
+    // publishes key versions in multiple epochs
+    for epoch in 1..=EPOCHS {
+        let data = vec![(key.clone(), AkdValue(format!("value{}", epoch)))];
+        akd.publish::<Hash>(data, true).await?;
+    }
+
+    // retrieves and verifies history proofs for the key
+    let proof = akd.key_history::<Hash>(&key).await?;
+    let internal_proof = convert_history_proof::<Hash>(&proof);
+    let (mut root_hashes, previous_root_hashes) =
+        akd::directory::get_key_history_hashes::<_, Hash, HardCodedAkdVRF>(&akd, &proof)
+            .await
+            .unwrap();
+
+    // verifies num of root hashes created
+    assert_eq!(root_hashes.len(), EPOCHS);
+
+    // verifies both traditional and lean history verification passes
+    {
+        let akd_result = akd::client::key_history_verify::<Hash>(
+            &vrf_pk,
+            root_hashes.clone(),
+            previous_root_hashes.clone(),
+            key.clone(),
+            proof.clone(),
+        );
+        let lean_result = crate::verify::key_history_verify(
+            &vrf_pk.to_bytes(),
+            to_digest_vec::<Hash>(root_hashes.clone()),
+            to_digest_vec_opt::<Hash>(previous_root_hashes.clone()),
+            key_bytes.clone(),
+            internal_proof.clone(),
+        );
+        assert!(matches!(akd_result, Ok(())), "{:?}", akd_result);
+        assert!(matches!(lean_result, Ok(())), "{:?}", lean_result);
+    }
+
+    // corrupts root_hashes[0] and verifies both traditional and lean history verification fail
+    {
+        root_hashes[0] = root_hashes[1];
+        // performs traditional AKD verification
+        let akd_result = akd::client::key_history_verify::<Hash>(
+            &vrf_pk,
+            root_hashes.clone(),
+            previous_root_hashes.clone(),
+            key.clone(),
+            proof.clone(),
+        );
+        // performs "lean" history verification
+        let lean_result = crate::verify::key_history_verify(
+            &vrf_pk.to_bytes(),
+            to_digest_vec::<Hash>(root_hashes),
+            to_digest_vec_opt::<Hash>(previous_root_hashes),
+            key_bytes,
+            internal_proof,
+        );
+        assert!(akd_result.is_err(), "{:?}", akd_result);
+        assert!(lean_result.is_err(), "{:?}", lean_result);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_history_proof_single_epoch() -> Result<(), AkdError> {
+    let db = InMemoryDb::new();
+    let vrf = HardCodedAkdVRF {};
+    let akd = Directory::new::<Hash>(&db, &vrf, false).await?;
+    let vrf_pk = akd.get_public_key().await.unwrap();
+    let key = AkdLabel("label".to_string());
+    let key_bytes = key.0.as_bytes().to_vec();
+
+    // publishes single key-value
+    akd.publish::<Hash>(vec![(key.clone(), AkdValue(format!("value")))], true)
+        .await?;
+
+    // retrieves and verifies history proofs for the key
+    let proof = akd.key_history::<Hash>(&key).await?;
+    let internal_proof = convert_history_proof::<Hash>(&proof);
+    let (root_hashes, previous_root_hashes) =
+        akd::directory::get_key_history_hashes::<_, Hash, HardCodedAkdVRF>(&akd, &proof)
+            .await
+            .unwrap();
+    assert_eq!(root_hashes.len(), 1);
+
+    // verifies both traditional and lean history verification passes
+    let akd_result = akd::client::key_history_verify::<Hash>(
+        &vrf_pk,
+        root_hashes.clone(),
+        previous_root_hashes.clone(),
+        key,
+        proof,
+    );
+    let lean_result = crate::verify::key_history_verify(
+        &vrf_pk.to_bytes(),
+        to_digest_vec::<Hash>(root_hashes),
+        to_digest_vec_opt::<Hash>(previous_root_hashes),
+        key_bytes,
+        internal_proof,
+    );
+    assert!(matches!(akd_result, Ok(())), "{:?}", akd_result);
+    assert!(matches!(lean_result, Ok(())), "{:?}", lean_result);
     Ok(())
 }
 

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -196,3 +196,45 @@ pub struct LookupProof {
     /// Freshness proof (non member at previous epoch)
     pub freshness_proof: NonMembershipProof,
 }
+
+/// A vector of UpdateProofs are sent as the proof to a history query for a particular key.
+/// For each version of the value associated with the key, the verifier must check that:
+/// * the version was included in the claimed epoch,
+/// * the previous version was retired at this epoch,
+/// * the version did not exist prior to this epoch,
+/// * the next few versions (up until the next marker), did not exist at this epoch,
+/// * the future marker versions did  not exist at this epoch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateProof {
+    /// Epoch of this update
+    pub epoch: u64,
+    /// Value at this update
+    pub plaintext_value: AkdValue,
+    /// Version at this update
+    pub version: u64,
+    /// VRF proof for the label for the current version
+    pub existence_vrf_proof: Vec<u8>,
+    /// Membership proof to show that the key was included in this epoch
+    pub existence_at_ep: MembershipProof,
+    /// VRF proof for the label for the previous version which became stale
+    pub previous_val_vrf_proof: Option<Vec<u8>>,
+    /// Proof that previous value was set to old at this epoch
+    pub previous_val_stale_at_ep: Option<MembershipProof>,
+    /// Proof that this value didn't exist prior to this ep
+    pub non_existence_before_ep: Option<NonMembershipProof>,
+    /// VRF Proofs for the labels of the next few values
+    pub next_few_vrf_proofs: Vec<Vec<u8>>,
+    /// Proof that the next few values did not exist at this time
+    pub non_existence_of_next_few: Vec<NonMembershipProof>,
+    /// VRF proofs for the labels of future marker entries
+    pub future_marker_vrf_proofs: Vec<Vec<u8>>,
+    /// Proof that future markers did not exist
+    pub non_existence_of_future_markers: Vec<NonMembershipProof>,
+}
+
+/// This proof is just an array of [`UpdateProof`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryProof {
+    /// The update proofs in the key history
+    pub proofs: Vec<UpdateProof>,
+}

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -204,6 +204,7 @@ pub struct LookupProof {
 /// * the version did not exist prior to this epoch,
 /// * the next few versions (up until the next marker), did not exist at this epoch,
 /// * the future marker versions did  not exist at this epoch.
+#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateProof {
     /// Epoch of this update
@@ -233,6 +234,7 @@ pub struct UpdateProof {
 }
 
 /// This proof is just an array of [`UpdateProof`]s.
+#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryProof {
     /// The update proofs in the key history

--- a/akd_client/src/utils.rs
+++ b/akd_client/src/utils.rs
@@ -8,7 +8,6 @@
 //! Utility functions
 
 /// Retrieve the marker version
-#[cfg(feature = "vrf")]
 pub(crate) fn get_marker_version(version: u64) -> u64 {
     64u64 - (version.leading_zeros() as u64) - 1u64
 }

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -16,7 +16,7 @@ use core::convert::TryFrom;
 
 use crate::hash::*;
 use crate::types::*;
-use crate::{verify_error, VerificationError, ARITY};
+use crate::{verify_error, VerificationError, VerificationErrorType, ARITY};
 
 /// Verify the membership proof
 fn verify_membership(root_hash: Digest, proof: &MembershipProof) -> Result<(), VerificationError> {
@@ -69,6 +69,12 @@ fn verify_nonmembership(
         lcp_hash = merge(&[lcp_hash, child_hash]);
         lcp_real = lcp_real.get_longest_common_prefix(proof.longest_prefix_children[i].label);
     }
+    if lcp_real == EMPTY_LABEL {
+        lcp_real = NodeLabel {
+            val: [0u8; 32],
+            len: 0,
+        };
+    }
     // lcp_hash = H::merge(&[lcp_hash, hash_label::<H>(proof.longest_prefix)]);
     verified = verified && (lcp_hash == proof.longest_prefix_membership_proof.hash_val);
     if !verified {
@@ -78,9 +84,9 @@ fn verify_nonmembership(
             "lcp_hash != longest_prefix_hash".to_string()
         ));
     }
-    let _sib_len = proof.longest_prefix_membership_proof.layer_proofs.len();
-    let _longest_prefix_verified =
-        verify_membership(root_hash, &proof.longest_prefix_membership_proof)?;
+
+    verify_membership(root_hash, &proof.longest_prefix_membership_proof)?;
+
     // The audit must have checked that this node is indeed the lcp of its children.
     // So we can just check that one of the children's lcp is = the proof.longest_prefix
     verified = verified && (proof.longest_prefix == lcp_real);
@@ -173,5 +179,169 @@ pub fn lookup_verify(
 
     verify_nonmembership(root_hash, &freshness_proof)?;
 
+    Ok(())
+}
+
+/// Verifies a key history proof, given the corresponding sequence of hashes.
+pub fn key_history_verify(
+    _vrf_public_key: &[u8],
+    root_hashes: Vec<Digest>,
+    previous_root_hashes: Vec<Option<Digest>>,
+    _akd_key: AkdLabel,
+    proof: HistoryProof,
+) -> Result<(), VerificationError> {
+    for (count, update_proof) in proof.proofs.into_iter().enumerate() {
+        let root_hash = root_hashes[count];
+        let previous_root_hash = previous_root_hashes[count];
+        verify_single_update_proof(
+            root_hash,
+            &_vrf_public_key,
+            previous_root_hash,
+            update_proof,
+            &_akd_key,
+        )?;
+    }
+    // use crate::VerificationErrorType;
+    // Err(VerificationError {error_message: "Not implemented".to_string(), error_type: VerificationErrorType::Unknown})
+    Ok(())
+}
+
+/// Verifies a single update proof
+fn verify_single_update_proof(
+    root_hash: Digest,
+    _vrf_public_key: &[u8],
+    previous_root_hash: Option<Digest>,
+    proof: UpdateProof,
+    uname: &AkdLabel,
+) -> Result<(), VerificationError> {
+    let epoch = proof.epoch;
+    let _plaintext_value = &proof.plaintext_value;
+    let version = proof.version;
+
+    let existence_at_ep_ref = &proof.existence_at_ep;
+    let existence_at_ep = existence_at_ep_ref;
+
+    let previous_val_stale_at_ep = &proof.previous_val_stale_at_ep;
+    let non_existence_before_ep = &proof.non_existence_before_ep;
+
+    // ***** PART 1 ***************************
+    // Verify the VRF and membership proof for the corresponding label for the version being updated to.
+    #[cfg(feature = "vrf")]
+    {
+        verify_vrf(
+            &_vrf_public_key,
+            &uname,
+            false,
+            version,
+            &proof.existence_vrf_proof,
+            existence_at_ep_ref.label,
+        )?;
+    }
+    verify_membership(root_hash, existence_at_ep)?;
+
+    // ***** PART 2 ***************************
+    // Edge case here! We need to account for version = 1 where the previous version won't have a proof.
+    if version > 1 {
+        // Verify the membership proof the for stale label of the previous version
+        let err_str = format!(
+            "Staleness proof of user {:?}'s version {:?} at epoch {:?} is None",
+            uname,
+            (version - 1),
+            epoch
+        );
+        let previous_null_err = VerificationError {
+            error_message: err_str,
+            error_type: VerificationErrorType::HistoryProof,
+        };
+        let previous_val_stale_at_ep =
+            previous_val_stale_at_ep.as_ref().ok_or(previous_null_err)?;
+        verify_membership(root_hash, previous_val_stale_at_ep)?;
+
+        #[cfg(feature = "vrf")]
+        {
+            let vrf_err_str = format!(
+                "Staleness proof of user {:?}'s version {:?} at epoch {:?} is None",
+                uname,
+                (version - 1),
+                epoch
+            );
+
+            // Verify the VRF for the stale label corresponding to the previous version for this username
+            let vrf_previous_null_err = VerificationError {
+                error_message: vrf_err_str,
+                error_type: VerificationErrorType::HistoryProof,
+            };
+            let previous_val_vrf_proof = proof
+                .previous_val_vrf_proof
+                .as_ref()
+                .ok_or(vrf_previous_null_err)?;
+
+            verify_vrf(
+                &_vrf_public_key,
+                &uname,
+                true,
+                version - 1,
+                &previous_val_vrf_proof,
+                previous_val_stale_at_ep.label,
+            )?;
+        }
+    }
+
+    // ***** PART 3 ***************************
+    // Verify that the current version was only added in this epoch and didn't exist before.
+    if epoch > 1 {
+        let root_hash = previous_root_hash.ok_or(VerificationError {
+            error_message: "No previous root hash given".to_string(),
+            error_type: VerificationErrorType::HistoryProof,
+        })?;
+        verify_nonmembership(
+            root_hash,
+            non_existence_before_ep.as_ref().ok_or_else(|| VerificationError {error_message: format!(
+                "Non-existence before this epoch proof of user {:?}'s version {:?} at epoch {:?} is None",
+                uname,
+                version,
+                epoch
+            ), error_type: VerificationErrorType::HistoryProof})?
+        )?;
+    }
+
+    // Get the least and greatest marker entries for the current version
+    let next_marker = crate::utils::get_marker_version(version) + 1;
+    let final_marker = crate::utils::get_marker_version(epoch);
+
+    // ***** PART 4 ***************************
+    // Verify the VRFs and non-membership of future entries, up to the next marker
+    for (i, ver) in (version + 1..(1 << next_marker)).enumerate() {
+        let pf = &proof.non_existence_of_next_few[i];
+        #[cfg(feature = "vrf")]
+        {
+            let vrf_pf = &proof.next_few_vrf_proofs[i];
+            let ver_label = pf.label;
+            verify_vrf(&_vrf_public_key, uname, false, ver, &vrf_pf, ver_label)?;
+        }
+        if !verify_nonmembership(root_hash, pf)? {
+            return Err(VerificationError {error_message:
+                    format!("Non-existence before epoch proof of user {:?}'s version {:?} at epoch {:?} does not verify",
+                    uname, ver, epoch-1), error_type: VerificationErrorType::HistoryProof});
+        }
+    }
+
+    // ***** PART 5 ***************************
+    // Verify the VRFs and non-membership proofs for future markers
+    for (i, pow) in (next_marker + 1..final_marker).enumerate() {
+        let ver = 1 << pow;
+        let pf = &proof.non_existence_of_future_markers[i];
+        #[cfg(feature = "vrf")]
+        {
+            let vrf_pf = &proof.future_marker_vrf_proofs[i];
+            let ver_label = pf.label;
+            verify_vrf(&_vrf_public_key, uname, false, ver, &vrf_pf, ver_label)?;
+        }
+        if !verify_nonmembership(root_hash, pf)? {
+            return Err(VerificationError {error_message:
+                    format!("Non-existence before epoch proof of user {:?}'s version {:?} at epoch {:?} does not verify",
+                    uname, ver, epoch-1), error_type: VerificationErrorType::HistoryProof});
+        }
+    }
     Ok(())
 }

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -184,7 +184,7 @@ pub fn lookup_verify(
 
 /// Verifies a key history proof, given the corresponding sequence of hashes.
 pub fn key_history_verify(
-    _vrf_public_key: &[u8],
+    vrf_public_key: &[u8],
     root_hashes: Vec<Digest>,
     previous_root_hashes: Vec<Option<Digest>>,
     _akd_key: AkdLabel,
@@ -195,7 +195,7 @@ pub fn key_history_verify(
         let previous_root_hash = previous_root_hashes[count];
         verify_single_update_proof(
             root_hash,
-            &_vrf_public_key,
+            vrf_public_key,
             previous_root_hash,
             update_proof,
             &_akd_key,
@@ -209,7 +209,7 @@ pub fn key_history_verify(
 /// Verifies a single update proof
 fn verify_single_update_proof(
     root_hash: Digest,
-    _vrf_public_key: &[u8],
+    vrf_public_key: &[u8],
     previous_root_hash: Option<Digest>,
     proof: UpdateProof,
     uname: &AkdLabel,
@@ -229,8 +229,8 @@ fn verify_single_update_proof(
     #[cfg(feature = "vrf")]
     {
         verify_vrf(
-            &_vrf_public_key,
-            &uname,
+            vrf_public_key,
+            uname,
             false,
             version,
             &proof.existence_vrf_proof,
@@ -277,11 +277,11 @@ fn verify_single_update_proof(
                 .ok_or(vrf_previous_null_err)?;
 
             verify_vrf(
-                &_vrf_public_key,
-                &uname,
+                vrf_public_key,
+                uname,
                 true,
                 version - 1,
-                &previous_val_vrf_proof,
+                previous_val_vrf_proof,
                 previous_val_stale_at_ep.label,
             )?;
         }
@@ -317,7 +317,7 @@ fn verify_single_update_proof(
         {
             let vrf_pf = &proof.next_few_vrf_proofs[i];
             let ver_label = pf.label;
-            verify_vrf(&_vrf_public_key, uname, false, ver, &vrf_pf, ver_label)?;
+            verify_vrf(vrf_public_key, uname, false, ver, vrf_pf, ver_label)?;
         }
         if !verify_nonmembership(root_hash, pf)? {
             return Err(VerificationError {error_message:
@@ -335,7 +335,7 @@ fn verify_single_update_proof(
         {
             let vrf_pf = &proof.future_marker_vrf_proofs[i];
             let ver_label = pf.label;
-            verify_vrf(&_vrf_public_key, uname, false, ver, &vrf_pf, ver_label)?;
+            verify_vrf(vrf_public_key, uname, false, ver, vrf_pf, ver_label)?;
         }
         if !verify_nonmembership(root_hash, pf)? {
             return Err(VerificationError {error_message:

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -187,7 +187,7 @@ pub fn key_history_verify(
     vrf_public_key: &[u8],
     root_hashes: Vec<Digest>,
     previous_root_hashes: Vec<Option<Digest>>,
-    _akd_key: AkdLabel,
+    akd_key: AkdLabel,
     proof: HistoryProof,
 ) -> Result<(), VerificationError> {
     for (count, update_proof) in proof.proofs.into_iter().enumerate() {
@@ -198,11 +198,9 @@ pub fn key_history_verify(
             vrf_public_key,
             previous_root_hash,
             update_proof,
-            &_akd_key,
+            &akd_key,
         )?;
     }
-    // use crate::VerificationErrorType;
-    // Err(VerificationError {error_message: "Not implemented".to_string(), error_type: VerificationErrorType::Unknown})
     Ok(())
 }
 


### PR DESCRIPTION
This change adds history proof validation support to akd_client crate with tests, see #143. Validation logic borrowed from akd::client::key_history_verify and should be kept in sync.

For tests run `cargo test -p akd_client`

### Context
The akd_client relies on as few dependencies as possible, so that when it compiles it leaves a smaller footprint as possible for embedded applications (phone clients; web). If one needs richer functionality, for example auditing, full AKD crate should be used.