### PR TITLE
Error handling cleanup

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -45,6 +45,7 @@ proptest = "1.0"
 proptest-derive = "0.3"
 colored = { version = "2" }
 once_cell = { version = "1" }
+ctor = "0.1"
 
 akd = { path =".", features = ["vrf", "public-tests"] }
 

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -11,7 +11,9 @@ readme = "../README.md"
 
 [features]
 bench = ["public-tests"]
-public-tests = ["rand", "bincode", "serde"]
+public-tests = ["rand", "bincode", "serde", "colored", "once_cell", "ed25519-dalek/serde"]
+# In the event that VRF's are enabled, AND builder has requested serde support
+# Add the serde flag to the dalek crate with --features "ed25519-dalek/serde"
 vrf = ["curve25519-dalek", "ed25519-dalek"]
 default = ["vrf"]
 
@@ -32,18 +34,19 @@ bincode = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 rand = { version = "0.7", optional = true }
 curve25519-dalek = { version = "3.2", optional = true }
-ed25519-dalek = { version = "1", optional = true}
-
-[target.'cfg(all(features = "serde", features = "vrf"))'.dependencies]
-# In the event that VRF's are enabled, AND builder has requested serde support
-# Add the serde flag to the dalek crate
-ed25519-dalek = { version = "1", features = ["serde"]}
+ed25519-dalek = { version = "1", optional = true }
+colored = { version = "2", optional = true }
+once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
 proptest = "1.0"
 proptest-derive = "0.3"
+colored = { version = "2" }
+once_cell = { version = "1" }
+
+akd = { path =".", features = ["vrf", "public-tests"] }
 
 [[bench]]
 name = "azks"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -611,6 +611,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_insert_basic() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let mut rng = OsRng;
         let num_nodes = 10;
         let db = AsyncInMemoryDatabase::new();
@@ -646,6 +648,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_permuted() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let num_nodes = 10;
         let mut rng = OsRng;
         let db = AsyncInMemoryDatabase::new();
@@ -683,6 +687,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_permuted() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -715,6 +721,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_failing() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -756,6 +764,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_intermediate() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
 
         let mut insertion_set: Vec<Node<Blake3>> = vec![];
@@ -793,6 +803,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_nonmembership_proof() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -826,6 +838,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_very_tiny() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
@@ -856,6 +870,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_tiny() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
@@ -895,6 +911,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -954,6 +972,8 @@ mod tests {
 
     #[tokio::test]
     async fn future_epoch_throws_error() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let azks = Azks::new::<_, Blake3>(&db).await?;
 

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -541,7 +541,7 @@ impl Azks {
                         label: optional_history_child_state_to_label(&curr_state.child_states[i]),
                         hash: to_digest::<H>(&optional_history_child_state_to_hash::<H>(
                             &curr_state.child_states[i],
-                        )?)?,
+                        ))?,
                     };
                     count += 1;
                 }

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -619,8 +619,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_insert_basic() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let mut rng = OsRng;
         let num_nodes = 10;
         let db = AsyncInMemoryDatabase::new();
@@ -656,8 +654,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_permuted() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let num_nodes = 10;
         let mut rng = OsRng;
         let db = AsyncInMemoryDatabase::new();
@@ -695,8 +691,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_permuted() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -729,8 +723,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_failing() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -772,8 +764,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_proof_intermediate() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
 
         let mut insertion_set: Vec<Node<Blake3>> = vec![];
@@ -811,8 +801,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_nonmembership_proof() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -846,8 +834,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_very_tiny() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
@@ -878,8 +864,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof_tiny() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let mut azks = Azks::new::<_, Blake3>(&db).await?;
 
@@ -919,8 +903,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_proof() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let num_nodes = 10;
         let mut rng = OsRng;
 
