### PR TITLE
Merge bulk lookup proofs

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -24,6 +24,7 @@ use tokio::time::Instant;
 use winter_crypto::{Digest, Hasher};
 
 use keyed_priority_queue::{Entry, KeyedPriorityQueue};
+use std::collections::HashSet;
 
 /// The default azks key
 pub const DEFAULT_AZKS_KEY: u8 = 1u8;
@@ -132,9 +133,6 @@ impl Azks {
         storage: &S,
         insertion_set: &[Node<H>],
     ) -> Result<u64, AkdError> {
-        let mut load_count: u64 = 0;
-        let mut current_nodes = vec![NodeKey(NodeLabel::root())];
-
         let prefixes_set = crate::utils::build_prefixes_set(
             insertion_set
                 .iter()
@@ -142,6 +140,18 @@ impl Azks {
                 .collect::<Vec<NodeLabel>>()
                 .as_ref(),
         );
+
+        self.bfs_preload_nodes::<S, H>(storage, prefixes_set).await
+    }
+
+    /// Preloads given nodes using breadth-first search.
+    pub async fn bfs_preload_nodes<S: Storage + Sync + Send, H: Hasher>(
+        &self,
+        storage: &S,
+        nodes_to_load: HashSet<NodeLabel>,
+    ) -> Result<u64, AkdError> {
+        let mut load_count: u64 = 0;
+        let mut current_nodes = vec![NodeKey(NodeLabel::root())];
 
         while !current_nodes.is_empty() {
             let nodes = HistoryTreeNode::batch_get_from_storage(
@@ -166,7 +176,7 @@ impl Azks {
             // Note, the two for loops are needed because otherwise, you'd be accessing remote storage
             // individually for each node's state.
             for node in &nodes {
-                if !prefixes_set.contains(&node.label) {
+                if !nodes_to_load.contains(&node.label) {
                     // Only continue to traverse nodes which are relevant prefixes to insertion_set
                     continue;
                 }
@@ -331,7 +341,6 @@ impl Azks {
                         self.get_latest_epoch(),
                     )
                     .await?;
-                    println!("Label of child {} is {:?}", i, unwrapped_child.label);
                     longest_prefix_children[i] = Node {
                         label: unwrapped_child.label,
                         hash: unwrapped_child
@@ -341,7 +350,6 @@ impl Azks {
                 }
             }
         }
-        println!("Lcp label = {:?}", longest_prefix);
         Ok(NonMembershipProof {
             label,
             longest_prefix,

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -230,8 +230,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             .get_root_hash_at_epoch::<_, H>(&self.storage, next_epoch)
             .await?;
 
-        // self.storage.log_metrics(log::Level::Info).await;
-
         Ok(EpochHash(current_epoch, root_hash))
         // At the moment the tree root is not being written anywhere. Eventually we
         // want to change this to call a write operation to post to a blockchain or some such thing
@@ -299,8 +297,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                 .await?,
         };
 
-        // self.storage.log_metrics(log::Level::Info).await;
-
         Ok(lookup_proof)
     }
 
@@ -352,8 +348,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                 .await?,
             );
         }
-
-        // self.storage.log_metrics(log::Level::Info).await;
 
         Ok(lookup_proofs)
     }

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -22,6 +22,7 @@ use log::{debug, error, info};
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 
+use crate::node_state::NodeLabel;
 use std::collections::HashMap;
 use std::marker::{Send, Sync};
 use std::sync::Arc;
@@ -30,6 +31,16 @@ use winter_crypto::Hasher;
 /// Root hash of the tree and its associated epoch
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct EpochHash<H: Hasher>(pub u64, pub H::Digest);
+
+#[derive(Clone)]
+/// Info needed for a lookup of a user for an epoch
+pub struct LookupInfo {
+    value_state: ValueState,
+    marker_version: u64,
+    existent_label: NodeLabel,
+    marker_label: NodeLabel,
+    non_existent_label: NodeLabel,
+}
 
 #[cfg(feature = "rand")]
 impl AkdValue {
@@ -219,7 +230,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             .get_root_hash_at_epoch::<_, H>(&self.storage, next_epoch)
             .await?;
 
-        self.storage.log_metrics(log::Level::Info).await;
+        // self.storage.log_metrics(log::Level::Info).await;
 
         Ok(EpochHash(current_epoch, root_hash))
         // At the moment the tree root is not being written anywhere. Eventually we
@@ -233,68 +244,155 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
         let current_azks = self.retrieve_current_azks().await?;
         let current_epoch = current_azks.get_latest_epoch();
+        let lookup_info = self
+            .get_lookup_info::<H>(uname.clone(), current_epoch)
+            .await?;
+        let lookup_proof = self
+            .lookup_with_info::<H>(uname, &current_azks, current_epoch, lookup_info)
+            .await;
+        lookup_proof
+    }
 
+    async fn lookup_with_info<H: Hasher>(
+        &self,
+        uname: AkdLabel,
+        current_azks: &Azks,
+        current_epoch: u64,
+        lookup_info: LookupInfo,
+    ) -> Result<LookupProof<H>, AkdError> {
+        let current_version = lookup_info.value_state.version;
+
+        let lookup_proof = LookupProof {
+            epoch: current_epoch,
+            plaintext_value: lookup_info.value_state.plaintext_val,
+            version: lookup_info.value_state.version,
+            exisitence_vrf_proof: self
+                .vrf
+                .get_label_proof::<H>(&uname, false, current_version)
+                .await?
+                .to_bytes()
+                .to_vec(),
+            existence_proof: current_azks
+                .get_membership_proof(&self.storage, lookup_info.existent_label, current_epoch)
+                .await?,
+            marker_vrf_proof: self
+                .vrf
+                .get_label_proof::<H>(&uname, false, lookup_info.marker_version)
+                .await?
+                .to_bytes()
+                .to_vec(),
+            marker_proof: current_azks
+                .get_membership_proof(&self.storage, lookup_info.marker_label, current_epoch)
+                .await?,
+            freshness_vrf_proof: self
+                .vrf
+                .get_label_proof::<H>(&uname, true, current_version)
+                .await?
+                .to_bytes()
+                .to_vec(),
+            freshness_proof: current_azks
+                .get_non_membership_proof(
+                    &self.storage,
+                    lookup_info.non_existent_label,
+                    current_epoch,
+                )
+                .await?,
+        };
+
+        // self.storage.log_metrics(log::Level::Info).await;
+
+        Ok(lookup_proof)
+    }
+
+    // TODO(eoz): Call proof generations async
+    /// Allows efficient batch lookups by preloading necessary nodes for the lookups.
+    pub async fn batch_lookup<H: Hasher>(
+        &self,
+        unames: &[AkdLabel],
+    ) -> Result<Vec<LookupProof<H>>, AkdError> {
+        let current_azks = self.retrieve_current_azks().await?;
+        let current_epoch = current_azks.get_latest_epoch();
+
+        // Take a union of the labels we will need proofs of for each lookup.
+        let mut lookup_labels = Vec::new();
+        let mut lookup_infos = Vec::new();
+        for uname in unames {
+            // Save lookup info for later use.
+            let lookup_info = self
+                .get_lookup_info::<H>(uname.clone(), current_epoch)
+                .await?;
+            lookup_infos.push(lookup_info.clone());
+
+            // A lookup proofs consists of the proofs for the following labels.
+            lookup_labels.push(lookup_info.existent_label);
+            lookup_labels.push(lookup_info.marker_label);
+            lookup_labels.push(lookup_info.non_existent_label);
+        }
+
+        // Create a union of set of prefixes we will need for lookups.
+        let lookup_prefixes_set = crate::utils::build_lookup_prefixes_set(&lookup_labels);
+
+        // Load nodes.
+        current_azks
+            .bfs_preload_nodes::<_, H>(&self.storage, lookup_prefixes_set)
+            .await?;
+
+        // Ensure we have got all lookup infos needed.
+        assert_eq!(unames.len(), lookup_infos.len());
+
+        let mut lookup_proofs = Vec::new();
+        for i in 0..unames.len() {
+            lookup_proofs.push(
+                self.lookup_with_info::<H>(
+                    unames[i].clone(),
+                    &current_azks,
+                    current_epoch,
+                    lookup_infos[i].clone(),
+                )
+                .await?,
+            );
+        }
+
+        // self.storage.log_metrics(log::Level::Info).await;
+
+        Ok(lookup_proofs)
+    }
+
+    async fn get_lookup_info<H: Hasher>(
+        &self,
+        uname: AkdLabel,
+        epoch: u64,
+    ) -> Result<LookupInfo, AkdError> {
         match self
             .storage
-            .get_user_state(&uname, ValueStateRetrievalFlag::LeqEpoch(current_epoch))
+            .get_user_state(&uname, ValueStateRetrievalFlag::LeqEpoch(epoch))
             .await
         {
             Err(_) => {
                 // Need to throw an error
                 Err(AkdError::Directory(DirectoryError::NonExistentUser(
-                    uname.0,
-                    current_epoch,
+                    uname.clone().0,
+                    epoch,
                 )))
             }
             Ok(latest_st) => {
                 // Need to account for the case where the latest state is
                 // added but the database is in the middle of an update
-                let current_version = latest_st.version;
-                let marker_version = 1 << get_marker_version(current_version);
-                let existent_label = self
-                    .vrf
-                    .get_node_label::<H>(&uname, false, current_version)
-                    .await?;
+                let version = latest_st.version;
+                let marker_version = 1 << get_marker_version(version);
+                let existent_label = self.vrf.get_node_label::<H>(&uname, false, version).await?;
                 let marker_label = self
                     .vrf
                     .get_node_label::<H>(&uname, false, marker_version)
                     .await?;
-                let non_existent_label = self
-                    .vrf
-                    .get_node_label::<H>(&uname, true, current_version)
-                    .await?;
-                let current_azks = self.retrieve_current_azks().await?;
-                Ok(LookupProof {
-                    epoch: current_epoch,
-                    plaintext_value: latest_st.plaintext_val,
-                    version: current_version,
-                    exisitence_vrf_proof: self
-                        .vrf
-                        .get_label_proof::<H>(&uname, false, current_version)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                    existence_proof: current_azks
-                        .get_membership_proof(&self.storage, existent_label, current_epoch)
-                        .await?,
-                    marker_vrf_proof: self
-                        .vrf
-                        .get_label_proof::<H>(&uname, false, marker_version)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                    marker_proof: current_azks
-                        .get_membership_proof(&self.storage, marker_label, current_epoch)
-                        .await?,
-                    freshness_vrf_proof: self
-                        .vrf
-                        .get_label_proof::<H>(&uname, true, current_version)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                    freshness_proof: current_azks
-                        .get_non_membership_proof(&self.storage, non_existent_label, current_epoch)
-                        .await?,
+                let non_existent_label =
+                    self.vrf.get_node_label::<H>(&uname, true, version).await?;
+                Ok(LookupInfo {
+                    value_state: latest_st,
+                    marker_version,
+                    existent_label,
+                    marker_label,
+                    non_existent_label,
                 })
             }
         }

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -148,6 +148,12 @@ impl NodeLabel {
         Self::new(out_val, len)
     }
 
+    // The sibling of a node in a binary tree has the same label as its sibling
+    // except its last bit is flipped (e.g., 000 and 001 are siblings).
+    // This function returns the sibling prefix of a specified length.
+    // The rest of the node label after the flipped bit is padded with zeroes.
+    // For instance, 010100 (length = 6) with sibling prefix length = 3 is 01[1]000 (length = 3)
+    // -- [bit] denoting flipped bit.
     pub(crate) fn get_sibling_prefix(&self, mut len: u32) -> Self {
         if len > self.get_len() {
             len = self.get_len();

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -27,6 +27,24 @@ pub(crate) fn build_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
     prefixes_set
 }
 
+pub(crate) fn build_lookup_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
+    let mut lookup_prefixes_set = HashSet::new();
+    for label in labels {
+        // We need the actual node for lookup too
+        lookup_prefixes_set.insert(*label);
+        for len in 0..(label.get_len() + 1) {
+            // Sibling prefixes unfortunately do not cover all the nodes we will need for
+            // a lookup proof. Although we can figure out which nodes are exactly needed
+            // this will require basically doing a pre-lookup.
+            // Instead here we load the prefixes as well.
+            // This combination (sibling- + self-prefixes) covers all the nodes we need.
+            lookup_prefixes_set.insert(label.get_prefix(len));
+            lookup_prefixes_set.insert(label.get_sibling_prefix(len));
+        }
+    }
+    lookup_prefixes_set
+}
+
 pub(crate) fn empty_node_hash<H: Hasher>() -> H::Digest {
     H::merge(&[H::hash(&EMPTY_VALUE), hash_label::<H>(EMPTY_LABEL)])
 }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -564,7 +564,7 @@ impl<'a> AsyncMySqlDatabase {
         }
         let call_count = (*stats)
             .entry(caller_name + &"~".to_string() + &data_type)
-            .or_insert(1);
+            .or_insert(0);
         *call_count += 1;
     }
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -79,7 +79,9 @@ pub struct AsyncMySqlDatabase {
     trans: LocalTransaction,
 
     num_reads: Arc<tokio::sync::RwLock<u64>>,
+    read_call_stats: Arc<tokio::sync::RwLock<HashMap<String, u64>>>,
     num_writes: Arc<tokio::sync::RwLock<u64>>,
+    write_call_stats: Arc<tokio::sync::RwLock<HashMap<String, u64>>>,
     time_read: Arc<tokio::sync::RwLock<Duration>>,
     time_write: Arc<tokio::sync::RwLock<Duration>>,
 
@@ -118,7 +120,9 @@ impl Clone for AsyncMySqlDatabase {
             trans: LocalTransaction::new(),
 
             num_reads: self.num_reads.clone(),
+            read_call_stats: self.read_call_stats.clone(),
             num_writes: self.num_writes.clone(),
+            write_call_stats: self.write_call_stats.clone(),
             time_read: self.time_read.clone(),
             time_write: self.time_write.clone(),
 
@@ -169,7 +173,9 @@ impl<'a> AsyncMySqlDatabase {
             trans: LocalTransaction::new(),
 
             num_reads: Arc::new(tokio::sync::RwLock::new(0)),
+            read_call_stats: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             num_writes: Arc::new(tokio::sync::RwLock::new(0)),
+            write_call_stats: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             time_read: Arc::new(tokio::sync::RwLock::new(Duration::from_millis(0))),
             time_write: Arc::new(tokio::sync::RwLock::new(Duration::from_millis(0))),
 
@@ -412,6 +418,8 @@ impl<'a> AsyncMySqlDatabase {
         trans: Option<mysql_async::Transaction<'a>>,
     ) -> Result<()> {
         *(self.num_writes.write().await) += 1;
+        self.record_call_stats('w', "internal_set".to_string(), "".to_string())
+            .await;
 
         debug!("BEGIN MySQL set");
         let tic = Instant::now();
@@ -454,6 +462,8 @@ impl<'a> AsyncMySqlDatabase {
         }
 
         *(self.num_writes.write().await) += records.len() as u64;
+        self.record_call_stats('w', "internal_batch_set".to_string(), "".to_string())
+            .await;
 
         debug!("BEGIN Computing mysql parameters");
         #[allow(clippy::needless_collect)]
@@ -541,6 +551,21 @@ impl<'a> AsyncMySqlDatabase {
             .await?;
 
         Ok(())
+    }
+
+    async fn record_call_stats(&self, call_type: char, caller_name: String, data_type: String) {
+        let mut stats;
+        if call_type == 'r' {
+            stats = self.read_call_stats.write().await;
+        } else if call_type == 'w' {
+            stats = self.write_call_stats.write().await;
+        } else {
+            panic!("Unknown call type to record call stats for.")
+        }
+        let call_count = (*stats)
+            .entry(caller_name + &"~".to_string() + &data_type)
+            .or_insert(1);
+        *call_count += 1;
     }
 
     fn try_dockers() -> std::io::Result<std::process::Output> {
@@ -674,12 +699,20 @@ impl Storage for AsyncMySqlDatabase {
         }
 
         let mut r = self.num_reads.write().await;
+        let mut rcs = self.read_call_stats.write().await;
         let mut w = self.num_writes.write().await;
+        let mut wcs = self.write_call_stats.write().await;
         let mut tr = self.time_read.write().await;
         let mut tw = self.time_write.write().await;
 
+        // Sort call stats for consistency.
+        let mut rcs_vec = (*rcs).iter().collect::<Vec<_>>();
+        let mut wcs_vec = (*wcs).iter().collect::<Vec<_>>();
+        rcs_vec.sort_by_key(|rc| rc.0);
+        wcs_vec.sort_by_key(|wc| wc.0);
+
         let msg = format!(
-            "MySQL writes: {}, MySQL reads: {}, Time read: {} s, Time write: {} s\n\t{}\n\t{}\n\t{}",
+            "MySQL writes: {}, MySQL reads: {}, Time read: {} s, Time write: {} s\n\t{}\n\t{}\n\t{}\nRead call stats: {:?}\nWrite call stats: {:?}\n",
             *w,
             *r,
             (*tr).as_secs_f64(),
@@ -687,10 +720,14 @@ impl Storage for AsyncMySqlDatabase {
             tree_size,
             node_state_size,
             value_state_size,
+            rcs_vec,
+            wcs_vec,
         );
 
         *r = 0;
+        *rcs = HashMap::new();
         *w = 0;
+        *wcs = HashMap::new();
         *tr = Duration::from_millis(0);
         *tw = Duration::from_millis(0);
 
@@ -890,6 +927,12 @@ impl Storage for AsyncMySqlDatabase {
         id: St::Key,
     ) -> core::result::Result<DbRecord, StorageError> {
         *(self.num_reads.write().await) += 1;
+        self.record_call_stats(
+            'r',
+            "get_direct:".to_string(),
+            format!("{:?}", St::data_type()),
+        )
+        .await;
 
         debug!("BEGIN MySQL get {:?}", id);
         let result = async {
@@ -1085,6 +1128,12 @@ impl Storage for AsyncMySqlDatabase {
             };
 
             *(self.num_reads.write().await) += 1;
+            self.record_call_stats(
+                'r',
+                "batch_get".to_string(),
+                format!("{:?}", St::data_type()),
+            )
+            .await;
 
             match result.await {
                 Ok(result_vec) => {
@@ -1105,6 +1154,9 @@ impl Storage for AsyncMySqlDatabase {
         // This is the same as previous logic under "get_all"
 
         *(self.num_reads.write().await) += 1;
+        self.record_call_stats('r', "get_user_data".to_string(), "".to_string())
+            .await;
+
         // DO NOT log the user info, it's PII in the future
         debug!("BEGIN MySQL get user data");
         let result = async {
@@ -1198,6 +1250,8 @@ impl Storage for AsyncMySqlDatabase {
         flag: ValueStateRetrievalFlag,
     ) -> core::result::Result<ValueState, StorageError> {
         *(self.num_reads.write().await) += 1;
+        self.record_call_stats('r', "get_user_state".to_string(), "".to_string())
+            .await;
 
         debug!("BEGIN MySQL get user state (flag {:?})", flag);
         let result = async {
@@ -1309,6 +1363,8 @@ impl Storage for AsyncMySqlDatabase {
         flag: ValueStateRetrievalFlag,
     ) -> core::result::Result<HashMap<AkdLabel, u64>, StorageError> {
         *(self.num_reads.write().await) += 1;
+        self.record_call_stats('r', "get_user_state_versions".to_string(), "".to_string())
+            .await;
 
         let mut results = HashMap::new();
 
@@ -1502,6 +1558,8 @@ impl Storage for AsyncMySqlDatabase {
         epoch_in_question: u64,
     ) -> core::result::Result<u64, StorageError> {
         *(self.num_reads.write().await) += 1;
+        self.record_call_stats('r', "get_epoch_lte_epoch".to_string(), "".to_string())
+            .await;
 
         let result = async {
             let tic = Instant::now();

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -562,9 +562,7 @@ impl<'a> AsyncMySqlDatabase {
         } else {
             panic!("Unknown call type to record call stats for.")
         }
-        let call_count = (*stats)
-            .entry(caller_name + &"~".to_string() + &data_type)
-            .or_insert(0);
+        let call_count = (*stats).entry(caller_name + "~" + &data_type).or_insert(0);
         *call_count += 1;
     }
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -16,7 +16,7 @@ use akd::storage::types::{
 };
 use akd::storage::{Storable, Storage};
 use async_trait::async_trait;
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, warn};
 use mysql_async::prelude::*;
 use mysql_async::*;
 
@@ -732,7 +732,9 @@ impl Storage for AsyncMySqlDatabase {
         *tw = Duration::from_millis(0);
 
         match level {
-            log::Level::Trace => trace!("{}", msg),
+            // Currently logs cannot be captured unless they are
+            // println!. Normally Level::Trace should use the trace! macro.
+            log::Level::Trace => println!("{}", msg),
             log::Level::Debug => debug!("{}", msg),
             log::Level::Info => info!("{}", msg),
             log::Level::Warn => warn!("{}", msg),

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -62,3 +62,57 @@ async fn test_directory_operations() {
 
     info!("\n\n******** Completed MySQL Directory Operations Integration Test ********\n\n");
 }
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_lookups() {
+    crate::test_util::log_init(log::Level::Info);
+
+    info!("\n\n******** Starting MySQL Lookup Tests ********\n\n");
+
+    if AsyncMySqlDatabase::test_guard() {
+        // create the "test" database
+        if let Err(error) = AsyncMySqlDatabase::create_test_db(
+            "localhost",
+            Option::from("root"),
+            Option::from("example"),
+            Option::from(8001),
+        )
+        .await
+        {
+            panic!("Error creating test database: {}", error);
+        }
+
+        // connect to the newly created test db
+        let mysql_db = AsyncMySqlDatabase::new(
+            "localhost",
+            "test_db",
+            Option::from("root"),
+            Option::from("example"),
+            Option::from(8001),
+            MySqlCacheOptions::Default,
+            200,
+        )
+        .await;
+
+        // delete all data from the db
+        if let Err(error) = mysql_db.delete_data().await {
+            error!("Error cleaning mysql prior to test suite: {}", error);
+        }
+
+        let vrf = HardCodedAkdVRF {};
+        crate::test_util::test_lookups::<_, HardCodedAkdVRF>(&mysql_db, &vrf, 50, 5, 100).await;
+
+        // clean the test infra
+        if let Err(mysql_async::Error::Server(error)) = mysql_db.drop_tables().await {
+            error!(
+                "ERROR: Failed to clean MySQL test database with error {}",
+                error
+            );
+        }
+    } else {
+        panic!("WARN: Skipping MySQL test due to test guard noting that the docker container appears to not be running.");
+    }
+
+    info!("\n\n******** Completed MySQL Lookup Tests ********\n\n");
+}

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -111,7 +111,7 @@ async fn test_lookups() {
             );
         }
     } else {
-        panic!("WARN: Skipping MySQL test due to test guard noting that the docker container appears to not be running.");
+        warn!("WARN: Skipping MySQL test due to test guard noting that the docker container appears to not be running.");
     }
 
     info!("\n\n******** Completed MySQL Lookup Tests ********\n\n");

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -242,3 +242,122 @@ pub(crate) async fn directory_test_suite<
         }
     }
 }
+
+pub(crate) async fn test_lookups<S: akd::storage::Storage + Sync + Send, V: VRFKeyStorage>(
+    mysql_db: &S,
+    vrf: &V,
+    num_users: u64,
+    num_epochs: u64,
+    num_lookups: usize,
+) {
+    // generate the test data
+    let mut rng = thread_rng();
+
+    let mut users: Vec<String> = vec![];
+    for _ in 0..num_users {
+        users.push(
+            thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(30)
+                .map(char::from)
+                .collect(),
+        );
+    }
+
+    // create & test the directory
+    let maybe_dir = Directory::<_, _>::new::<Blake3>(mysql_db, vrf, false).await;
+    match maybe_dir {
+        Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
+        Ok(dir) => {
+            info!("AKD Directory started. Beginning tests");
+
+            // Publish `num_epochs` epochs of user material
+            for i in 1..=num_epochs {
+                let mut data = Vec::new();
+                for value in users.iter() {
+                    data.push((AkdLabel(value.clone()), AkdValue(format!("{}", i))));
+                }
+
+                if let Err(error) = dir.publish::<Blake3>(data, true).await {
+                    panic!("Error publishing batch {:?}", error);
+                } else {
+                    info!("Published epoch {}", i);
+                }
+            }
+
+            // Perform `num_lookup` random lookup proofs on the published users
+            let azks = dir.retrieve_current_azks().await.unwrap();
+            let root_hash = dir.get_root_hash::<Blake3>(&azks).await.unwrap();
+
+            // Pick a set of users to lookup
+            let mut labels = Vec::new();
+            for user in users.iter().choose_multiple(&mut rng, num_lookups) {
+                let label = AkdLabel(user.clone());
+                labels.push(label);
+            }
+
+            println!("Metrics after publish(es).");
+            reset_mysql_db::<S>(&mysql_db).await;
+
+            let start = Instant::now();
+            // Lookup selected users one by one
+            for label in labels.clone() {
+                match dir.lookup::<Blake3>(label.clone()).await {
+                    Err(error) => panic!("Error looking up user information {:?}", error),
+                    Ok(proof) => {
+                        let vrf_pk = dir.get_public_key().await.unwrap();
+                        if let Err(error) =
+                            akd::client::lookup_verify::<Blake3>(&vrf_pk, root_hash, label, proof)
+                        {
+                            panic!("Lookup proof failed to verify {:?}", error);
+                        }
+                    }
+                }
+            }
+            println!(
+                "Individual {} lookups took {}ms.",
+                num_lookups,
+                start.elapsed().as_millis()
+            );
+
+            println!("Metrics after individual lookups:");
+            reset_mysql_db::<S>(&mysql_db).await;
+
+            let start = Instant::now();
+            // Bulk lookup selected users
+            match dir.batch_lookup::<Blake3>(&labels).await {
+                Err(error) => panic!("Error batch looking up user information {:?}", error),
+                Ok(proofs) => {
+                    assert_eq!(labels.len(), proofs.len());
+
+                    let vrf_pk = dir.get_public_key().await.unwrap();
+                    for i in 0..proofs.len() {
+                        let label = labels[i].clone();
+                        let proof = proofs[i].clone();
+                        if let Err(error) =
+                            akd::client::lookup_verify::<Blake3>(&vrf_pk, root_hash, label, proof)
+                        {
+                            panic!("Batch lookup failed to verify for index {} {:?}", i, error);
+                        }
+                    }
+                }
+            }
+            println!(
+                "Bulk {} lookups took {}ms.",
+                num_lookups,
+                start.elapsed().as_millis()
+            );
+
+            println!("Metrics after lookup proofs: ");
+            reset_mysql_db::<S>(&mysql_db).await;
+        }
+    }
+}
+
+// Reset MySQL database by logging metrics which resets the metrics, and flushing cache.
+// These allow us to accurately assess the additional efficiency of
+// bulk lookup proofs.
+async fn reset_mysql_db<S: akd::storage::Storage + Sync + Send>(mysql_db: &S) {
+    mysql_db.log_metrics(Level::Info).await;
+    mysql_db.flush_cache().await;
+}

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -358,6 +358,6 @@ pub(crate) async fn test_lookups<S: akd::storage::Storage + Sync + Send, V: VRFK
 // These allow us to accurately assess the additional efficiency of
 // bulk lookup proofs.
 async fn reset_mysql_db<S: akd::storage::Storage + Sync + Send>(mysql_db: &S) {
-    mysql_db.log_metrics(Level::Info).await;
+    mysql_db.log_metrics(Level::Trace).await;
     mysql_db.flush_cache().await;
 }


### PR DESCRIPTION
This PR adds support for bulk lookup proofs (See Issue #103). 

First, for each lookup proof requested, necessary labels are calculated. Then, the nodes corresponding to their self- and sibling-prefixes are preloaded before the lookup operations (See the comments above the function `build_lookup_prefixes_set` for my understanding why this is the case). 

To test it, I added a new feature to the MySQL implementation where each storage call is tracked with its self-(`read`/`write`) and data-type (e.g., `HistoryTreeNode`). Here is its output with the following parameters:

```diff
num_users: 50
num_epochs: 5
num_lookups: 100

running 1 test
Metrics after publish(es).
MySQL writes: 3279, MySQL reads: 6, Time read: 0.071272952 s, Time write: 1.13520928 s
        Tree size: 899
        Node state count: 1386
        Value state count: 250
Read call stats: [("get_direct:~Azks", 1), ("get_user_state_versions~", 5)]
Write call stats: [("internal_batch_set~", 20), ("internal_set~", 3)]

- Individual 100 lookups took 3103ms.
Metrics after individual lookups:
MySQL writes: 0, MySQL reads: 969, Time read: 2.041950956 s, Time write: 0 s
        Tree size: 899
        Node state count: 1386
        Value state count: 250
- Read call stats: [("get_direct:~Azks", 1), ("get_direct:~HistoryNodeState", 459), ("get_direct:~HistoryTreeNode", 459), ("get_user_state~", 50)]
Write call stats: []

+ Bulk 100 lookups took 1732ms.
Metrics after lookup proofs: 
MySQL writes: 0, MySQL reads: 75, Time read: 0.59272097 s, Time write: 0 s
        Tree size: 899
        Node state count: 1386
        Value state count: 250
+ Read call stats: [("batch_get~HistoryNodeState", 12), ("batch_get~HistoryTreeNode", 12), ("get_direct:~Azks", 1), ("get_user_state~", 50)]
Write call stats: []
```

Note the reduction in completion time (about 40% but may vary depending on the parameters) and `get_direct` calls replaced with `batch_get`s in bulk lookups.

This code was a bit tricky to test since MySQL metrics are reset when printed and nodes in cache may change the resulting numbers. In addition, the users looked up might result in different time measurements. I tried and accounted for all that but if you notice any issues, please let me know!

