### PR TITLE
Bump version number to v0.6.2

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.6.1", features = ["serde_serialization"] }
+akd = { path = "../akd", version = "^0.6.2", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.6.1", features = ["public-tests"] }
+akd = { path = "../akd", version = "^0.6.2", features = ["public-tests"] }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "^0.6.1" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "^0.6.2" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "^0.6.1" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "^0.6.2" }


### PR DESCRIPTION
This version bump is to create a release that has a commit hash at which the `akd_test_tools` crate exists. This will resolve some downstream import issues.