### PR TITLE
Using proper commitments for the AkdValue leaf node representation

### DIFF
--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -145,6 +145,8 @@ pub struct LookupProof<H: Hasher> {
     pub freshness_vrf_proof: Vec<u8>,
     /// Freshness proof (non membership of stale label)
     pub freshness_proof: NonMembershipProof<H>,
+    /// Proof for commitment value derived from raw AkdLabel and AkdValue
+    pub commitment_proof: Vec<u8>,
 }
 
 // Manual implementation of Clone, see: https://github.com/rust-lang/rust/issues/41481
@@ -160,6 +162,7 @@ impl<H: Hasher> Clone for LookupProof<H> {
             existence_vrf_proof: self.existence_vrf_proof.clone(),
             marker_vrf_proof: self.marker_vrf_proof.clone(),
             freshness_vrf_proof: self.freshness_vrf_proof.clone(),
+            commitment_proof: self.commitment_proof.clone(),
         }
     }
 }
@@ -199,6 +202,8 @@ pub struct UpdateProof<H: Hasher> {
     pub future_marker_vrf_proofs: Vec<Vec<u8>>,
     /// Proof that future markers did not exist
     pub non_existence_of_future_markers: Vec<NonMembershipProof<H>>,
+    /// Proof for commitment value derived from raw AkdLabel and AkdValue
+    pub commitment_proof: Vec<u8>,
 }
 
 // Manual implementation of Clone, see: https://github.com/rust-lang/rust/issues/41481
@@ -217,6 +222,7 @@ impl<H: Hasher> Clone for UpdateProof<H> {
             previous_val_vrf_proof: self.previous_val_vrf_proof.clone(),
             next_few_vrf_proofs: self.next_few_vrf_proofs.clone(),
             future_marker_vrf_proofs: self.future_marker_vrf_proofs.clone(),
+            commitment_proof: self.commitment_proof.clone(),
         }
     }
 }

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -86,6 +86,11 @@ pub(crate) fn get_commitment_proof<H: Hasher>(
 //
 // proof = H(commitment_key, label, version, value)
 // commmitment = H(value, proof)
+//
+// The proof value is a nonce used to create a hiding and binding commitment using a
+// cryptographic hash function. Note that it is derived from the label, version, and
+// value (even though the binding to value is somewhat optional).
+//
 // Note that this commitment needs to be a hash function (random oracle) output
 pub(crate) fn commit_value<H: Hasher>(
     commitment_key: &[u8],

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -164,6 +164,7 @@ where
         marker_proof: convert_membership_proof(&proof.marker_proof),
         freshness_vrf_proof: proof.freshness_vrf_proof.clone(),
         freshness_proof: convert_non_membership_proof(&proof.freshness_proof),
+        commitment_proof: proof.commitment_proof.clone(),
     }
 }
 
@@ -202,6 +203,7 @@ where
                 .iter()
                 .map(|non_exist_markers| convert_non_membership_proof(non_exist_markers))
                 .collect(),
+            commitment_proof: proof.commitment_proof.clone(),
         };
         res_update_proofs.push(update_proof);
     }

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -201,6 +201,8 @@ pub struct LookupProof {
     pub freshness_vrf_proof: Vec<u8>,
     /// Freshness proof (non member at previous epoch)
     pub freshness_proof: NonMembershipProof,
+    /// Proof for commitment value derived from raw AkdLabel and AkdValue
+    pub commitment_proof: Vec<u8>,
 }
 
 /// A vector of UpdateProofs are sent as the proof to a history query for a particular key.
@@ -237,6 +239,8 @@ pub struct UpdateProof {
     pub future_marker_vrf_proofs: Vec<Vec<u8>>,
     /// Proof that future markers did not exist
     pub non_existence_of_future_markers: Vec<NonMembershipProof>,
+    /// Proof for commitment value derived from raw AkdLabel and AkdValue
+    pub commitment_proof: Vec<u8>,
 }
 
 /// This proof is just an array of [`UpdateProof`]s.

--- a/akd_client/src/utils.rs
+++ b/akd_client/src/utils.rs
@@ -15,8 +15,17 @@ pub(crate) fn get_marker_version(version: u64) -> u64 {
     64u64 - (version.leading_zeros() as u64) - 1u64
 }
 
-// FIXME: Make a real commitment here, alongwith a blinding factor. See issue #123
-/// Gets the bytes for a value.
-pub(crate) fn value_to_bytes(value: &crate::AkdValue) -> crate::Digest {
-    crate::hash::hash(value)
+// Corresponds to the I2OSP() function from RFC8017, prepending the length of
+// a byte array to the byte array (so that it is ready for serialization and hashing)
+//
+// Input byte array cannot be > 2^64-1 in length
+pub(crate) fn i2osp_array(input: &[u8]) -> Vec<u8> {
+    [&(input.len() as u64).to_be_bytes(), input].concat()
+}
+
+pub(crate) fn generate_commitment_from_proof_client(
+    value: &crate::AkdValue,
+    proof: &[u8],
+) -> crate::Digest {
+    crate::hash::hash(&[i2osp_array(value), i2osp_array(proof)].concat())
 }


### PR DESCRIPTION
Introducing a commitment to replace the `value_to_bytes` function used to convert AkdValues to bytestrings that get hashed. We will use a keyed hash (modeled as a random oracle) as a commitment here.

This means we need the server to hold a commitment_key server. The server needs to generate a proof for each label+value, and send this proof as a component of the lookup and update proofs. The client can then verify the proofs by supplying the raw value and checking that the commitment matches.

Construction:

proof = H(commitment_key, label, version, value)
commmitment = H(value, proof)

Resolves #123.

Note that we do a kindof hacky generation of the commitment key for now. Opened #184 to track a fix for this.