### PR TITLE
Skip duplicate values for a user if they're equal in a publish

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.5.5"
+version = "0.6.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -208,9 +208,9 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             info!("After filtering for duplicated user information, there is no publish which is necessary (0 updates)");
             // The AZKS has not been updated/mutated at this point, so we can just return the root hash from before
             let root_hash = current_azks
-                .get_root_hash_at_epoch::<_, H>(&self.storage, current_epoch)
+                .get_root_hash::<_, H>(&self.storage)
                 .await?;
-            return Ok(EpochHash(current_azks.get_latest_epoch(), root_hash));
+            return Ok(EpochHash(current_epoch, root_hash));
         }
 
         if let false = self.storage.begin_transaction().await {

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -208,7 +208,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             info!("After filtering for duplicated user information, there is no publish which is necessary (0 updates)");
             // The AZKS has not been updated/mutated at this point, so we can just return the root hash from before
             let root_hash = current_azks
-                .get_root_hash_at_epoch::<_, H>(&self.storage, next_epoch)
+                .get_root_hash_at_epoch::<_, H>(&self.storage, current_epoch)
                 .await?;
             return Ok(EpochHash(current_azks.get_latest_epoch(), root_hash));
         }
@@ -246,7 +246,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             .get_root_hash_at_epoch::<_, H>(&self.storage, next_epoch)
             .await?;
 
-        Ok(EpochHash(current_epoch, root_hash))
+        Ok(EpochHash(next_epoch, root_hash))
         // At the moment the tree root is not being written anywhere. Eventually we
         // want to change this to call a write operation to post to a blockchain or some such thing
     }

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -207,9 +207,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         if insertion_set.is_empty() {
             info!("After filtering for duplicated user information, there is no publish which is necessary (0 updates)");
             // The AZKS has not been updated/mutated at this point, so we can just return the root hash from before
-            let root_hash = current_azks
-                .get_root_hash::<_, H>(&self.storage)
-                .await?;
+            let root_hash = current_azks.get_root_hash::<_, H>(&self.storage).await?;
             return Ok(EpochHash(current_epoch, root_hash));
         }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -166,7 +166,11 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                         ValueState::new(uname, val, latest_version, label, next_epoch);
                     user_data_update_set.push(latest_state);
                 }
-                Some(previous_version) => {
+                Some((_, previous_value)) if val == *previous_value => {
+                    // skip this version because the user is trying to re-publish the already most recent value
+                    // Issue #197: https://github.com/novifinancial/akd/issues/197
+                }
+                Some((previous_version, _)) => {
                     // Data found for the given user
                     let latest_version = *previous_version + 1;
                     let stale_label = self
@@ -199,6 +203,15 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             }
         }
         let insertion_set: Vec<Node<H>> = update_set.to_vec();
