### PR TITLE
Migrate from structopt to clap 3 and fix random string generation

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -19,8 +19,9 @@ use crate::storage::types::{AkdLabel, AkdValue, DbRecord, ValueState, ValueState
 use crate::storage::Storage;
 
 use log::{debug, error, info};
+
 #[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
+use rand::{distributions::Alphanumeric, CryptoRng, Rng};
 
 use crate::node_state::NodeLabel;
 use std::collections::HashMap;
@@ -45,7 +46,7 @@ pub struct LookupInfo {
 #[cfg(feature = "rand")]
 impl AkdValue {
     /// Gets a random value for a AKD
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         Self::from_utf8_str(&get_random_str(rng))
     }
 }
@@ -53,7 +54,7 @@ impl AkdValue {
 #[cfg(feature = "rand")]
 impl AkdLabel {
     /// Creates a random key for a AKD
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         Self::from_utf8_str(&get_random_str(rng))
     }
 }
@@ -772,10 +773,11 @@ pub(crate) fn get_marker_version(version: u64) -> u64 {
 }
 
 #[cfg(feature = "rand")]
-fn get_random_str<R: RngCore + CryptoRng>(rng: &mut R) -> String {
-    let mut byte_str = [0u8; 32];
-    rng.fill_bytes(&mut byte_str);
-    format!("{:?}", &byte_str)
+fn get_random_str<R: CryptoRng + Rng>(rng: &mut R) -> String {
+    rng.sample_iter(&Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect()
 }
 
 type KeyHistoryHelper<D> = (Vec<D>, Vec<Option<D>>);

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -18,7 +18,6 @@ rand = "0.8"
 once_cell = "1"
 thread-id = "3"
 multi_log = "0.1"
-clap = "2"
 hex = "0.4.3"
 
 akd = { path = "../akd", features = ["public-tests"] }

--- a/poc/Cargo.toml
+++ b/poc/Cargo.toml
@@ -12,13 +12,12 @@ winter-math = "0.2"
 tokio = { version = "1.10", features = ["full"] }
 colored = "2.0.0"
 hex = "0.4.3"
-structopt = "0.3.13"
 rand = "0.8"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 once_cell = "1"
 thread-id = "3"
 multi_log = "0.1"
-clap = "2"
+clap = { version="3", features = ["derive"] }
 
 akd = { path = "../akd", features = ["public-tests"] }
 akd_mysql = { path = "../akd_mysql" }


### PR DESCRIPTION
`structopt` is now in [maintenance mode](https://docs.rs/structopt/latest/structopt/#maintenance) and has been superseded by `clap` v3. This PR migrates us to `clap`.

In addition, the `get_random_str` helper function did not properly generate 32-byte strings. Instead of creating a 32-char string, it created a string of an array of 32 bytes (e.g. `"[244, 198, 197, 130, ...]"`). This PR fixes the function to return a random 32-char string which can later be interpreted as 32 bytes.