@@ -980,8 +962,6 @@ mod tests {
 
     #[tokio::test]
     async fn future_epoch_throws_error() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let azks = Azks::new::<_, Blake3>(&db).await?;
 

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -242,7 +242,7 @@ fn verify_single_update_proof<H: Hasher>(
     // ***** PART 3 ***************************
     // Verify that the current version was only added in this epoch and didn't exist before.
     if epoch > 1 {
-        let root_hash = previous_root_hash.ok_or(AkdError::NoEpochGiven)?;
+        let root_hash = previous_root_hash.ok_or(AzksError::NoEpochGiven)?;
         verify_nonmembership(
             root_hash,
             non_existence_before_ep.as_ref().ok_or_else(|| AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(format!(

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -736,8 +736,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_tree_root_hash() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false).await?;
@@ -757,8 +755,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_publish() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -773,8 +769,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_lookup() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -806,8 +800,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_key_history() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -941,8 +933,6 @@ mod tests {
     #[allow(unused)]
     #[tokio::test]
     async fn test_simple_audit() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let mut akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -1101,8 +1091,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_during_publish() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -1210,8 +1198,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_directory_read_only_mode() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         // There is no AZKS object in the storage layer, directory construction should fail
@@ -1231,8 +1217,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         // writer will write the AZKS record

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -13,7 +13,7 @@ use crate::ecvrf::{VRFKeyStorage, VRFPublicKey};
 use crate::node_state::Node;
 use crate::proof_structs::*;
 
-use crate::errors::{AkdError, DirectoryError, HistoryTreeNodeError, StorageError};
+use crate::errors::{AkdError, DirectoryError, StorageError};
 
 use crate::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Storage;
@@ -70,11 +70,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         let azks = Directory::<S, V>::get_azks_from_storage(storage, false).await;
 
         if read_only && azks.is_err() {
-            return Err(AkdError::Directory(DirectoryError::Storage(
-                StorageError::GetData(
-                    "AZKS record not found and Directory constructed in read-only mode".to_string(),
-                ),
-            )));
+            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(true)));
         } else if azks.is_err() {
             // generate a new azks if one is not found
             let azks = Azks::new::<_, H>(storage).await?;
@@ -97,10 +93,8 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         use_transaction: bool,
     ) -> Result<EpochHash<H>, AkdError> {
         if self.read_only {
-            return Err(AkdError::Directory(DirectoryError::Storage(
-                StorageError::SetData(
-                    "Directory cannot publish when created in read-only mode!".to_string(),
-                ),
+            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(
+                false,
             )));
         }
 
@@ -185,8 +179,8 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         if use_transaction {
             if let false = self.storage.begin_transaction().await {
                 error!("Transaction is already active");
-                return Err(AkdError::HistoryTreeNode(HistoryTreeNodeError::Storage(
-                    StorageError::SetData("Transaction is already active".to_string()),
+                return Err(AkdError::Storage(StorageError::Transaction(
+                    "Transaction is already active".to_string(),
                 )));
             }
         }
@@ -207,9 +201,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             if let Err(err) = self.storage.commit_transaction().await {
                 // ignore any rollback error(s)
                 let _ = self.storage.rollback_transaction().await;
-                return Err(AkdError::HistoryTreeNode(HistoryTreeNodeError::Storage(
-                    err,
-                )));
+                return Err(AkdError::Storage(err));
             } else {
                 debug!("Transaction committed");
             }
@@ -239,13 +231,10 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             .get_user_state(&uname, ValueStateRetrievalFlag::LeqEpoch(current_epoch))
             .await
         {
-            Err(_) => {
-                // Need to throw an error
-                Err(AkdError::Directory(DirectoryError::NonExistentUser(
-                    uname.0,
-                    current_epoch,
-                )))
-            }
+            Err(_) => Err(AkdError::Storage(StorageError::NotFound(format!(
+                "User {} at epoch {}",
+                uname.0, current_epoch
+            )))),
             Ok(latest_st) => {
                 // Need to account for the case where the latest state is
                 // added but the database is in the middle of an update
@@ -327,10 +316,10 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             }
             Ok(HistoryProof { proofs })
         } else {
-            Err(AkdError::Directory(DirectoryError::NonExistentUser(
-                username,
-                current_epoch,
-            )))
+            Err(AkdError::Storage(StorageError::NotFound(format!(
+                "User {} at epoch {}",
+                username, current_epoch
+            ))))
         }
     }
 
@@ -367,7 +356,12 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
                     // notify change occurred
                     if let Some(channel) = &change_detected {
-                        channel.send(()).await.map_err(|send_err| AkdError::Directory(DirectoryError::Storage(StorageError::Connection(format!("Tokio MPSC sender failed to publish notification with error {:?}", send_err)))))?;
+                        channel.send(()).await.map_err(|send_err| {
+                            AkdError::Storage(StorageError::Connection(format!(
+                                "Tokio MPSC sender failed to publish notification with error {:?}",
+                                send_err
+                            )))
+                        })?;
                     }
                     // drop the guard
                 }
@@ -430,8 +424,8 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             DbRecord::Azks(azks) => Ok(azks),
             _ => {
                 error!("No AZKS can be found. You should re-initialize the directory to create a new one");
-                Err(crate::errors::AkdError::AzksNotFound(String::from(
-                    "AZKS not found in storage.",
+                Err(AkdError::Storage(StorageError::NotFound(
+                    "AZKS not found".to_string(),
                 )))
             }
         }
@@ -440,7 +434,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
     /// HELPERS ///
 
     /// Use this function to retrieve the VRF public key for this AKD.
-    pub async fn get_public_key(&self) -> Result<VRFPublicKey, DirectoryError> {
+    pub async fn get_public_key(&self) -> Result<VRFPublicKey, AkdError> {
         Ok(self.vrf.get_vrf_public_key().await?)
     }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -81,7 +81,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         let azks = Directory::<S, V>::get_azks_from_storage(storage, false).await;
 
         if read_only && azks.is_err() {
-            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(true)));
+            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory("Cannot start directory in read-only mode when AZKS is missing".to_string())));
         } else if azks.is_err() {
             // generate a new azks if one is not found
             let azks = Azks::new::<_, H>(storage).await?;
@@ -105,7 +105,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
     ) -> Result<EpochHash<H>, AkdError> {
         if self.read_only {
             return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(
-                false,
+                "Cannot publish while in read-only mode".to_string(),
             )));
         }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -644,6 +644,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_tree_root_hash() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false).await?;
@@ -663,6 +665,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_publish() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -677,6 +681,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_lookup() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -708,6 +714,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_key_history() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -841,6 +849,8 @@ mod tests {
     #[allow(unused)]
     #[tokio::test]
     async fn test_simple_audit() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let mut akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -999,6 +1009,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_during_publish() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
@@ -1106,6 +1118,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_directory_read_only_mode() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         // There is no AZKS object in the storage layer, directory construction should fail
@@ -1125,6 +1139,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         // writer will write the AZKS record

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -81,7 +81,9 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         let azks = Directory::<S, V>::get_azks_from_storage(storage, false).await;
 
         if read_only && azks.is_err() {
-            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory("Cannot start directory in read-only mode when AZKS is missing".to_string())));
+            return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(
+                "Cannot start directory in read-only mode when AZKS is missing".to_string(),
+            )));
         } else if azks.is_err() {
             // generate a new azks if one is not found
             let azks = Azks::new::<_, H>(storage).await?;

--- a/akd/src/ecvrf/ecvrf_impl.rs
+++ b/akd/src/ecvrf/ecvrf_impl.rs
@@ -120,7 +120,7 @@ impl TryFrom<&[u8]> for VRFPublicKey {
 
     fn try_from(bytes: &[u8]) -> std::result::Result<VRFPublicKey, Self::Error> {
         if bytes.len() != ed25519_dalek::PUBLIC_KEY_LENGTH {
-            return Err(VrfError::Verification("Wrong length".to_string()));
+            return Err(VrfError::PublicKey("Wrong length".to_string()));
         }
 
         let mut bits: [u8; 32] = [0u8; 32];
@@ -129,12 +129,12 @@ impl TryFrom<&[u8]> for VRFPublicKey {
         let compressed = curve25519_dalek::edwards::CompressedEdwardsY(bits);
         let point = compressed
             .decompress()
-            .ok_or_else(|| VrfError::Verification("Deserialization failed".to_string()))?;
+            .ok_or_else(|| VrfError::PublicKey("Deserialization failed".to_string()))?;
 
         // Check if the point lies on a small subgroup. This is required
         // when using curves with a small cofactor (in ed25519, cofactor = 8).
         if point.is_small_order() {
-            return Err(VrfError::Verification("Small subgroup".to_string()));
+            return Err(VrfError::PublicKey("Small subgroup".to_string()));
         }
 
         match ed25519_PublicKey::from_bytes(bytes) {
@@ -299,7 +299,7 @@ impl TryFrom<&[u8]> for Proof {
         let pk_point = match CompressedEdwardsY::from_slice(&bytes[..32]).decompress() {
             Some(pt) => pt,
             None => {
-                return Err(VrfError::Verification(
+                return Err(VrfError::PublicKey(
                     "Failed to decompress public key into Edwards Point".to_string(),
                 ))
             }

--- a/akd/src/ecvrf/ecvrf_impl.rs
+++ b/akd/src/ecvrf/ecvrf_impl.rs
@@ -213,7 +213,7 @@ impl VRFPublicKey {
             name_hash_bytes,
             H::merge_with_int(H::hash(stale_bytes), version),
         ]);
-        let message_vec = crate::serialization::from_digest::<H>(hashed_label).unwrap();
+        let message_vec = crate::serialization::from_digest::<H>(hashed_label);
         let message: &[u8] = message_vec.as_slice();
 
         // VRF proof verification (returns VRF hash output)

--- a/akd/src/ecvrf/mod.rs
+++ b/akd/src/ecvrf/mod.rs
@@ -51,8 +51,8 @@ unsafe impl Send for HardCodedAkdVRF {}
 
 #[async_trait::async_trait]
 impl VRFKeyStorage for HardCodedAkdVRF {
-    async fn retrieve(&self) -> Result<Vec<u8>, crate::errors::VRFStorageError> {
+    async fn retrieve(&self) -> Result<Vec<u8>, crate::errors::VrfError> {
         hex::decode("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721")
-            .map_err(|hex_err| crate::errors::VRFStorageError::GetPK(hex_err.to_string()))
+            .map_err(|hex_err| crate::errors::VrfError::PublicKey(hex_err.to_string()))
     }
 }

--- a/akd/src/ecvrf/traits.rs
+++ b/akd/src/ecvrf/traits.rs
@@ -76,7 +76,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
             name_hash_bytes,
             H::merge_with_int(H::hash(stale_bytes), version),
         ]);
-        let message_vec = from_digest::<H>(hashed_label).unwrap();
+        let message_vec = from_digest::<H>(hashed_label);
         let message: &[u8] = message_vec.as_slice();
 
         // VRF proof and hash output

--- a/akd/src/ecvrf/traits.rs
+++ b/akd/src/ecvrf/traits.rs
@@ -9,7 +9,7 @@
 //! of public and private keys
 use super::{Proof, VRFPrivateKey, VRFPublicKey};
 use crate::serialization::from_digest;
-use crate::{errors::VRFStorageError, node_state::NodeLabel, storage::types::AkdLabel};
+use crate::{errors::VrfError, node_state::NodeLabel, storage::types::AkdLabel};
 
 use async_trait::async_trait;
 use std::convert::TryInto;
@@ -27,12 +27,12 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
     /* ======= To be implemented ====== */
 
     /// Retrieve the VRF Private key as a vector of bytes
-    async fn retrieve(&self) -> Result<Vec<u8>, VRFStorageError>;
+    async fn retrieve(&self) -> Result<Vec<u8>, VrfError>;
 
     /* ======= Common trait functionality ====== */
 
     /// Retrieve the properly constructed VRF Private key
-    async fn get_vrf_private_key(&self) -> Result<VRFPrivateKey, VRFStorageError> {
+    async fn get_vrf_private_key(&self) -> Result<VRFPrivateKey, VrfError> {
         match self.retrieve().await {
             Ok(bytes) => {
                 let pk_ref: &[u8] = &bytes;
@@ -43,7 +43,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
     }
 
     /// Retrieve the VRF public key
-    async fn get_vrf_public_key(&self) -> Result<VRFPublicKey, VRFStorageError> {
+    async fn get_vrf_public_key(&self) -> Result<VRFPublicKey, VrfError> {
         self.get_vrf_private_key().await.map(|key| (&key).into())
     }
 
@@ -55,7 +55,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
         uname: &AkdLabel,
         stale: bool,
         version: u64,
-    ) -> Result<NodeLabel, VRFStorageError> {
+    ) -> Result<NodeLabel, VrfError> {
         let proof = self.get_label_proof::<H>(uname, stale, version).await?;
         let output: super::ecvrf_impl::Output = (&proof).into();
         Ok(NodeLabel::new(output.to_truncated_bytes(), 256u32))
@@ -67,7 +67,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
         uname: &AkdLabel,
         stale: bool,
         version: u64,
-    ) -> Result<Proof, VRFStorageError> {
+    ) -> Result<Proof, VrfError> {
         let key = self.get_vrf_private_key().await?;
         let name_hash_bytes = H::hash(uname.0.as_bytes());
         let stale_bytes = if stale { &[0u8] } else { &[1u8] };

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -11,7 +11,8 @@ use core::fmt;
 use crate::node_state::NodeLabel;
 
 /// Symbolizes a AkdError, thrown by the akd.
-#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
 pub enum AkdError {
     /// Error propagation
     HistoryTreeNode(HistoryTreeNodeError),
@@ -148,7 +149,8 @@ impl fmt::Display for HistoryTreeNodeError {
 }
 
 /// An error thrown by the Azks data structure.
-#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
 pub enum AzksError {
     /// Membership proof did not verify
     VerifyMembershipProof(String),
@@ -177,7 +179,8 @@ impl fmt::Display for AzksError {
 }
 
 /// The errors thrown by various algorithms in [crate::directory::Directory]
-#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
 pub enum DirectoryError {
     /// Lookup proof did not verify
     VerifyLookupProof(String),
@@ -186,7 +189,7 @@ pub enum DirectoryError {
     /// Tried to audit an invalid epoch range
     InvalidEpoch(String),
     /// AZKS not found in read-only directory mode
-    ReadOnlyDirectory(bool),
+    ReadOnlyDirectory(String),
 }
 
 impl std::error::Error for DirectoryError {}
@@ -203,20 +206,16 @@ impl fmt::Display for DirectoryError {
             Self::VerifyLookupProof(err_string) => {
                 write!(f, "Failed to verify lookup proof {}", err_string)
             }
-            Self::ReadOnlyDirectory(missing_azks) => {
-                let specific = if *missing_azks {
-                    "AZKS not found"
-                } else {
-                    "Operation not permitted"
-                };
-                write!(f, "Directory in read-only mode: {}", specific)
+            Self::ReadOnlyDirectory(inner_message) => {
+                write!(f, "Directory in read-only mode: {}", inner_message)
             }
         }
     }
 }
 
 /// Represents a storage-layer error
-#[derive(PartialEq, Debug)]
+#[cfg_attr(any(test, feature = "public-tests"), derive(PartialEq))]
+#[derive(Debug)]
 pub enum StorageError {
     /// Data wasn't found in the storage layer
     NotFound(String),
@@ -249,8 +248,10 @@ impl fmt::Display for StorageError {
     }
 }
 
-/// Represents a VRF-storage-layer error
-#[derive(PartialEq, Debug)]
+/// Represents a VRF related error (key retrieval,
+/// parsing, verification of a VRF proof, etc)
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
 pub enum VrfError {
     /// An error occurred when getting a key
     PublicKey(String),
@@ -272,7 +273,7 @@ impl fmt::Display for VrfError {
                 write!(f, "VRF public key: {}", error_string)
             }
             Self::Verification(error_string) => {
-                write!(f, "VRF prooving or verifying: {}", error_string)
+                write!(f, "VRF proving or verifying: {}", error_string)
             }
         }
     }

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -97,7 +97,7 @@ pub enum HistoryTreeNodeError {
     /// The state of a node did not exist at a given epoch
     NoStateAtEpoch(NodeLabel, u64),
     /// Failed to deserialize a digest
-    DigestDeserializationFailed,
+    DigestDeserializationFailed(String),
 }
 
 impl std::error::Error for HistoryTreeNodeError {}
@@ -140,8 +140,8 @@ impl fmt::Display for HistoryTreeNodeError {
                     label, epoch
                 )
             }
-            Self::DigestDeserializationFailed => {
-                write!(f, "Encountered a serialization error")
+            Self::DigestDeserializationFailed(inner_error) => {
+                write!(f, "Encountered a serialization error {}", inner_error)
             }
         }
     }

--- a/akd/src/history_tree_node.rs
+++ b/akd/src/history_tree_node.rs
@@ -279,7 +279,7 @@ impl HistoryTreeNode {
                 new_node.write_to_storage(storage).await?;
                 set_state_map(
                     storage,
-                    HistoryNodeState::new::<H>(NodeStateKey(new_node.label, epoch))?,
+                    HistoryNodeState::new::<H>(NodeStateKey(new_node.label, epoch)),
                 )
                 .await?;
                 *num_nodes += 1;
@@ -386,7 +386,7 @@ impl HistoryTreeNode {
                     hash_digest = H::merge(&[hash_digest, hash_label::<H>(self.label)]);
                 }
                 let mut updated_state = self.get_state_at_epoch(storage, epoch).await?;
-                updated_state.value = from_digest::<H>(hash_digest)?;
+                updated_state.value = from_digest::<H>(hash_digest);
                 updated_state.key = NodeStateKey(self.label, epoch);
                 set_state_map(storage, updated_state).await?;
 
@@ -411,7 +411,7 @@ impl HistoryTreeNode {
                 new_hash,
                 to_digest::<H>(&optional_history_child_state_to_hash::<H>(
                     &epoch_node_state.get_child_state_in_dir(child_index),
-                )?)?,
+                ))?,
             ]);
         }
         Ok(new_hash)
@@ -455,7 +455,7 @@ impl HistoryTreeNode {
                         parent_updated_state
                             .get_child_state_in_dir(s_dir)
                             .ok_or(HistoryTreeNodeError::NoChildAtEpoch(epoch, s_dir))?;
-                    self_child_state.hash_val = from_digest::<H>(new_hash_val)?;
+                    self_child_state.hash_val = from_digest::<H>(new_hash_val);
                     parent_updated_state.child_states[s_dir] = Some(self_child_state);
                     parent_updated_state.key = NodeStateKey(parent.label, epoch);
                     set_state_map(storage, parent_updated_state).await?;
@@ -495,7 +495,7 @@ impl HistoryTreeNode {
                         latest_st.key = NodeStateKey(self.label, epoch);
                         latest_st
                     }
-                    Err(_) => HistoryNodeState::new::<H>(NodeStateKey(self.label, epoch))?,
+                    Err(_) => HistoryNodeState::new::<H>(NodeStateKey(self.label, epoch)),
                 },
             )
             .await?;
@@ -575,7 +575,7 @@ impl HistoryTreeNode {
         let children = self.get_state_at_epoch(storage, epoch).await?.child_states;
         let mut new_hash = H::hash(&EMPTY_VALUE);
         for child in children.iter().take(ARITY) {
-            let hash_val = optional_history_child_state_to_hash::<H>(child)?;
+            let hash_val = optional_history_child_state_to_hash::<H>(child);
             new_hash = H::merge(&[new_hash, to_digest::<H>(&hash_val)?]);
         }
         Ok(new_hash)
@@ -763,7 +763,7 @@ impl HistoryTreeNode {
             hash_val: from_digest::<H>(H::merge(&[
                 self.get_value::<_, H>(storage).await?,
                 hash_label::<H>(self.label),
-            ]))?,
+            ])),
             epoch_version: self.get_latest_epoch(),
         })
     }
@@ -778,7 +778,7 @@ impl HistoryTreeNode {
             hash_val: from_digest::<H>(H::merge(&[
                 self.get_value::<_, H>(storage).await?,
                 hash_label::<H>(self.label),
-            ]))?,
+            ])),
             epoch_version: self.get_latest_epoch(),
         })
     }
