### PR TITLE
Make VRF(Public|Private) key Cloneable

### DIFF
--- a/akd/src/ecvrf/ecvrf_impl.rs
+++ b/akd/src/ecvrf/ecvrf_impl.rs
@@ -54,8 +54,17 @@ impl core::ops::Deref for VRFPrivateKey {
         &self.0
     }
 }
+
+impl std::clone::Clone for VRFPrivateKey {
+    fn clone(&self) -> Self {
+        // In theory, creating a key from bytes could be a DecodingError, except
+        // we just copied these bytes out of the source key, so ...
+        Self(ed25519_PrivateKey::from_bytes(self.0.as_bytes()).unwrap())
+    }
+}
+
 /// An ECVRF public key
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct VRFPublicKey(ed25519_PublicKey);
 

--- a/akd/src/ecvrf/no_vrf.rs
+++ b/akd/src/ecvrf/no_vrf.rs
@@ -15,6 +15,7 @@ use winter_crypto::Digest;
 use winter_crypto::Hasher;
 
 /// A mock VRF public key
+#[derive(Clone)]
 pub struct VRFPublicKey;
 
 impl VRFPublicKey {
@@ -34,6 +35,7 @@ impl VRFPublicKey {
 }
 
 /// A mock VRF private key
+#[derive(Clone)]
 pub struct VRFPrivateKey;
 
 /// A mock VRF proof

--- a/akd/src/ecvrf/tests.rs
+++ b/akd/src/ecvrf/tests.rs
@@ -267,6 +267,29 @@ fn test_output_from_proof() {
     }
 }
 
+#[test]
+fn test_publickey_clone() {
+    // PublicKey has its own implementation of Clone
+    for tv in TESTVECTORS.iter() {
+        let orig = from_string!(VRFPublicKey, tv.PK);
+        let clone = orig.clone();
+        // the same bytes comprise both keys
+        assert_eq!(orig.as_bytes(), clone.as_bytes());
+    }
+}
+
+#[test]
+fn test_privatekey_clone() {
+    // PrivateKey (aka SecretKey) uses a custom implementation of clone wherein
+    // the cloned key is created from the bytes of the original
+    for tv in TESTVECTORS.iter() {
+        let orig = from_string!(VRFPrivateKey, tv.SK);
+        let clone = orig.clone();
+        // the same bytes comprise both keys
+        assert_eq!(orig.as_bytes(), clone.as_bytes());
+    }
+}
+
 proptest! {
     #[test]
     fn test_prove_and_verify(


### PR DESCRIPTION
This implements the std::clone::Clone trait on the VRFPublicKey and VRFPrivateKey structs. In the case of the PublicKey, the ed25519_dalek::PublicKey already supports clone so the trait can be #derived. The ed25519_dalek::SecretKey does not, so a manual implementation is required. It simply creates a new SecretKey out of the bytes of the original.