+
+        if insertion_set.is_empty() {
+            info!("After filtering for duplicated user information, there is no publish which is necessary (0 updates)");
+            // The AZKS has not been updated/mutated at this point, so we can just return the root hash from before
+            let root_hash = current_azks
+                .get_root_hash_at_epoch::<_, H>(&self.storage, next_epoch)
+                .await?;
+            return Ok(EpochHash(current_azks.get_latest_epoch(), root_hash));
+        }
 
         if let false = self.storage.begin_transaction().await {
             error!("Transaction is already active");

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -12,7 +12,8 @@
 use crate::errors::StorageError;
 use crate::storage::transaction::Transaction;
 use crate::storage::types::{
-    AkdLabel, DbRecord, KeyData, StorageType, ValueState, ValueStateKey, ValueStateRetrievalFlag,
+    AkdLabel, AkdValue, DbRecord, KeyData, StorageType, ValueState, ValueStateKey,
+    ValueStateRetrievalFlag,
 };
 use crate::storage::{Storable, Storage, StorageUtil};
 use async_trait::async_trait;
@@ -324,11 +325,14 @@ impl Storage for AsyncInMemoryDatabase {
         &self,
         keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> Result<HashMap<AkdLabel, u64>, StorageError> {
+    ) -> Result<HashMap<AkdLabel, (u64, AkdValue)>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
             if let Ok(result) = self.get_user_state(username, flag).await {
-                map.insert(AkdLabel(result.username.to_vec()), result.version);
+                map.insert(
+                    AkdLabel(result.username.to_vec()),
+                    (result.version, AkdValue(result.plaintext_val.to_vec())),
+                );
             }
         }
         Ok(map)
@@ -792,11 +796,14 @@ impl Storage for AsyncInMemoryDbWithCache {
         &self,
         keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> Result<HashMap<AkdLabel, u64>, StorageError> {
+    ) -> Result<HashMap<AkdLabel, (u64, AkdValue)>, StorageError> {
         let mut map = HashMap::new();
         for username in keys.iter() {
             if let Ok(result) = self.get_user_state(username, flag).await {
-                map.insert(AkdLabel(result.username.to_vec()), result.version);
+                map.insert(
+                    AkdLabel(result.username.to_vec()),
+                    (result.version, AkdValue(result.plaintext_val.to_vec())),
+                );
             }
         }
         Ok(map)

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -151,7 +151,7 @@ pub trait Storage: Clone {
         &self,
         keys: &[types::AkdLabel],
         flag: types::ValueStateRetrievalFlag,
-    ) -> Result<HashMap<types::AkdLabel, u64>, StorageError>;
+    ) -> Result<HashMap<types::AkdLabel, (u64, types::AkdValue)>, StorageError>;
 }
 
 /// Optional storage layer utility functions for debug and test purposes

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -149,7 +149,7 @@ pub trait Storage: Clone {
     /// Retrieve the user -> state version mapping in bulk. This is the same as get_user_states but with less data retrieved from the storage layer
     async fn get_user_state_versions(
         &self,
-        keys: &[types::AkdLabel],
+        usernames: &[types::AkdLabel],
         flag: types::ValueStateRetrievalFlag,
     ) -> Result<HashMap<types::AkdLabel, (u64, types::AkdValue)>, StorageError>;
 }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -260,7 +260,7 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
                     .find(|&x| {
                         if let DbRecord::ValueState(value_state) = &x {
                             return value_state.username == result.0
-                                && value_state.version == result.1;
+                                && value_state.version == result.1 .0;
                         }
                         false
                     })
@@ -274,7 +274,7 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
                     });
 
                 // assert it matches what was given matches what was retrieved
-                assert_eq!(Some(result.1), initial_record);
+                assert_eq!(Some(result.1 .0), initial_record);
             }
         }
     }
@@ -301,7 +301,7 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
                     .find(|&x| {
                         if let DbRecord::ValueState(value_state) = &x {
                             return value_state.username == result.0
-                                && value_state.version == result.1;
+                                && value_state.version == result.1 .0;
                         }
                         false
                     })
@@ -314,7 +314,7 @@ async fn test_batch_get_items<Ns: Storage>(storage: &Ns) {
                         }
                     });
                 // assert it matches what was given matches what was retrieved
-                assert_eq!(Some(result.1), initial_record);
+                assert_eq!(Some(result.1 .0), initial_record);
             }
         }
     }

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -109,11 +109,11 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
     akd.publish::<Blake3>(vec![
         (
             AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
+            AkdValue::from_utf8_str("world_2"),
         ),
         (
             AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
+            AkdValue::from_utf8_str("world2_2"),
         ),
     ])
     .await?;