@@ -788,10 +788,10 @@ impl HistoryTreeNode {
 
 pub(crate) fn optional_history_child_state_to_hash<H: Hasher>(
     input: &Option<HistoryChildState>,
-) -> Result<Vec<u8>, AkdError> {
+) -> Vec<u8> {
     match input {
-        Some(child_state) => Ok(child_state.hash_val.clone()),
-        None => Ok(from_digest::<H>(crate::utils::empty_node_hash::<H>())?),
+        Some(child_state) => child_state.hash_val.clone(),
+        None => from_digest::<H>(crate::utils::empty_node_hash::<H>()),
     }
 }
 
@@ -814,7 +814,7 @@ pub async fn get_empty_root<H: Hasher, S: Storage + Send + Sync>(
         node.birth_epoch = epoch;
         node.last_epoch = epoch;
         let new_state: HistoryNodeState =
-            HistoryNodeState::new::<H>(NodeStateKey(node.label, epoch))?;
+            HistoryNodeState::new::<H>(NodeStateKey(node.label, epoch));
         set_state_map(storage, new_state).await?;
     }
 
@@ -838,8 +838,8 @@ pub async fn get_leaf_node<H: Hasher, S: Storage + Sync + Send>(
     };
 
     let mut new_state: HistoryNodeState =
-        HistoryNodeState::new::<H>(NodeStateKey(node.label, birth_epoch))?;
-    new_state.value = from_digest::<H>(H::merge(&[H::hash(&EMPTY_VALUE), H::hash(value)]))?;
+        HistoryNodeState::new::<H>(NodeStateKey(node.label, birth_epoch));
+    new_state.value = from_digest::<H>(H::merge(&[H::hash(&EMPTY_VALUE), H::hash(value)]));
 
     set_state_map(storage, new_state).await?;
 
@@ -861,8 +861,8 @@ pub(crate) async fn get_leaf_node_without_hashing<H: Hasher, S: Storage + Sync +
     };
 
     let mut new_state: HistoryNodeState =
