### PR TITLE
Adjusting crate dependency tree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,17 @@ jobs:
       run: cargo publish --manifest-path Cargo.toml -p akd
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish AKD_CLIENT
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_client
+    - name: Publish crate akd_client
+      run: cargo publish --manifest-path Cargo.toml -p akd_client
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
     - name: Run the script that waits for AKD to be published
       run: bash ./.github/workflows/wait-for-akd-publish.sh
     - name: Dry run publish AKD_MYSQL
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
     - name: Publish crate akd_mysql
       run: cargo publish --manifest-path Cargo.toml -p akd_mysql
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
-    - name: Dry run publish AKD_CLIENT
-      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_client
-    - name: Publish crate akd_client
-      run: cargo publish --manifest-path Cargo.toml -p akd_client
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.5.0", features = ["serde_serialization"] }
+akd = { path = "../akd", version = "^0.5.4", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.5.0", features = ["public-tests"] }
+akd = { path = "../akd", version = "^0.5.4", features = ["public-tests"] }


### PR DESCRIPTION
Needed to hard-target specific version of AKD such that mysql has the expected serialization feature flag.

Also moved akd_client up in the publish flow, as it doesn't strictly depend on the akd crate to publish.