@@ -229,11 +229,11 @@ async fn test_simple_audit() -> Result<(), AkdError> {
     akd.publish::<Blake3>(vec![
         (
             AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
+            AkdValue::from_utf8_str("world_2"),
         ),
         (
             AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
+            AkdValue::from_utf8_str("world2_2"),
         ),
     ])
     .await?;
@@ -581,11 +581,11 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
     akd.publish::<Blake3>(vec![
         (
             AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
+            AkdValue::from_utf8_str("world_2"),
         ),
         (
             AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
+            AkdValue::from_utf8_str("world2_2"),
         ),
     ])
     .await?;
@@ -774,6 +774,52 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
     assert_eq!(false, tombstones[2]);
     assert_eq!(true, tombstones[3]);
     assert_eq!(true, tombstones[4]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_publish_skip_same_value() -> Result<(), AkdError> {
+    let db = AsyncInMemoryDatabase::new();
+    let vrf = HardCodedAkdVRF {};
+    // epoch 0
+    let akd = Directory::<_, _>::new::<Blake3>(&db, &vrf, false).await?;
+
+    // epoch 1
+    let epoch1_hash = akd
+        .publish::<Blake3>(vec![(
+            AkdLabel::from_utf8_str("user"),
+            AkdValue::from_utf8_str("value"),
+        )])
+        .await?;
+
+    assert_eq!(1u64, epoch1_hash.0);
+
+    // still epoch 1 because the value is the same
+    let epoch1_hash_again = akd
+        .publish::<Blake3>(vec![(
+            AkdLabel::from_utf8_str("user"),
+            AkdValue::from_utf8_str("value"),
+        )])
+        .await?;
+
+    assert_eq!(1u64, epoch1_hash_again.0);
+
+    // epoch 2 because even though 1 value is the same, the other value is unique so we
+    // should continue with a publish
+    let epoch2_hash = akd
+        .publish::<Blake3>(vec![
+            (
+                AkdLabel::from_utf8_str("user"),
+                AkdValue::from_utf8_str("value"),
+            ),
+            (
+                AkdLabel::from_utf8_str("user2"),
+                AkdValue::from_utf8_str("value"),
+            ),
+        ])
+        .await?;
+    assert_eq!(2u64, epoch2_hash.0);
 
     Ok(())
 }

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -804,6 +804,7 @@ async fn test_publish_skip_same_value() -> Result<(), AkdError> {
         .await?;
 
     assert_eq!(1u64, epoch1_hash_again.0);
+    assert_eq!(epoch1_hash.1, epoch1_hash_again.1);
 
     // epoch 2 because even though 1 value is the same, the other value is unique so we
     // should continue with a publish

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.5.5"
+version = "0.6.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.5.5"
+version = "0.6.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.5.4", features = ["serde_serialization"] }
+akd = { path = "../akd", version = "^0.6.0", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.5.4", features = ["public-tests"] }
+akd = { path = "../akd", version = "^0.6.0", features = ["public-tests"] }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -12,7 +12,7 @@ use akd::errors::StorageError;
 use akd::history_tree_node::HistoryTreeNode;
 use akd::node_state::HistoryNodeState;
 use akd::storage::types::{
-    AkdLabel, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
+    AkdLabel, AkdValue, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
 };
 use akd::storage::{Storable, Storage};
 use akd::NodeLabel;
@@ -1429,7 +1429,7 @@ impl Storage for AsyncMySqlDatabase {
         &self,
         keys: &[AkdLabel],
         flag: ValueStateRetrievalFlag,
-    ) -> core::result::Result<HashMap<AkdLabel, u64>, StorageError> {
+    ) -> core::result::Result<HashMap<AkdLabel, (u64, AkdValue)>, StorageError> {
         *(self.num_reads.write().await) += 1;
         self.record_call_stats('r', "get_user_state_versions".to_string(), "".to_string())
             .await;
@@ -1551,7 +1551,7 @@ impl Storage for AsyncMySqlDatabase {
                 }
             };
             let select_statement = format!(
-                r"SELECT full.`username`, full.`version`
+                r"SELECT full.`username`, full.`version`, full.`data`
                 FROM {} full
                 INNER JOIN (
                     SELECT tmp.`username`, {} AS `epoch`
@@ -1571,10 +1571,10 @@ impl Storage for AsyncMySqlDatabase {
                 let _t = conn.query_iter(select_statement).await;
                 self.check_for_infra_error(_t)?
                     .reduce_and_drop(vec![], |mut acc, mut row: mysql_async::Row| {
-                        if let (Some(Ok(username)), Some(Ok(version))) =
-                            (row.take_opt(0), row.take_opt(1))
+                        if let (Some(Ok(username)), Some(Ok(version)), Some(Ok(data))) =
+                            (row.take_opt(0), row.take_opt(1), row.take_opt(2))
                         {
-                            acc.push((AkdLabel(username), version))
+                            acc.push((AkdLabel(username), (version, AkdValue(data))))
                         }
                         acc
                     })
@@ -1585,10 +1585,10 @@ impl Storage for AsyncMySqlDatabase {
                     .await;
                 self.check_for_infra_error(_t)?
                     .reduce_and_drop(vec![], |mut acc, mut row: mysql_async::Row| {
-                        if let (Some(Ok(username)), Some(Ok(version))) =
-                            (row.take_opt(0), row.take_opt(1))
+                        if let (Some(Ok(username)), Some(Ok(version)), Some(Ok(data))) =
+                            (row.take_opt(0), row.take_opt(1), row.take_opt(2))
                         {
-                            acc.push((AkdLabel(username), version))
+                            acc.push((AkdLabel(username), (version, AkdValue(data))))
                         }
                         acc
                     })


### PR DESCRIPTION
When a user requests publishing a new value to the directory, check that it's not ALREADY the latest value. This helps solve some corner cases around potential race conditions batching changes from upstream queue-like services. See Issue #197 for context.

This pull request adds the described functionality as well as a new test around that functionality. It also cleans up existing tests where we apparently were double-publishing the same value for users sequentially.

As a note! Publishing value "a", then "b", then "a" again **is** valid! This is a set of changes. However publishing "a" then "a" again is a no-op in this case, as nothing has changed.

Resolves #197 