-        HistoryNodeState::new::<H>(NodeStateKey(history_node.label, birth_epoch))?;
-    new_state.value = from_digest::<H>(node.hash)?;
+        HistoryNodeState::new::<H>(NodeStateKey(history_node.label, birth_epoch));
+    new_state.value = from_digest::<H>(node.hash);
 
     set_state_map(storage, new_state).await?;
 

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -325,8 +325,10 @@ pub mod client;
 pub mod ecvrf;
 pub mod errors;
 
+#[cfg(any(test, feature = "public-tests"))]
+pub mod test_utils;
 #[cfg(test)]
-pub mod tests;
+mod tests;
 
 /// The arity of the underlying tree structure of the akd.
 pub const ARITY: usize = 2;

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -212,7 +212,7 @@ pub fn hash_label<H: Hasher>(label: NodeLabel) -> H::Digest {
 /// To be used in its parent, alongwith the label.
 pub struct HistoryNodeState {
     /// The hash at this node state
-    pub value: Vec<u8>,
+    pub value: [u8; 32],
     /// The states of the children at this time
     pub child_states: [Option<HistoryChildState>; ARITY],
     /// A unique key
@@ -307,7 +307,7 @@ impl HistoryNodeState {
 impl Clone for HistoryNodeState {
     fn clone(&self) -> Self {
         Self {
-            value: self.value.clone(),
+            value: self.value,
             child_states: self.child_states.clone(),
             key: self.key,
         }
@@ -337,7 +337,7 @@ pub struct HistoryChildState {
     /// Child node's label
     pub label: NodeLabel,
     /// Child node's hash value
-    pub hash_val: Vec<u8>,
+    pub hash_val: [u8; 32],
     /// Child node's state this epoch being pointed to here
     pub epoch_version: u64,
 }
@@ -359,7 +359,7 @@ impl Clone for HistoryChildState {
     fn clone(&self) -> Self {
         Self {
             label: self.label,
-            hash_val: self.hash_val.clone(),
+            hash_val: self.hash_val,
             epoch_version: self.epoch_version,
         }
     }

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -7,7 +7,6 @@
 
 //! The representation for the label of a history tree node.
 
-use crate::errors::AkdError;
 use crate::serialization::from_digest;
 #[cfg(feature = "serde")]
 use crate::serialization::{digest_deserialize, digest_serialize};
@@ -290,13 +289,13 @@ unsafe impl Sync for HistoryNodeState {}
 
 impl HistoryNodeState {
     /// Creates a new [HistoryNodeState]
-    pub fn new<H: Hasher>(key: NodeStateKey) -> Result<Self, AkdError> {
+    pub fn new<H: Hasher>(key: NodeStateKey) -> Self {
         const INIT: Option<HistoryChildState> = None;
-        Ok(HistoryNodeState {
-            value: from_digest::<H>(H::hash(&EMPTY_VALUE))?,
+        HistoryNodeState {
+            value: from_digest::<H>(H::hash(&EMPTY_VALUE)),
             child_states: [INIT; ARITY],
             key,
-        })
+        }
     }
 
     /// Returns a copy of the child state, in the calling HistoryNodeState in the given direction.
@@ -347,16 +346,12 @@ unsafe impl Sync for HistoryChildState {}
 
 impl HistoryChildState {
     /// Instantiates a new [HistoryChildState] with given label and hash val.
-    pub fn new<H: Hasher>(
-        label: NodeLabel,
-        hash_val: H::Digest,
-        ep: u64,
-    ) -> Result<Self, AkdError> {
-        Ok(HistoryChildState {
+    pub fn new<H: Hasher>(label: NodeLabel, hash_val: H::Digest, ep: u64) -> Self {
+        HistoryChildState {
             label,
-            hash_val: from_digest::<H>(hash_val)?,
+            hash_val: from_digest::<H>(hash_val),
             epoch_version: ep,
-        })
+        }
     }
 }
 

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -7,7 +7,7 @@
 
 //! The representation for the label of a history tree node.
 
-use crate::errors::HistoryTreeNodeError;
+use crate::errors::AkdError;
 use crate::serialization::from_digest;
 #[cfg(feature = "serde")]
 use crate::serialization::{digest_deserialize, digest_serialize};
@@ -290,7 +290,7 @@ unsafe impl Sync for HistoryNodeState {}
 
 impl HistoryNodeState {
     /// Creates a new [HistoryNodeState]
-    pub fn new<H: Hasher>(key: NodeStateKey) -> Result<Self, HistoryTreeNodeError> {
+    pub fn new<H: Hasher>(key: NodeStateKey) -> Result<Self, AkdError> {
         const INIT: Option<HistoryChildState> = None;
         Ok(HistoryNodeState {
             value: from_digest::<H>(H::hash(&EMPTY_VALUE))?,
@@ -351,7 +351,7 @@ impl HistoryChildState {
         label: NodeLabel,
         hash_val: H::Digest,
         ep: u64,
-    ) -> Result<Self, HistoryTreeNodeError> {
+    ) -> Result<Self, AkdError> {
         Ok(HistoryChildState {
             label,
             hash_val: from_digest::<H>(hash_val)?,

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -7,7 +7,7 @@
 
 //! This module contains serialization calls for helping serialize/deserialize digests
 
-use crate::errors::HistoryTreeNodeError;
+use crate::errors::{AkdError, HistoryTreeNodeError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
@@ -16,13 +16,13 @@ use winter_crypto::Hasher;
 use winter_utils::{Deserializable, Serializable, SliceReader};
 
 /// Converts from &[u8] to H::Digest
-pub fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, HistoryTreeNodeError> {
-    H::Digest::read_from(&mut SliceReader::new(input))
-        .map_err(|_| HistoryTreeNodeError::SerializationError)
+pub fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, AkdError> {
+    Ok(H::Digest::read_from(&mut SliceReader::new(input))
+        .map_err(|_| HistoryTreeNodeError::DigestDeserializationFailed)?)
 }
 
 /// Converts from H::Digest to Vec<u8>
-pub fn from_digest<H: Hasher>(input: H::Digest) -> Result<Vec<u8>, HistoryTreeNodeError> {
+pub fn from_digest<H: Hasher>(input: H::Digest) -> Result<Vec<u8>, AkdError> {
     let mut output = vec![];
     input.write_into(&mut output);
     Ok(output)

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -70,8 +70,6 @@ mod tests {
 
     #[test]
     pub fn serialize_deserialize() {
-        crate::test_utils::init_logger(log::Level::Info);
-
         use winter_crypto::hashers::Blake3_256;
         use winter_crypto::Hasher;
         use winter_math::fields::f128::BaseElement;
@@ -89,8 +87,6 @@ mod tests {
 
     #[tokio::test]
     pub async fn lookup_proof_roundtrip() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
 
         let vrf = HardCodedAkdVRF {};
@@ -125,8 +121,6 @@ mod tests {
 
     #[tokio::test]
     pub async fn history_proof_roundtrip() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false)
@@ -160,8 +154,6 @@ mod tests {
 
     #[tokio::test]
     pub async fn audit_proof_roundtrip() -> Result<(), AkdError> {
-        crate::test_utils::init_logger(log::Level::Info);
-
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false)

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -13,19 +13,17 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
 use winter_crypto::Digest;
 use winter_crypto::Hasher;
-use winter_utils::{Deserializable, Serializable, SliceReader};
+use winter_utils::{Deserializable, SliceReader};
 
 /// Converts from &[u8] to H::Digest
 pub fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, AkdError> {
     Ok(H::Digest::read_from(&mut SliceReader::new(input))
-        .map_err(|_| HistoryTreeNodeError::DigestDeserializationFailed)?)
+        .map_err(|msg| HistoryTreeNodeError::DigestDeserializationFailed(format!("{}", msg)))?)
 }
 
 /// Converts from H::Digest to Vec<u8>
-pub fn from_digest<H: Hasher>(input: H::Digest) -> Result<Vec<u8>, AkdError> {
-    let mut output = vec![];
-    input.write_into(&mut output);
-    Ok(output)
+pub fn from_digest<H: Hasher>(input: H::Digest) -> Vec<u8> {
+    input.as_bytes().to_vec()
 }
 
 /// A serde serializer for the type `winter_crypto::Digest`

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -70,6 +70,8 @@ mod tests {
 
     #[test]
     pub fn serialize_deserialize() {
+        crate::test_utils::init_logger(log::Level::Info);
+
         use winter_crypto::hashers::Blake3_256;
         use winter_crypto::Hasher;
         use winter_math::fields::f128::BaseElement;
@@ -87,6 +89,8 @@ mod tests {
 
     #[tokio::test]
     pub async fn lookup_proof_roundtrip() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
 
         let vrf = HardCodedAkdVRF {};
@@ -121,6 +125,8 @@ mod tests {
 
     #[tokio::test]
     pub async fn history_proof_roundtrip() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false)
@@ -154,6 +160,8 @@ mod tests {
 
     #[tokio::test]
     pub async fn audit_proof_roundtrip() -> Result<(), AkdError> {
+        crate::test_utils::init_logger(log::Level::Info);
+
         let db = AsyncInMemoryDatabase::new();
         let vrf = HardCodedAkdVRF {};
         let akd = Directory::<_, _>::new::<Blake3_256<BaseElement>>(&db, &vrf, false)

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -21,9 +21,9 @@ pub fn to_digest<H: Hasher>(input: &[u8]) -> Result<H::Digest, AkdError> {
         .map_err(|msg| HistoryTreeNodeError::DigestDeserializationFailed(format!("{}", msg)))?)
 }
 
-/// Converts from H::Digest to Vec<u8>
-pub fn from_digest<H: Hasher>(input: H::Digest) -> Vec<u8> {
-    input.as_bytes().to_vec()
+/// Converts from H::Digest to [u8; 32]
+pub fn from_digest<H: Hasher>(input: H::Digest) -> [u8; 32] {
+    input.as_bytes()
 }
 
 /// A serde serializer for the type `winter_crypto::Digest`

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -155,7 +155,7 @@ impl Storage for AsyncInMemoryDatabase {
                         return Ok(DbRecord::ValueState(item.clone()));
                     }
                 }
-                return Err(StorageError::GetData("Not found".to_string()));
+                return Err(StorageError::NotFound(format!("ValueState {:?}", id)));
             }
         }
         // fallback to regular get/set db
@@ -163,7 +163,11 @@ impl Storage for AsyncInMemoryDatabase {
         if let Some(result) = (*guard).get(&bin_id).cloned() {
             Ok(result)
         } else {
-            Err(StorageError::GetData("Not found".to_string()))
+            Err(StorageError::NotFound(format!(
+                "{:?} {:?}",
+                St::data_type(),
+                id
+            )))
         }
     }
 
@@ -197,7 +201,7 @@ impl Storage for AsyncInMemoryDatabase {
 
             Ok(KeyData { states: results })
         } else {
-            Err(StorageError::GetData("Not found".to_string()))
+            Err(StorageError::NotFound(format!("ValueState {:?}", username)))
         }
     }
 
@@ -264,7 +268,7 @@ impl Storage for AsyncInMemoryDatabase {
                 }
             }
         }
-        Err(StorageError::GetData(String::from("Not found")))
+        Err(StorageError::NotFound(format!("ValueState {:?}", username)))
     }
 
     async fn get_user_state_versions(
@@ -313,7 +317,7 @@ impl Storage for AsyncInMemoryDatabase {
             }
         }
 
-        Err(StorageError::GetData(format!(
+        Err(StorageError::NotFound(format!(
             "Node (val: {:?}, len: {}) did not exist <= epoch {}",
             node_label.val, node_label.len, epoch_in_question
         )))
@@ -536,7 +540,7 @@ impl Storage for AsyncInMemoryDbWithCache {
                         return Ok(DbRecord::ValueState(item.clone()));
                     }
                 }
-                return Err(StorageError::GetData("Not found".to_string()));
+                return Err(StorageError::NotFound(format!("ValueState {:?}", id)));
             }
         }
         let mut stats = self.stats.write().await;
@@ -555,7 +559,11 @@ impl Storage for AsyncInMemoryDbWithCache {
 
                     Ok(result)
                 } else {
-                    Err(StorageError::GetData("Not found".to_string()))
+                    Err(StorageError::NotFound(format!(
+                        "{:?} {:?}",
+                        St::data_type(),
+                        id
+                    )))
                 }
             }
         }
@@ -589,7 +597,7 @@ impl Storage for AsyncInMemoryDbWithCache {
 
             Ok(KeyData { states: results })
         } else {
-            Err(StorageError::GetData("Not found".to_string()))
+            Err(StorageError::NotFound(format!("ValueState {:?}", username)))
         }
     }
 
@@ -655,7 +663,7 @@ impl Storage for AsyncInMemoryDbWithCache {
                 }
             }
         }
-        Err(StorageError::GetData(String::from("Not found")))
+        Err(StorageError::NotFound(format!("ValueState {:?}", username)))
     }
 
     async fn get_user_state_versions(
@@ -703,7 +711,7 @@ impl Storage for AsyncInMemoryDbWithCache {
                 return Ok(item);
             }
         }
-        Err(StorageError::GetData(format!(
+        Err(StorageError::NotFound(format!(
             "Node (val: {:?}, len: {}) did not exist <= epoch {}",
             node_label.val, node_label.len, epoch_in_question
         )))

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -26,7 +26,7 @@ Various implementations supported by the library are imported here and usable at
 */
 pub mod memory;
 
-#[cfg(feature = "public-tests")]
+#[cfg(any(test, feature = "public-tests"))]
 pub mod tests;
 
 #[cfg(feature = "serde")]

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -47,7 +47,6 @@ mod memory_storage_tests {
 /// for consistency checks (e.g. mysql, memcached, etc)
 pub async fn run_test_cases_for_storage_impl<S: Storage + Sync + Send>(db: &S) {
     crate::test_utils::init_logger(log::Level::Info);
-
     test_get_and_set_item(db).await;
     test_user_data(db).await;
     test_transactions(db).await;

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -46,6 +46,8 @@ mod memory_storage_tests {
 /// This is public because it can be used by other implemented storage layers
 /// for consistency checks (e.g. mysql, memcached, etc)
 pub async fn run_test_cases_for_storage_impl<S: Storage + Sync + Send>(db: &S) {
+    crate::test_utils::init_logger(log::Level::Info);
+
     test_get_and_set_item(db).await;
     test_user_data(db).await;
     test_transactions(db).await;

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -511,7 +511,7 @@ async fn test_user_data<S: Storage + Sync + Send>(storage: &S) {
             ValueStateRetrievalFlag::SpecificVersion(100),
         )
         .await;
-    assert!(matches!(missing_result, Err(StorageError::GetData(_)),));
+    assert!(matches!(missing_result, Err(StorageError::NotFound(_)),));
 
     let specific_result = storage
         .get_user_state(

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -113,7 +113,7 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     // === HistoryNodeState storage === //
     let key = NodeStateKey(NodeLabel::new(byte_arr_from_u64(1), 1), 1);
     let node_state = HistoryNodeState {
-        value: vec![],
+        value: [0u8; 32],
         child_states: [None, None],
         key,
     };

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -101,7 +101,7 @@ impl Transaction {
         let mut guard = self.state.write().await;
 
         if !(*guard).active {
-            return Err(StorageError::SetData(
+            return Err(StorageError::Transaction(
                 "Transaction not currently active".to_string(),
             ));
         }
@@ -126,7 +126,7 @@ impl Transaction {
         let mut guard = self.state.write().await;
 
         if !(*guard).active {
-            return Err(StorageError::SetData(
+            return Err(StorageError::Transaction(
                 "Transaction not currently active".to_string(),
             ));
         }

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -204,12 +204,12 @@ mod tests {
             node_type: NodeType::Leaf,
         });
         let node_state1 = DbRecord::HistoryNodeState(HistoryNodeState {
-            value: vec![],
+            value: [0u8; 32],
             child_states: [None, None],
             key: NodeStateKey(NodeLabel::new(byte_arr_from_u64(1), 1), 1),
         });
         let node_state2 = DbRecord::HistoryNodeState(HistoryNodeState {
-            value: vec![],
+            value: [0u8; 32],
             child_states: [None, None],
             key: NodeStateKey(NodeLabel::new(byte_arr_from_u64(1), 1), 2),
         });

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -218,7 +218,7 @@ impl DbRecord {
 
     /// Build a history node state from the properties
     pub fn build_history_node_state(
-        value: Vec<u8>,
+        value: [u8; 32],
         child_states: [Option<HistoryChildState>; ARITY],
         label_len: u32,
         label_val: [u8; 32],
@@ -235,7 +235,7 @@ impl DbRecord {
     pub fn build_history_child_state(
         label_len: u32,
         label_val: [u8; 32],
-        hash_val: Vec<u8>,
+        hash_val: [u8; 32],
         epoch_version: u64,
     ) -> HistoryChildState {
         HistoryChildState {

--- a/akd/src/test_utils.rs
+++ b/akd/src/test_utils.rs
@@ -97,3 +97,16 @@ pub fn init_logger(level: Level) {
             .unwrap();
     });
 }
+
+/// Global test startup constructor. Only runs in the TEST profile. Each
+/// crate which wants logging enabled in tests being run should make this call
+/// itself.
+///
+/// However we additionally call the init_logger(..) fn in the external storage
+/// based test suite in case an external entity doesn't want to deal with the
+/// ctor construction (or initializing the logger themselves)
+#[cfg(test)]
+#[ctor::ctor]
+fn test_start() {
+    init_logger(Level::Info);
+}

--- a/akd/src/test_utils.rs
+++ b/akd/src/test_utils.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This module contains common test utilities for crates generating tests utilizing the
+//! AKD crate
+
+use colored::*;
+use log::{Level, Metadata, Record};
+use once_cell::sync::OnceCell;
+use std::sync::Once;
+use tokio::time::{Duration, Instant};
+
+static EPOCH: OnceCell<Instant> = OnceCell::new();
+static LOGGER: TestConsoleLogger = TestConsoleLogger {};
+static INIT_ONCE: Once = Once::new();
+
+pub(crate) struct TestConsoleLogger;
+
+impl TestConsoleLogger {
+    pub(crate) fn format_log_record(record: &Record) {
+        let target = {
+            if let Some(target_str) = record.target().split(':').last() {
+                if let Some(line) = record.line() {
+                    format!(" ({}:{})", target_str, line)
+                } else {
+                    format!(" ({})", target_str)
+                }
+            } else {
+                "".to_string()
+            }
+        };
+
+        let toc = if let Some(epoch) = EPOCH.get() {
+            Instant::now() - *epoch
+        } else {
+            Duration::from_millis(0)
+        };
+
+        let seconds = toc.as_secs();
+        let hours = seconds / 3600;
+        let minutes = (seconds / 60) % 60;
+        let seconds = seconds % 60;
+        let miliseconds = toc.subsec_millis();
+
+        let msg = format!(
+            "[{:02}:{:02}:{:02}.{:03}] {:6} {}{}",
+            hours,
+            minutes,
+            seconds,
+            miliseconds,
+            record.level(),
+            record.args(),
+            target
+        );
+        let msg = match record.level() {
+            Level::Trace | Level::Debug => msg.white(),
+            Level::Info => msg.blue(),
+            Level::Warn => msg.yellow(),
+            Level::Error => msg.red(),
+        };
+        println!("{}", msg);
+    }
+}
+
+impl log::Log for TestConsoleLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        TestConsoleLogger::format_log_record(record);
+    }
+
+    fn flush(&self) {}
+}
+
+/// Initialize the logger for console logging within test environments.
+/// This is safe to call multiple times, but it will only initialize the logger
+/// to the log-level _first_ set. If you want a specific log-level (e.g. Debug)
+/// for a specific test, make sure to only run that single test after editing that
+/// test's log-level.
+///
+/// The default level applied everywhere is Info
+pub fn init_logger(level: Level) {
+    EPOCH.get_or_init(Instant::now);
+
+    INIT_ONCE.call_once(|| {
+        log::set_logger(&LOGGER)
+            .map(|()| log::set_max_level(level.to_level_filter()))
+            .unwrap();
+    });
+}

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -39,8 +39,7 @@ async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
         NodeLabel::new(byte_arr_from_u64(1), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     root.write_to_storage(&db).await?;
     root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()))
         .await?;
@@ -72,14 +71,12 @@ async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
         NodeLabel::new(byte_arr_from_u64(1), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(byte_arr_from_u64(0), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()),)
@@ -133,14 +130,12 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdErro
         NodeLabel::new(byte_arr_from_u64(11), 2),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(byte_arr_from_u64(00), 2),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1))
@@ -161,14 +156,12 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdErro
         NodeLabel::new(byte_arr_from_u64(1), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     let child_hist_node_4: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(byte_arr_from_u64(0), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_3.clone()),)
@@ -222,14 +215,12 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdEr
         NodeLabel::new(byte_arr_from_u64(11), 2),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(byte_arr_from_u64(00), 2),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     root.write_to_storage(&db).await?;
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_1.clone()),)
@@ -250,14 +241,12 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdEr
         NodeLabel::new(byte_arr_from_u64(1), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     let child_hist_node_4: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(byte_arr_from_u64(0), 1),
         Blake3::hash(&[0u8]),
         ep,
-    )
-    .unwrap();
+    );
     assert!(
         root.set_child::<_, Blake3>(&db, ep, &(Direction::Some(1), child_hist_node_3.clone()),)
             .await
@@ -316,14 +305,12 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
             ),
             Blake3::hash(&[0u8]),
             2 * ep,
-        )
-        .unwrap();
+        );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(0), ep.clone().try_into().unwrap()),
             Blake3::hash(&[0u8]),
             2 * ep,
-        )
-        .unwrap();
+        );
         root.write_to_storage(&db).await?;
         root.set_child::<_, Blake3>(&db, 2 * ep, &(Direction::Some(1), child_hist_node_1))
             .await?;
@@ -340,8 +327,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
         ),
         Blake3::hash(&[0u8]),
         2 * ep_existing,
-    )
-    .unwrap();
+    );
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
         NodeLabel::new(
             byte_arr_from_u64(0),
@@ -349,8 +335,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
         ),
         Blake3::hash(&[0u8]),
         2 * ep_existing,
-    )
-    .unwrap();
+    );
 
     let set_child_1 = root
         .get_child_at_epoch::<_, Blake3>(&db, 1, Direction::Some(1))
@@ -603,10 +588,10 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError>
     ]);
 
     let mut leaf_0_as_child = new_leaf.to_node_child_state::<_, Blake3>(&db).await?;
-    leaf_0_as_child.hash_val = from_digest::<Blake3>(leaf_0_hash).unwrap();
+    leaf_0_as_child.hash_val = from_digest::<Blake3>(leaf_0_hash);
 
     let mut leaf_3_as_child = leaf_3.to_node_child_state::<_, Blake3>(&db).await?;
-    leaf_3_as_child.hash_val = from_digest::<Blake3>(leaf_3_hash).unwrap();
+    leaf_3_as_child.hash_val = from_digest::<Blake3>(leaf_3_hash);
 
     root.write_to_storage(&db).await?;
     let mut num_nodes = 1;

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -32,6 +32,8 @@ type InMemoryDb = storage::memory::AsyncInMemoryDatabase;
 
 #[tokio::test]
 async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -64,6 +66,8 @@ async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -123,6 +127,8 @@ async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -208,6 +214,8 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdErro
 
 #[tokio::test]
 async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -293,6 +301,8 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdEr
 //  Test get_child_at_epoch
 #[tokio::test]
 pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let init_ep = 0;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(init_ep)).await?;
@@ -373,6 +383,8 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -429,6 +441,8 @@ async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -514,6 +528,8 @@ async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -620,6 +636,8 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError>
 
 #[tokio::test]
 async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
+    crate::test_utils::init_logger(log::Level::Info);
+
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     root.write_to_storage(&db).await?;
@@ -694,4 +712,17 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
 
     assert!(root_val == expected, "Root hash not equal to expected");
     Ok(())
+}
+
+#[test]
+// Comment the following line to see log messages being written in failed testing scenarios
+#[should_panic(expected = "boom.")]
+fn boom() {
+    crate::test_utils::init_logger(log::Level::Info);
+
+    log::error!("Uh oh!");
+    log::debug!("I'm not going to print");
+    log::warn!("Hmmm a warning? Do I care?");
+
+    panic!("boom.");
 }

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -32,8 +32,6 @@ type InMemoryDb = storage::memory::AsyncInMemoryDatabase;
 
 #[tokio::test]
 async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -66,8 +64,6 @@ async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -127,8 +123,6 @@ async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -214,8 +208,6 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdErro
 
 #[tokio::test]
 async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -301,8 +293,6 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdEr
 //  Test get_child_at_epoch
 #[tokio::test]
 pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let init_ep = 0;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(init_ep)).await?;
@@ -383,8 +373,6 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -441,8 +429,6 @@ async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -528,8 +514,6 @@ async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
 
 #[tokio::test]
 async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -636,8 +620,6 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError>
 
 #[tokio::test]
 async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
-    crate::test_utils::init_logger(log::Level::Info);
-
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     root.write_to_storage(&db).await?;
@@ -718,8 +700,6 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
 // Comment the following line to see log messages being written in failed testing scenarios
 #[should_panic(expected = "boom.")]
 fn boom() {
-    crate::test_utils::init_logger(log::Level::Info);
-
     log::error!("Uh oh!");
     log::debug!("I'm not going to print");
     log::warn!("Hmmm a warning? Do I care?");

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -31,7 +31,7 @@ type InMemoryDb = storage::memory::AsyncInMemoryDatabase;
 //  Test set_child_without_hash and get_child_at_existing_epoch
 
 #[tokio::test]
-async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_set_child_without_hash_at_root() -> Result<(), AkdError> {
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -54,10 +54,7 @@ async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeErro
         set_child == Some(child_hist_node_1),
         "Child in direction is not equal to the set value"
     );
-    assert!(
-        root.get_latest_epoch().unwrap_or(0) == 1,
-        "Latest epochs don't match!"
-    );
+    assert!(root.get_latest_epoch() == 1, "Latest epochs don't match!");
     assert!(
         root.birth_epoch == root.last_epoch,
         "How would the last epoch be different from the birth epoch without an update?"
@@ -67,7 +64,7 @@ async fn test_set_child_without_hash_at_root() -> Result<(), HistoryTreeNodeErro
 }
 
 #[tokio::test]
-async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_set_children_without_hash_at_root() -> Result<(), AkdError> {
     let ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -118,7 +115,7 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
     }
     let latest_ep = root.get_latest_epoch();
-    assert!(latest_ep.unwrap_or(0) == 1, "Latest epochs don't match!");
+    assert!(latest_ep == 1, "Latest epochs don't match!");
     assert!(
         root.birth_epoch == root.last_epoch,
         "How would the last epoch be different from the birth epoch without an update?"
@@ -128,7 +125,7 @@ async fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeE
 }
 
 #[tokio::test]
-async fn test_set_children_without_hash_multiple_at_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_set_children_without_hash_multiple_at_root() -> Result<(), AkdError> {
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -207,7 +204,7 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
     }
     let latest_ep = root.get_latest_epoch();
-    assert!(latest_ep.unwrap_or(0) == 2, "Latest epochs don't match!");
+    assert!(latest_ep == 2, "Latest epochs don't match!");
     assert!(
         root.birth_epoch < root.last_epoch,
         "How is the last epoch not higher than the birth epoch after an udpate?"
@@ -217,7 +214,7 @@ async fn test_set_children_without_hash_multiple_at_root() -> Result<(), History
 }
 
 #[tokio::test]
-async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), AkdError> {
     let mut ep = 1;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
@@ -295,7 +292,7 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
     }
     let latest_ep = root.get_latest_epoch();
-    assert!(latest_ep.unwrap_or(0) == 2, "Latest epochs don't match!");
+    assert!(latest_ep == 2, "Latest epochs don't match!");
     assert!(
         root.birth_epoch < root.last_epoch,
         "How is the last epoch not higher than the birth epoch after an udpate?"
@@ -306,7 +303,7 @@ async fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), Histo
 
 //  Test get_child_at_epoch
 #[tokio::test]
-pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeError> {
+pub async fn test_get_child_at_epoch_at_root() -> Result<(), AkdError> {
     let init_ep = 0;
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(init_ep)).await?;
@@ -378,7 +375,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
         Err(_) => panic!("Child not set in test_set_children_without_hash_at_root"),
     }
     let latest_ep = root.get_latest_epoch();
-    assert!(latest_ep.unwrap_or(0) == 4, "Latest epochs don't match!");
+    assert!(latest_ep == 4, "Latest epochs don't match!");
     assert!(
         root.birth_epoch < root.last_epoch,
         "How is the last epoch not higher than the birth epoch after an udpate?"
@@ -390,7 +387,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
 // insert_single_leaf tests
 
 #[tokio::test]
-async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -446,7 +443,7 @@ async fn test_insert_single_leaf_root() -> Result<(), HistoryTreeNodeError> {
 }
 
 #[tokio::test]
-async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError> {
+async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -531,7 +528,7 @@ async fn test_insert_single_leaf_below_root() -> Result<(), HistoryTreeNodeError
 }
 
 #[tokio::test]
-async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTreeNodeError> {
+async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     let new_leaf = get_leaf_node::<Blake3, _>(
@@ -637,7 +634,7 @@ async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), HistoryTr
 }
 
 #[tokio::test]
-async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError> {
+async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
     let db = InMemoryDb::new();
     let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(0u64)).await?;
     root.write_to_storage(&db).await?;

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -46,7 +46,7 @@ wasm = ["wasm-bindgen", "serde"]
 vrf = ["curve25519-dalek", "ed25519-dalek"]
 
 [dev-dependencies]
-akd = { path = "../akd", version = "^0.5.0", features = ["rand", "vrf"] }
+akd = { path = "../akd", version = "^0.5.0", features = ["vrf", "public-tests"] }
 winter-crypto = "0.2"
 winter-utils = "0.2"
 winter-math = "0.2"

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -196,13 +196,13 @@ where
             non_existence_of_next_few: proof
                 .non_existence_of_next_few
                 .iter()
-                .map(|non_memb_proof| convert_non_membership_proof(&non_memb_proof))
+                .map(|non_memb_proof| convert_non_membership_proof(non_memb_proof))
                 .collect(),
             future_marker_vrf_proofs: proof.future_marker_vrf_proofs.clone(),
             non_existence_of_future_markers: proof
                 .non_existence_of_future_markers
                 .iter()
-                .map(|non_exist_markers| convert_non_membership_proof(&non_exist_markers))
+                .map(|non_exist_markers| convert_non_membership_proof(non_exist_markers))
                 .collect(),
         };
         res_update_proofs.push(update_proof);
@@ -345,7 +345,7 @@ async fn test_history_proof_single_epoch() -> Result<(), AkdError> {
     let key_bytes = key.0.as_bytes().to_vec();
 
     // publishes single key-value
-    akd.publish::<Hash>(vec![(key.clone(), AkdValue(format!("value")))], true)
+    akd.publish::<Hash>(vec![(key.clone(), AkdValue("value".to_string()))], true)
         .await?;
 
     // retrieves and verifies history proofs for the key

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -20,7 +20,7 @@ use alloc::vec;
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
 
-use akd::errors::AkdError;
+use akd::errors::{AkdError, StorageError};
 use akd::storage::types::{AkdLabel, AkdValue};
 
 use crate::hash::DIGEST_BYTES;
@@ -186,7 +186,7 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
         target_label_bytes,
         internal_lookup_proof,
     )
-    .map_err(|i_err| AkdError::AzksNotFound(format!("Internal: {:?}", i_err)));
+    .map_err(|i_err| AkdError::Storage(StorageError::Other(format!("Internal: {:?}", i_err))));
     // check the two results to make sure they both verify
     assert!(matches!(akd_result, Ok(())));
     assert!(matches!(lean_result, Ok(())));

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -344,7 +344,7 @@ impl<'a> AsyncMySqlDatabase {
         let command = "CREATE TABLE IF NOT EXISTS `".to_owned()
             + TABLE_HISTORY_NODE_STATES
             + "` (`label_len` INT UNSIGNED NOT NULL, `label_val` VARBINARY(32) NOT NULL, "
-            + " `epoch` BIGINT UNSIGNED NOT NULL, `value` VARBINARY(2000), `child_states` VARBINARY(2000),"
+            + " `epoch` BIGINT UNSIGNED NOT NULL, `value` VARBINARY(32), `child_states` VARBINARY(2000),"
             + " PRIMARY KEY (`label_len`, `label_val`, `epoch`))";
         tx.query_drop(command).await?;
 

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -757,7 +757,7 @@ impl Storage for AsyncMySqlDatabase {
 
         match self.internal_set(record, None).await {
             Ok(_) => Ok(()),
-            Err(error) => Err(StorageError::SetData(error.to_string())),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -855,7 +855,7 @@ impl Storage for AsyncMySqlDatabase {
         };
         match result.await {
             Ok(_) => Ok(()),
-            Err(error) => Err(StorageError::SetData(error.to_string())),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -924,8 +924,12 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get");
         match result.await {
             Ok(Some(r)) => Ok(r),
-            Ok(None) => Err(StorageError::GetData("Not found".to_string())),
-            Err(error) => Err(StorageError::GetData(error.to_string())),
+            Ok(None) => Err(StorageError::NotFound(format!(
+                "{:?} {:?}",
+                St::data_type(),
+                id
+            ))),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -1092,7 +1096,7 @@ impl Storage for AsyncMySqlDatabase {
                         map.push(item);
                     }
                 }
-                Err(error) => return Err(StorageError::GetData(error.to_string())),
+                Err(error) => return Err(StorageError::Other(format!("MySQL Error {}", error))),
             }
         }
         Ok(map)
@@ -1188,7 +1192,7 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get user data");
         match result.await {
             Ok(output) => Ok(output),
-            Err(code) => Err(StorageError::GetData(code.to_string())),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -1298,8 +1302,8 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get user state");
         match result.await {
             Ok(Some(result)) => Ok(result),
-            Ok(None) => Err(StorageError::GetData(String::from("Not found"))),
-            Err(code) => Err(StorageError::GetData(code.to_string())),
+            Ok(None) => Err(StorageError::NotFound(format!("ValueState {:?}", username))),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -1492,7 +1496,7 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get user states");
         match result.await {
             Ok(()) => Ok(results),
-            Err(code) => Err(StorageError::GetData(code.to_string())),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 
@@ -1533,12 +1537,12 @@ impl Storage for AsyncMySqlDatabase {
 
         debug!("END MySQL get epoch LTE epoch");
         match result.await {
-            Ok(u64::MAX) => Err(StorageError::GetData(format!(
+            Ok(u64::MAX) => Err(StorageError::NotFound(format!(
                 "Node (val: {:?}, len: {}) did not exist <= epoch {}",
                 node_label.val, node_label.len, epoch_in_question
             ))),
             Ok(ep) => Ok(ep),
-            Err(code) => Err(StorageError::GetData(code.to_string())),
+            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
         }
     }
 }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -301,6 +301,7 @@ impl<'a> AsyncMySqlDatabase {
                     attempts,
                     start.elapsed().as_secs()
                 );
+                error!("{}", message);
                 return Err(StorageError::Connection(message));
             }
 
@@ -757,7 +758,10 @@ impl Storage for AsyncMySqlDatabase {
 
         match self.internal_set(record, None).await {
             Ok(_) => Ok(()),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -855,7 +859,10 @@ impl Storage for AsyncMySqlDatabase {
         };
         match result.await {
             Ok(_) => Ok(()),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -929,7 +936,10 @@ impl Storage for AsyncMySqlDatabase {
                 St::data_type(),
                 id
             ))),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -1096,7 +1106,10 @@ impl Storage for AsyncMySqlDatabase {
                         map.push(item);
                     }
                 }
-                Err(error) => return Err(StorageError::Other(format!("MySQL Error {}", error))),
+                Err(error) => {
+                    error!("MySQL error {}", error);
+                    return Err(StorageError::Other(format!("MySQL Error {}", error)));
+                }
             }
         }
         Ok(map)
@@ -1192,7 +1205,10 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get user data");
         match result.await {
             Ok(output) => Ok(output),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -1303,7 +1319,10 @@ impl Storage for AsyncMySqlDatabase {
         match result.await {
             Ok(Some(result)) => Ok(result),
             Ok(None) => Err(StorageError::NotFound(format!("ValueState {:?}", username))),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -1496,7 +1515,10 @@ impl Storage for AsyncMySqlDatabase {
         debug!("END MySQL get user states");
         match result.await {
             Ok(()) => Ok(results),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 
@@ -1542,7 +1564,10 @@ impl Storage for AsyncMySqlDatabase {
                 node_label.val, node_label.len, epoch_in_question
             ))),
             Ok(ep) => Ok(ep),
-            Err(error) => Err(StorageError::Other(format!("MySQL Error {}", error))),
+            Err(error) => {
+                error!("MySQL error {}", error);
+                Err(StorageError::Other(format!("MySQL Error {}", error)))
+            }
         }
     }
 }

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -80,7 +80,7 @@ impl MySqlStorable for DbRecord {
                 if let Ok(bin_data) = bincode::serialize(&state.child_states) {
                     let id = state.get_id();
                     Some(
-                        params! { "label_len" => id.0.len, "label_val" => id.0.val, "epoch" => id.1, "value" => state.value.clone(), "child_states" => bin_data },
+                        params! { "label_len" => id.0.len, "label_val" => id.0.val, "epoch" => id.1, "value" => state.value, "child_states" => bin_data },
                     )
                 } else {
                     None
@@ -152,7 +152,7 @@ impl MySqlStorable for DbRecord {
                             (format!("label_len{}", idx), Value::from(id.0.len)),
                             (format!("label_val{}", idx), Value::from(id.0.val)),
                             (format!("epoch{}", idx), Value::from(id.1)),
-                            (format!("value{}", idx), Value::from(state.value.clone())),
+                            (format!("value{}", idx), Value::from(state.value)),
                             (format!("child_states{}", idx), Value::from(bin_data)),
                         ])
                     } else {

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -297,7 +297,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Storage + Sync + Send, V: VRFK
             }
 
             println!("Metrics after publish(es).");
-            reset_mysql_db::<S>(&mysql_db).await;
+            reset_mysql_db::<S>(mysql_db).await;
 
             let start = Instant::now();
             // Lookup selected users one by one
@@ -321,7 +321,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Storage + Sync + Send, V: VRFK
             );
 
             println!("Metrics after individual lookups:");
-            reset_mysql_db::<S>(&mysql_db).await;
+            reset_mysql_db::<S>(mysql_db).await;
 
             let start = Instant::now();
             // Bulk lookup selected users
@@ -349,7 +349,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Storage + Sync + Send, V: VRFK
             );
 
             println!("Metrics after lookup proofs: ");
-            reset_mysql_db::<S>(&mysql_db).await;
+            reset_mysql_db::<S>(mysql_db).await;
         }
     }
 }


### PR DESCRIPTION
A decent-sized rewrite of the error constructs to clarify a lot of the error patterns (i.e. storage throws clearer errors rather than just get/set). Additionally

1. Small utility functions which cannot throw errors should not return `Result<_, _>` and have been rewritten to not be error potential.
2. Digest serialization changed to `[u8; 32]` from `Vec<u8>` as we know the size and it makes it clearer to other developers downstream