### PR TITLE
Adding verification of sequential nature of history proof

### DIFF
--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -167,9 +167,22 @@ pub fn key_history_verify<H: Hasher>(
     allow_tombstones: bool,
 ) -> Result<Vec<bool>, AkdError> {
     let mut tombstones = vec![];
+    let some_max_version = proof.proofs.get(0).map(|item| item.version);
     for (count, update_proof) in proof.proofs.into_iter().enumerate() {
         let root_hash = root_hashes[count];
         let previous_root_hash = previous_root_hashes[count];
+        if let Some(max_version) = some_max_version {
+            if update_proof.version != max_version - (count as u64) {
+                // there is a version mismatch, therefore we should return an error as there appears to be
+                // missing history in the key history
+                return Err(AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(
+                    format!(
+                        "Expected version {} is missing from the key history",
+                        count + 1
+                    ),
+                )));
+            }
+        }
         let is_tombstone = verify_single_update_proof::<H>(
             root_hash,
             vrf_pk,


### PR DESCRIPTION
We calculate the expected version number given a maximum version, and work backwards assuring that the versions are sequentially decreasing until the minimum version. This assures there are no gaps in the history 

Resolves #191