### PR TITLE
Making the dalek dependencies a less specific version

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,12 @@ readme = "../README.md"
 
 [features]
 bench = ["public-tests"]
-public-tests = ["rand", "bincode", "serde", "colored", "once_cell", "ed25519-dalek/serde"]
+public-tests = ["rand", "bincode", "colored", "once_cell", "serde_serialization"]
 # In the event that VRF's are enabled, AND builder has requested serde support
 # Add the serde flag to the dalek crate with --features "ed25519-dalek/serde"
 vrf = ["curve25519-dalek", "ed25519-dalek"]
 default = ["vrf"]
+serde_serialization = ["serde", "ed25519-dalek/serde"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ serde = { version = "1.0", optional = true, features = ["derive"]}
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 wee_alloc = { version = "0.4.5", optional = true }
 
-curve25519-dalek = { version = "3.2", optional = true }
+curve25519-dalek = { version = "3", optional = true }
 ed25519-dalek = { version = "1", features = ["serde"], optional = true}
 
 [features]

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.5.0", features = ["serde"] }
+akd = { path = "../akd", version = "^0.5.0", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.5.0", features = ["public-tests", "serde"] }
+akd = { path = "../akd", version = "^0.5.0", features = ["public-tests"] }


### PR DESCRIPTION
Rolling the `curve25519-dalek` crate to only be v 3 instead of v 3.2 which allows for more downstream flexibility in version upgrades.

Also added a new meta-feature for proper serde handling. Will release v 0.5.3 after merging
