### PR TITLE
Protect storage key deserializations

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -57,7 +57,7 @@ impl Storable for Azks {
     }
 
     fn key_from_full_binary(bin: &[u8]) -> Result<u8, String> {
-        if bin[0] != StorageType::Azks as u8 {
+        if bin.is_empty() || bin[0] != StorageType::Azks as u8 {
             return Err("Not an AZKS key".to_string());
         }
         Ok(DEFAULT_AZKS_KEY)

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -56,7 +56,10 @@ impl Storable for Azks {
         vec![StorageType::Azks as u8, *key]
     }
 
-    fn key_from_full_binary(_bin: &[u8]) -> Result<u8, String> {
+    fn key_from_full_binary(bin: &[u8]) -> Result<u8, String> {
+        if bin[0] != StorageType::Azks as u8 {
+            return Err("Not an AZKS key".to_string());
+        }
         Ok(DEFAULT_AZKS_KEY)
     }
 }

--- a/akd/src/history_tree_node.rs
+++ b/akd/src/history_tree_node.rs
@@ -94,6 +94,10 @@ impl Storable for HistoryTreeNode {
             return Err("Not enough bytes to form a proper key".to_string());
         }
 
+        if bin[0] != StorageType::HistoryTreeNode as u8 {
+            return Err("Not a history tree node key".to_string());
+        }
+
         let len_bytes: [u8; 4] = bin[1..=4].try_into().expect("Slice with incorrect length");
         let val_bytes: [u8; 32] = bin[5..=36].try_into().expect("Slice with incorrect length");
         let len = u32::from_le_bytes(len_bytes);

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -302,6 +302,10 @@ impl Storable for HistoryNodeState {
             return Err("Not enough bytes to form a proper key".to_string());
         }
 
+        if bin[0] != StorageType::HistoryNodeState as u8 {
+            return Err("Not a history node state key".to_string());
+        }
+
         let len_bytes: [u8; 4] = bin[1..=4].try_into().expect("Slice with incorrect length");
         let val_bytes: [u8; 32] = bin[5..=36].try_into().expect("Slice with incorrect length");
         let epoch_bytes: [u8; 8] = bin[37..=44]

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -109,6 +109,11 @@ impl crate::storage::Storable for ValueState {
         if bin.len() < 10 {
             return Err("Not enough bytes to form a proper key".to_string());
         }
+
+        if bin[0] != StorageType::ValueState as u8 {
+            return Err("Not a value state key".to_string());
+        }
+
         let epoch_bytes: [u8; 8] = bin[1..=8].try_into().expect("Slice with incorrect length");
         let epoch = u64::from_le_bytes(epoch_bytes);
         Ok(ValueStateKey(bin[9..].to_vec(), epoch))


### PR DESCRIPTION
This change adds a protection on storage-type key deserialization to assert that the first byte does indeed denote the same type of key that is trying to be deserialzed.