### PR TITLE
Using EMPTY_VALUE in place of &[0u8]

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -748,7 +748,7 @@ mod tests {
         let mut proof = azks
             .get_membership_proof(&db, insertion_set[0].label, 1)
             .await?;
-        let hash_val = Blake3::hash(&[0u8]);
+        let hash_val = Blake3::hash(&EMPTY_VALUE);
         proof = MembershipProof::<Blake3> {
             label: proof.label,
             hash_val,
@@ -757,7 +757,7 @@ mod tests {
         assert!(
             !verify_membership::<Blake3>(azks.get_root_hash::<_, Blake3>(&db).await?, &proof)
                 .is_ok(),
-            "Membership proof does verifies, despite being wrong"
+            "Membership proof does verify, despite being wrong"
         );
 
         Ok(())

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -170,7 +170,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                         .vrf
                         .get_node_label::<H>(&uname, false, latest_version)
                         .await?;
-                    let stale_value_to_add = H::hash(&[0u8]);
+                    let stale_value_to_add = H::hash(&crate::EMPTY_VALUE);
                     let fresh_value_to_add = crate::utils::value_to_bytes::<H>(&val);
                     update_set.push(Node::<H> {
                         label: stale_label,

--- a/akd/src/history_tree_node.rs
+++ b/akd/src/history_tree_node.rs
@@ -923,7 +923,7 @@ mod tests {
         let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(1), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         root.write_to_storage(&db).await?;
@@ -955,12 +955,12 @@ mod tests {
         let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(1), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(0), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         root.write_to_storage(&db).await?;
@@ -1014,12 +1014,12 @@ mod tests {
         let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(11), 2),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(00), 2),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         root.write_to_storage(&db).await?;
@@ -1040,12 +1040,12 @@ mod tests {
 
         let child_hist_node_3: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(1), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         let child_hist_node_4: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(0), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         root.write_to_storage(&db).await?;
@@ -1099,12 +1099,12 @@ mod tests {
         let mut root = get_empty_root::<Blake3, _>(&db, Option::Some(ep)).await?;
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(11), 2),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(00), 2),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         root.write_to_storage(&db).await?;
@@ -1125,12 +1125,12 @@ mod tests {
 
         let child_hist_node_3: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(1), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         let child_hist_node_4: HistoryChildState = HistoryChildState::new::<Blake3>(
             NodeLabel::new(byte_arr_from_u64(0), 1),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             ep,
         );
         assert!(
@@ -1189,12 +1189,12 @@ mod tests {
                     byte_arr_from_u64(0b1u64 << ep.clone()),
                     ep.try_into().unwrap(),
                 ),
-                Blake3::hash(&[0u8]),
+                Blake3::hash(&EMPTY_VALUE),
                 2 * ep,
             );
             let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
                 NodeLabel::new(byte_arr_from_u64(0), ep.clone().try_into().unwrap()),
-                Blake3::hash(&[0u8]),
+                Blake3::hash(&EMPTY_VALUE),
                 2 * ep,
             );
             root.write_to_storage(&db).await?;
@@ -1211,7 +1211,7 @@ mod tests {
                 byte_arr_from_u64(0b1u64 << ep_existing.clone()),
                 ep_existing.try_into().unwrap(),
             ),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             2 * ep_existing,
         );
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
@@ -1219,7 +1219,7 @@ mod tests {
                 byte_arr_from_u64(0),
                 ep_existing.clone().try_into().unwrap(),
             ),
-            Blake3::hash(&[0u8]),
+            Blake3::hash(&EMPTY_VALUE),
             2 * ep_existing,
         );
 
@@ -1264,7 +1264,7 @@ mod tests {
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32),
-            &Blake3::hash(&[0u8]),
+            &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             0,
         )
@@ -1320,7 +1320,7 @@ mod tests {
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
-            &Blake3::hash(&[0u8]),
+            &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             1,
         )
@@ -1405,7 +1405,7 @@ mod tests {
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b000u64), 3u32),
-            &Blake3::hash(&[0u8]),
+            &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             0,
         )


### PR DESCRIPTION
Found a couple of places where we should be referring to the constant instead of &[0u8]