### PR TITLE
Addressing the concurrency access of the storage layer mid-update

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -300,7 +300,9 @@ impl Azks {
             hash: crate::utils::empty_node_hash::<H>(),
         }; ARITY];
         for i in 0..ARITY {
-            let child = lcp_node.get_child_state(storage, Some(i), self.latest_epoch).await?;
+            let child = lcp_node
+                .get_child_state(storage, Some(i), self.latest_epoch)
+                .await?;
             match child {
                 None => {
                     debug!("i = {}, empty", i);
@@ -511,7 +513,9 @@ impl Azks {
                 curr_node.label,
                 None,
             )))?;
-            let next_state = curr_node.get_child_state(storage, Some(direction), self.latest_epoch).await?;
+            let next_state = curr_node
+                .get_child_state(storage, Some(direction), self.latest_epoch)
+                .await?;
             if next_state.is_some() {
                 for i in 0..ARITY {
                     let no_direction_error =
@@ -595,6 +599,7 @@ mod tests {
         let num_nodes = 10;
         let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
+        azks1.increment_epoch();
 
         let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
@@ -630,6 +635,7 @@ mod tests {
         let mut rng = OsRng;
         let db = AsyncInMemoryDatabase::new();
         let mut azks1 = Azks::new::<_, Blake3>(&db).await?;
+        azks1.increment_epoch();
         let mut insertion_set: Vec<Node<Blake3>> = vec![];
 
         for _ in 0..num_nodes {

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -96,10 +96,16 @@ async fn test_get_and_set_item<Ns: Storage>(storage: &Ns) {
     let key = NodeKey(NodeLabel::new(byte_arr_from_u64(13), 4));
     let key2 = NodeKey(NodeLabel::new(byte_arr_from_u64(16), 4));
 
-    let set_result = storage.set(DbRecord::TreeNode(PvTreeNode::from_tree_node(node.clone()))).await;
+    let set_result = storage
+        .set(DbRecord::TreeNode(PvTreeNode::from_tree_node(node.clone())))
+        .await;
     assert_eq!(Ok(()), set_result);
 
-    let set_result = storage.set(DbRecord::TreeNode(PvTreeNode::from_tree_node(node2.clone()))).await;
+    let set_result = storage
+        .set(DbRecord::TreeNode(PvTreeNode::from_tree_node(
+            node2.clone(),
+        )))
+        .await;
     assert_eq!(Ok(()), set_result);
 
     let get_result = storage.get::<PvTreeNode>(&key).await;

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -189,7 +189,7 @@ mod tests {
             num_nodes: 0,
             latest_epoch: 0,
         });
-        let node1 = DbRecord::TreeNode(TreeNode {
+        let node1 = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
             label: NodeLabel::new(byte_arr_from_u64(0), 0),
             last_epoch: 1,
             least_descendent_ep: 1,
@@ -198,8 +198,8 @@ mod tests {
             left_child: None,
             right_child: None,
             hash: [0u8; 32],
-        });
-        let node2 = DbRecord::TreeNode(TreeNode {
+        }));
+        let node2 = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
             last_epoch: 1,
             least_descendent_ep: 1,
@@ -208,7 +208,7 @@ mod tests {
             left_child: None,
             right_child: None,
             hash: [0u8; 32],
-        });
+        }));
         let value1 = DbRecord::ValueState(ValueState {
             username: AkdLabel::from_utf8_str("test"),
             epoch: 1,

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -210,7 +210,7 @@ pub enum ValueStateRetrievalFlag {
 pub enum DbRecord {
     /// An Azks
     Azks(Azks),
-    /// A TreeNodeNode
+    /// A TreeNode
     TreeNode(TreeNodeWithPreviousValue),
     /// The state of the value for a particular key.
     ValueState(ValueState),
@@ -261,7 +261,7 @@ impl DbRecord {
 
     #[allow(clippy::too_many_arguments)]
     /// Build a history tree node from the properties
-    pub fn build_history_tree_node(
+    pub fn build_tree_node_with_previous_value(
         label_val: [u8; 32],
         label_len: u32,
         last_epoch: u64,

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -206,6 +206,7 @@ pub enum ValueStateRetrievalFlag {
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
 )]
+#[allow(clippy::large_enum_variant)]
 pub enum DbRecord {
     /// An Azks
     Azks(Azks),

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -281,20 +281,25 @@ impl DbRecord {
         p_hash: Option<[u8; 32]>,
     ) -> TreeNodeWithPreviousValue {
         let label = NodeLabel::new(label_val, label_len);
-        let p_node = match (p_last_epoch, p_least_descendent_ep, p_parent_label_val, p_parent_label_len, p_node_type, p_hash) {
-            (Some(a), Some(b), Some(c), Some(d), Some(e), Some(f)) => {
-                Some(TreeNode {
-                    label,
-                    last_epoch: a,
-                    least_descendent_ep: b,
-                    parent: NodeLabel::new(c, d),
-                    node_type: NodeType::from_u8(e),
-                    left_child: p_left_child,
-                    right_child: p_right_child,
-                    hash: f,
-                })
-            },
-            _ => None
+        let p_node = match (
+            p_last_epoch,
+            p_least_descendent_ep,
+            p_parent_label_val,
+            p_parent_label_len,
+            p_node_type,
+            p_hash,
+        ) {
+            (Some(a), Some(b), Some(c), Some(d), Some(e), Some(f)) => Some(TreeNode {
+                label,
+                last_epoch: a,
+                least_descendent_ep: b,
+                parent: NodeLabel::new(c, d),
+                node_type: NodeType::from_u8(e),
+                left_child: p_left_child,
+                right_child: p_right_child,
+                hash: f,
+            }),
+            _ => None,
         };
         TreeNodeWithPreviousValue {
             label,

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -383,8 +383,7 @@ async fn test_simple_audit() -> Result<(), AkdError> {
     Ok(())
 }
 
-// #[tokio::test]
-#[allow(dead_code)]
+#[tokio::test]
 async fn test_read_during_publish() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
     let vrf = HardCodedAkdVRF {};

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -112,12 +112,11 @@ impl Storable for TreeNodeWithPreviousValue {
 }
 
 impl TreeNodeWithPreviousValue {
-
     pub(crate) fn from_tree_node(node: TreeNode) -> Self {
         Self {
             label: node.label,
             latest_node: node,
-            previous_node: None
+            previous_node: None,
         }
     }
 
@@ -140,7 +139,10 @@ impl TreeNodeWithPreviousValue {
                         Ok(previous_node)
                     } else {
                         // no previous, return not found
-                        Err(StorageError::NotFound(format!("TreeNode {:?} at epoch {}", key, current_epoch)))
+                        Err(StorageError::NotFound(format!(
+                            "TreeNode {:?} at epoch {}",
+                            key, current_epoch
+                        )))
                     }
                 } else {
                     Ok(node.latest_node)
@@ -164,7 +166,10 @@ impl TreeNodeWithPreviousValue {
                         nodes.push(previous_node);
                     } else {
                         // no previous, return not found
-                        return Err(StorageError::NotFound(format!("TreeNode {:?} at epoch {}", node.label, current_epoch)));
+                        return Err(StorageError::NotFound(format!(
+                            "TreeNode {:?} at epoch {}",
+                            node.label, current_epoch
+                        )));
                     }
                 } else {
                     nodes.push(node.latest_node);
@@ -225,17 +230,22 @@ impl TreeNode {
         &self,
         storage: &S,
     ) -> Result<(), StorageError> {
-
         // retrieve the higest node properties, at a previous epoch than this one. If we're modifying "this" epoch, simply take it as no need for a rotation.
         // When we write the node, with an updated epoch value, we'll rotate the stored value and capture the previous
         let target_epoch = match self.last_epoch {
             e if e > 0 => e - 1,
-            other => other
+            other => other,
         };
-        let previous = match TreeNodeWithPreviousValue::get_from_storage(storage, &NodeKey(self.label), target_epoch).await {
-            Ok(p)=> Some(p),
+        let previous = match TreeNodeWithPreviousValue::get_from_storage(
+            storage,
+            &NodeKey(self.label),
+            target_epoch,
+        )
+        .await
+        {
+            Ok(p) => Some(p),
             Err(StorageError::NotFound(_)) => None,
-            Err(other) => return Err(other)
+            Err(other) => return Err(other),
         };
         // construct the "new" record, shifting the most recent stored value into the "previous" field
         let left_shifted = TreeNodeWithPreviousValue {
@@ -627,7 +637,8 @@ impl TreeNode {
             Direction::Some(_dir) => {
                 if let Some(child_label) = self.get_child_label(direction) {
                     let child_key = NodeKey(child_label);
-                    let get_result = Self::get_from_storage(storage, &child_key, current_epoch).await;
+                    let get_result =
+                        Self::get_from_storage(storage, &child_key, current_epoch).await;
                     match get_result {
                         Ok(node) => Ok(Some(node)),
                         Err(StorageError::NotFound(_)) => Ok(None),
@@ -821,7 +832,9 @@ mod tests {
         root.insert_single_leaf::<_, Blake3>(&db, leaf_2.clone(), 3, &mut num_nodes, None)
             .await?;
 
-        let stored_root = db.get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root())).await?;
+        let stored_root = db
+            .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
+            .await?;
 
         let root_least_descendent_ep = match stored_root {
             DbRecord::TreeNode(node) => node.latest_node.least_descendent_ep,
@@ -920,9 +933,13 @@ mod tests {
         let expected = Blake3::merge(&[leaves_hash, hash_label::<Blake3>(root.label)]);
 
         // Get root hash
-        let stored_root = db.get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root())).await?;
+        let stored_root = db
+            .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
+            .await?;
         let root_digest = match stored_root {
-            DbRecord::TreeNode(node) => hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?,
+            DbRecord::TreeNode(node) => {
+                hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?
+            }
             _ => panic!("Root not found in storage."),
         };
 
@@ -988,9 +1005,13 @@ mod tests {
         root.insert_single_leaf::<_, Blake3>(&db, leaf_2.clone(), 3, &mut num_nodes, None)
             .await?;
 
-        let stored_root = db.get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root())).await?;
+        let stored_root = db
+            .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
+            .await?;
         let root_digest = match stored_root {
-            DbRecord::TreeNode(node) => hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?,
+            DbRecord::TreeNode(node) => {
+                hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?
+            }
             _ => panic!("Root not found in storage."),
         };
 
@@ -1079,9 +1100,13 @@ mod tests {
         root.insert_single_leaf::<_, Blake3>(&db, leaf_3.clone(), 4, &mut num_nodes, None)
             .await?;
 
-        let stored_root = db.get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root())).await?;
+        let stored_root = db
+            .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
+            .await?;
         let root_digest = match stored_root {
-            DbRecord::TreeNode(node) => hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?,
+            DbRecord::TreeNode(node) => {
+                hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?
+            }
             _ => panic!("Root not found in storage."),
         };
 
@@ -1158,9 +1183,13 @@ mod tests {
             .await?;
         }
 
-        let stored_root = db.get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root())).await?;
+        let stored_root = db
+            .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
+            .await?;
         let root_digest = match stored_root {
-            DbRecord::TreeNode(node) => hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?,
+            DbRecord::TreeNode(node) => {
+                hash_u8_with_label::<Blake3>(&node.latest_node.hash, node.label)?
+            }
             _ => panic!("Root not found in storage."),
         };
 

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.6.2", features = ["serde_serialization"] }
+akd = { path = "../akd", version = "^0.7.0", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.6.2", features = ["public-tests"] }
+akd = { path = "../akd", version = "^0.7.0", features = ["public-tests"] }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -13,7 +13,7 @@ use akd::storage::types::{
     AkdLabel, AkdValue, DbRecord, KeyData, StorageType, ValueState, ValueStateRetrievalFlag,
 };
 use akd::storage::{Storable, Storage};
-use akd::tree_node::TreeNode;
+use akd::tree_node::TreeNodeWithPreviousValue;
 use akd::NodeLabel;
 use async_trait::async_trait;
 use log::{debug, error, info, warn};
@@ -351,6 +351,10 @@ impl<'a> AsyncMySqlDatabase {
             + " `parent_label_val` VARBINARY(32) NOT NULL, `node_type` SMALLINT UNSIGNED NOT NULL,"
             + " `left_child_len` INT UNSIGNED, `left_child_label_val` VARBINARY(32),"
             + " `right_child_len` INT UNSIGNED, `right_child_label_val` VARBINARY(32), `hash` VARBINARY(32) NOT NULL,"
+            + " `p_last_epoch` BIGINT UNSIGNED, `p_least_descendent_ep` BIGINT UNSIGNED, "
+            + " `p_parent_label_len` INT UNSIGNED, `p_parent_label_val` VARBINARY(32), "
+            + " `p_node_type` SMALLINT UNSIGNED, `p_left_child_len` INT UNSIGNED, `p_left_child_label_val` VARBINARY(32), "
+            + " `p_right_child_len` INT UNSIGNED, `p_right_child_label_val` VARBINARY(32), `p_hash` VARBINARY(32),"
             + " PRIMARY KEY (`label_len`, `label_val`))";
         tx.query_drop(command).await?;
 
@@ -481,7 +485,9 @@ impl<'a> AsyncMySqlDatabase {
         let statement = |i: usize| -> String {
             match &head {
                 DbRecord::Azks(_) => DbRecord::set_batch_statement::<akd::Azks>(i),
-                DbRecord::TreeNode(_) => DbRecord::set_batch_statement::<TreeNode>(i),
+                DbRecord::TreeNode(_) => {
+                    DbRecord::set_batch_statement::<TreeNodeWithPreviousValue>(i)
+                }
                 DbRecord::ValueState(_) => {
                     DbRecord::set_batch_statement::<akd::storage::types::ValueState>(i)
                 }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -441,12 +441,12 @@ impl<'a> AsyncMySqlDatabase {
                 }
             }
         };
-        let result = self.check_for_infra_error(out)?;
+        self.check_for_infra_error(out)?;
         let toc = Instant::now() - tic;
         *(self.time_write.write().await) += toc;
 
         debug!("END MySQL set");
-        Ok(result)
+        Ok(())
     }
 
     /// NOTE: This is assuming all of the DB records have been narrowed down to a single record type!

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -570,7 +570,7 @@ impl MySqlStorable for DbRecord {
                         None => None,
                     };
 
-                    let node = DbRecord::build_history_tree_node(
+                    let node = DbRecord::build_tree_node_with_previous_value(
                         label_val_vec.try_into().map_err(|_| cast_err())?,
                         label_len,
                         last_epoch,

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -151,8 +151,14 @@ impl MySqlStorable for DbRecord {
                 DbRecord::TreeNode(node) => {
                     let pnode = &node.previous_node;
                     Ok(vec![
-                        (format!("label_len{}", idx), Value::from(node.label.label_len)),
-                        (format!("label_val{}", idx), Value::from(node.label.label_val)),
+                        (
+                            format!("label_len{}", idx),
+                            Value::from(node.label.label_len),
+                        ),
+                        (
+                            format!("label_val{}", idx),
+                            Value::from(node.label.label_val),
+                        ),
                         (
                             format!("last_epoch{}", idx),
                             Value::from(node.latest_node.last_epoch),
@@ -212,19 +218,35 @@ impl MySqlStorable for DbRecord {
                         ),
                         (
                             format!("p_left_child_len{}", idx),
-                            Value::from(pnode.clone().and_then(|a| a.left_child.map(|lc| lc.label_len))),
+                            Value::from(
+                                pnode
+                                    .clone()
+                                    .and_then(|a| a.left_child.map(|lc| lc.label_len)),
+                            ),
                         ),
                         (
                             format!("p_left_child_label_val{}", idx),
-                            Value::from(pnode.clone().and_then(|a| a.left_child.map(|lc| lc.label_val))),
+                            Value::from(
+                                pnode
+                                    .clone()
+                                    .and_then(|a| a.left_child.map(|lc| lc.label_val)),
+                            ),
                         ),
                         (
                             format!("p_right_child_len{}", idx),
-                            Value::from(pnode.clone().and_then(|a| a.right_child.map(|rc| rc.label_len))),
+                            Value::from(
+                                pnode
+                                    .clone()
+                                    .and_then(|a| a.right_child.map(|rc| rc.label_len)),
+                            ),
                         ),
                         (
                             format!("p_right_child_label_val{}", idx),
-                            Value::from(pnode.clone().and_then(|a| a.right_child.map(|rc| rc.label_val))),
+                            Value::from(
+                                pnode
+                                    .clone()
+                                    .and_then(|a| a.right_child.map(|rc| rc.label_val)),
+                            ),
                         ),
                         (
                             format!("p_hash{}", idx),

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -11,7 +11,7 @@ use std::convert::TryInto;
 
 use akd::storage::types::{DbRecord, StorageType};
 use akd::storage::Storable;
-use akd::tree_node::{NodeKey, TreeNode};
+use akd::tree_node::{NodeKey, TreeNodeWithPreviousValue};
 use akd::NodeLabel;
 use mysql_async::prelude::*;
 use mysql_async::*;
@@ -25,7 +25,7 @@ pub(crate) const TEMP_IDS_TABLE: &str = "temp_ids_table";
 
 const SELECT_AZKS_DATA: &str = "`epoch`, `num_nodes`";
 const SELECT_HISTORY_TREE_NODE_DATA: &str =
-    "`label_len`, `label_val`, `last_epoch`, `least_descendent_ep`, `parent_label_len`, `parent_label_val`, `node_type`, `left_child_len`, `left_child_label_val`, `right_child_len`, `right_child_label_val`, `hash`";
+    "`label_len`, `label_val`, `last_epoch`, `least_descendent_ep`, `parent_label_len`, `parent_label_val`, `node_type`, `left_child_len`, `left_child_label_val`, `right_child_len`, `right_child_label_val`, `hash`, `p_last_epoch`, `p_least_descendent_ep`, `p_parent_label_len`, `p_parent_label_val`, `p_node_type`, `p_left_child_len`, `p_left_child_label_val`, `p_right_child_len`, `p_right_child_label_val`, `p_hash`";
 const SELECT_USER_DATA: &str =
     "`username`, `epoch`, `version`, `node_label_val`, `node_label_len`, `data`";
 
@@ -62,7 +62,7 @@ impl MySqlStorable for DbRecord {
     fn set_statement(&self) -> String {
         match &self {
             DbRecord::Azks(_) => format!("INSERT INTO `{}` (`key`, {}) VALUES (:key, :epoch, :num_nodes) ON DUPLICATE KEY UPDATE `epoch` = :epoch, `num_nodes` = :num_nodes", TABLE_AZKS, SELECT_AZKS_DATA),
-            DbRecord::TreeNode(_) => format!("INSERT INTO `{}` ({}) VALUES (:label_len, :label_val, :last_epoch, :least_descendent_ep, :parent_label_len, :parent_label_val, :node_type, :left_child_len, :left_child_label_val, :right_child_len, :right_child_label_val, :hash) ON DUPLICATE KEY UPDATE `label_len` = :label_len, `label_val` = :label_val, `last_epoch` = :last_epoch, `least_descendent_ep` = :least_descendent_ep, `parent_label_len` = :parent_label_len, `parent_label_val` = :parent_label_val, `node_type` = :node_type, `left_child_len` = :left_child_len, `left_child_label_val` = :left_child_label_val, `right_child_len` = :right_child_len, `right_child_label_val` = :right_child_label_val, `hash` = :hash", TABLE_HISTORY_TREE_NODES, SELECT_HISTORY_TREE_NODE_DATA),
+            DbRecord::TreeNode(_) => format!("INSERT INTO `{}` ({}) VALUES (:label_len, :label_val, :last_epoch, :least_descendent_ep, :parent_label_len, :parent_label_val, :node_type, :left_child_len, :left_child_label_val, :right_child_len, :right_child_label_val, :hash, :p_last_epoch, :p_least_descendent_ep, :p_parent_label_len, :p_parent_label_val, :p_node_type, :p_left_child_len, :p_left_child_label_val, :p_right_child_len, :p_right_child_label_val, :p_hash) ON DUPLICATE KEY UPDATE `label_len` = :label_len, `label_val` = :label_val, `last_epoch` = :last_epoch, `least_descendent_ep` = :least_descendent_ep, `parent_label_len` = :parent_label_len, `parent_label_val` = :parent_label_val, `node_type` = :node_type, `left_child_len` = :left_child_len, `left_child_label_val` = :left_child_label_val, `right_child_len` = :right_child_len, `right_child_label_val` = :right_child_label_val, `hash` = :hash, `p_last_epoch` = :p_last_epoch, `p_least_descendent_ep` = :p_least_descendent_ep, `p_parent_label_len` = :p_parent_label_len, `p_parent_label_val` = :p_parent_label_val, `p_node_type` = :p_node_type, `p_left_child_len` = :p_left_child_len, `p_left_child_label_val` = :p_left_child_label_val, `p_right_child_len` = :p_right_child_len, `p_right_child_label_val` = :p_right_child_label_val, `p_hash` = :p_hash", TABLE_HISTORY_TREE_NODES, SELECT_HISTORY_TREE_NODE_DATA),
             DbRecord::ValueState(_) => format!("INSERT INTO `{}` ({}) VALUES (:username, :epoch, :version, :node_label_val, :node_label_len, :data)", TABLE_USER, SELECT_USER_DATA),
         }
     }
@@ -75,16 +75,28 @@ impl MySqlStorable for DbRecord {
             DbRecord::TreeNode(node) => Some(params! {
                 "label_len" => node.label.len,
                 "label_val" => node.label.val,
-                "last_epoch" => node.last_epoch,
-                "least_descendent_ep" => node.least_descendent_ep,
-                "parent_label_len" => node.parent.len,
-                "parent_label_val" => node.parent.val,
-                "node_type" => node.node_type as u8,
-                "left_child_len" => node.left_child.map(|lc| lc.len),
-                "left_child_label_val" => node.left_child.map(|lc| lc.val),
-                "right_child_len" => node.right_child.map(|rc| rc.len),
-                "right_child_label_val" => node.right_child.map(|rc| rc.val),
-                "hash" => node.hash,
+                // "Latest" node values
+                "last_epoch" => node.latest_node.last_epoch,
+                "least_descendent_ep" => node.latest_node.least_descendent_ep,
+                "parent_label_len" => node.latest_node.parent.len,
+                "parent_label_val" => node.latest_node.parent.val,
+                "node_type" => node.latest_node.node_type as u8,
+                "left_child_len" => node.latest_node.left_child.map(|lc| lc.len),
+                "left_child_label_val" => node.latest_node.left_child.map(|lc| lc.val),
+                "right_child_len" => node.latest_node.right_child.map(|rc| rc.len),
+                "right_child_label_val" => node.latest_node.right_child.map(|rc| rc.val),
+                "hash" => node.latest_node.hash,
+                // "Previous" node values
+                "p_last_epoch" => node.previous_node.clone().map(|a| a.last_epoch),
+                "p_least_descendent_ep" => node.previous_node.clone().map(|a| a.least_descendent_ep),
+                "p_parent_label_len" => node.previous_node.clone().map(|a| a.parent.len),
+                "p_parent_label_val" => node.previous_node.clone().map(|a| a.parent.val),
+                "p_node_type" => node.previous_node.clone().map(|a| a.node_type as u8),
+                "p_left_child_len" => node.previous_node.clone().and_then(|a| a.left_child.map(|lc| lc.len)),
+                "p_left_child_label_val" => node.previous_node.clone().and_then(|a| a.left_child.map(|lc| lc.val)),
+                "p_right_child_len" => node.previous_node.clone().and_then(|a| a.right_child.map(|rc| rc.len)),
+                "p_right_child_label_val" => node.previous_node.clone().and_then(|a| a.right_child.map(|rc| rc.val)),
+                "p_hash" => node.previous_node.clone().map(|a| a.hash),
             }),
             DbRecord::ValueState(state) => Some(
                 params! { "username" => state.get_id().0, "epoch" => state.epoch, "version" => state.version, "node_label_len" => state.label.len, "node_label_val" => state.label.val, "data" => state.plaintext_val.0.clone() },
@@ -98,8 +110,8 @@ impl MySqlStorable for DbRecord {
             match St::data_type() {
                 StorageType::TreeNode => {
                     parts = format!(
-                        "{}(:label_len{}, :label_val{}, :last_epoch{}, :least_descendent_ep{}, :parent_label_len{}, :parent_label_val{}, :node_type{}, :left_child_len{}, :left_child_label_val{}, :right_child_len{}, :right_child_label_val{}, :hash{})",
-                        parts, i, i, i, i, i, i, i, i, i, i, i, i
+                        "{}(:label_len{}, :label_val{}, :last_epoch{}, :least_descendent_ep{}, :parent_label_len{}, :parent_label_val{}, :node_type{}, :left_child_len{}, :left_child_label_val{}, :right_child_len{}, :right_child_label_val{}, :hash{}, :p_last_epoch{}, :p_least_descendent_ep{}, :p_parent_label_len{}, :p_parent_label_val{}, :p_node_type{}, :p_left_child_len{}, :p_left_child_label_val{}, :p_right_child_len{}, :p_right_child_label_val{}, :p_hash{})",
+                        parts, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i
                     );
                 }
                 StorageType::ValueState => {
@@ -120,7 +132,7 @@ impl MySqlStorable for DbRecord {
 
         match St::data_type() {
             StorageType::Azks => format!("INSERT INTO `{}` (`key`, {}) VALUES (:key, :epoch, :num_nodes) as new ON DUPLICATE KEY UPDATE `epoch` = new.epoch, `num_nodes` = new.num_nodes", TABLE_AZKS, SELECT_AZKS_DATA),
-            StorageType::TreeNode => format!("INSERT INTO `{}` ({}) VALUES {} as new ON DUPLICATE KEY UPDATE `label_len` = new.label_len, `label_val` = new.label_val, `least_descendent_ep` = new.least_descendent_ep, `last_epoch` = new.last_epoch, `parent_label_len` = new.parent_label_len, `parent_label_val` = new.parent_label_val, `node_type` = new.node_type, `left_child_len` = new.left_child_len, `left_child_label_val` = new.left_child_label_val, `right_child_len` = new.right_child_len, `right_child_label_val` = new.right_child_label_val, `hash` = new.hash", TABLE_HISTORY_TREE_NODES, SELECT_HISTORY_TREE_NODE_DATA, parts),
+            StorageType::TreeNode => format!("INSERT INTO `{}` ({}) VALUES {} as new ON DUPLICATE KEY UPDATE `label_len` = new.label_len, `label_val` = new.label_val, `least_descendent_ep` = new.least_descendent_ep, `last_epoch` = new.last_epoch, `parent_label_len` = new.parent_label_len, `parent_label_val` = new.parent_label_val, `node_type` = new.node_type, `left_child_len` = new.left_child_len, `left_child_label_val` = new.left_child_label_val, `right_child_len` = new.right_child_len, `right_child_label_val` = new.right_child_label_val, `hash` = new.hash, `p_last_epoch` = new.p_last_epoch, `p_least_descendent_ep` = new.p_least_descendent_ep, `p_parent_label_len` = new.p_parent_label_len, `p_parent_label_val` = new.p_parent_label_val, `p_node_type` = new.p_node_type, `p_left_child_len` = new.p_left_child_len, `p_left_child_label_val` = new.p_left_child_label_val, `p_right_child_len` = new.p_right_child_len, `p_right_child_label_val` = new.p_right_child_label_val, `p_hash` = new.p_hash", TABLE_HISTORY_TREE_NODES, SELECT_HISTORY_TREE_NODE_DATA, parts),
             StorageType::ValueState => format!("INSERT INTO `{}` ({}) VALUES {} as new ON DUPLICATE KEY UPDATE `data` = new.data, `node_label_val` = new.node_label_val, `node_label_len` = new.node_label_len, `version` = new.version", TABLE_USER, SELECT_USER_DATA, parts),
         }
     }
@@ -135,44 +147,90 @@ impl MySqlStorable for DbRecord {
                     ("epoch".to_string(), Value::from(azks.latest_epoch)),
                     ("num_nodes".to_string(), Value::from(azks.num_nodes)),
                 ]),
-                DbRecord::TreeNode(node) => Ok(vec![
-                    (format!("label_len{}", idx), Value::from(node.label.len)),
-                    (format!("label_val{}", idx), Value::from(node.label.val)),
-                    (format!("last_epoch{}", idx), Value::from(node.last_epoch)),
-                    (
-                        format!("least_descendent_ep{}", idx),
-                        Value::from(node.least_descendent_ep),
-                    ),
-                    (
-                        format!("parent_label_len{}", idx),
-                        Value::from(node.parent.len),
-                    ),
-                    (
-                        format!("parent_label_val{}", idx),
-                        Value::from(node.parent.val),
-                    ),
-                    (
-                        format!("node_type{}", idx),
-                        Value::from(node.node_type as u8),
-                    ),
-                    (
-                        format!("left_child_len{}", idx),
-                        Value::from(node.left_child.map(|lc| lc.len)),
-                    ),
-                    (
-                        format!("left_child_label_val{}", idx),
-                        Value::from(node.left_child.map(|lc| lc.val)),
-                    ),
-                    (
-                        format!("right_child_len{}", idx),
-                        Value::from(node.right_child.map(|rc| rc.len)),
-                    ),
-                    (
-                        format!("right_child_label_val{}", idx),
-                        Value::from(node.right_child.map(|rc| rc.val)),
-                    ),
-                    (format!("hash{}", idx), Value::from(node.hash)),
-                ]),
+                DbRecord::TreeNode(node) => {
+                    let pnode = &node.previous_node;
+                    Ok(vec![
+                        (format!("label_len{}", idx), Value::from(node.label.len)),
+                        (format!("label_val{}", idx), Value::from(node.label.val)),
+                        (
+                            format!("last_epoch{}", idx),
+                            Value::from(node.latest_node.last_epoch),
+                        ),
+                        (
+                            format!("least_descendent_ep{}", idx),
+                            Value::from(node.latest_node.least_descendent_ep),
+                        ),
+                        (
+                            format!("parent_label_len{}", idx),
+                            Value::from(node.latest_node.parent.len),
+                        ),
+                        (
+                            format!("parent_label_val{}", idx),
+                            Value::from(node.latest_node.parent.val),
+                        ),
+                        (
+                            format!("node_type{}", idx),
+                            Value::from(node.latest_node.node_type as u8),
+                        ),
+                        (
+                            format!("left_child_len{}", idx),
+                            Value::from(node.latest_node.left_child.map(|lc| lc.len)),
+                        ),
+                        (
+                            format!("left_child_label_val{}", idx),
+                            Value::from(node.latest_node.left_child.map(|lc| lc.val)),
+                        ),
+                        (
+                            format!("right_child_len{}", idx),
+                            Value::from(node.latest_node.right_child.map(|rc| rc.len)),
+                        ),
+                        (
+                            format!("right_child_label_val{}", idx),
+                            Value::from(node.latest_node.right_child.map(|rc| rc.val)),
+                        ),
+                        (format!("hash{}", idx), Value::from(node.latest_node.hash)),
+                        (
+                            format!("p_last_epoch{}", idx),
+                            Value::from(pnode.clone().map(|a| a.last_epoch)),
+                        ),
+                        (
+                            format!("p_least_descendent_ep{}", idx),
+                            Value::from(pnode.clone().map(|a| a.least_descendent_ep)),
+                        ),
+                        (
+                            format!("p_parent_label_len{}", idx),
+                            Value::from(pnode.clone().map(|a| a.parent.len)),
+                        ),
+                        (
+                            format!("p_parent_label_val{}", idx),
+                            Value::from(pnode.clone().map(|a| a.parent.val)),
+                        ),
+                        (
+                            format!("p_node_type{}", idx),
+                            Value::from(pnode.clone().map(|a| a.node_type as u8)),
+                        ),
+                        (
+                            format!("p_left_child_len{}", idx),
+                            Value::from(pnode.clone().and_then(|a| a.left_child.map(|lc| lc.len))),
+                        ),
+                        (
+                            format!("p_left_child_label_val{}", idx),
+                            Value::from(pnode.clone().and_then(|a| a.left_child.map(|lc| lc.val))),
+                        ),
+                        (
+                            format!("p_right_child_len{}", idx),
+                            Value::from(pnode.clone().and_then(|a| a.right_child.map(|rc| rc.len))),
+                        ),
+                        (
+                            format!("p_right_child_label_val{}", idx),
+                            Value::from(pnode.clone().and_then(|a| a.right_child.map(|rc| rc.val))),
+                        ),
+                        (
+                            format!("p_hash{}", idx),
+                            Value::from(pnode.clone().map(|a| a.hash)),
+                        ),
+                    ])
+                }
                 DbRecord::ValueState(state) => Ok(vec![
                     (format!("username{}", idx), Value::from(state.get_id().0)),
                     (format!("epoch{}", idx), Value::from(state.epoch)),
@@ -319,7 +377,7 @@ impl MySqlStorable for DbRecord {
             StorageType::Azks => None,
             StorageType::TreeNode => {
                 let bin = St::get_full_binary_key_id(key);
-                if let Ok(back) = TreeNode::key_from_full_binary(&bin) {
+                if let Ok(back) = TreeNodeWithPreviousValue::key_from_full_binary(&bin) {
                     Some(params! {
                         "label_len" => back.0.len,
                         "label_val" => back.0.val,
@@ -355,7 +413,8 @@ impl MySqlStorable for DbRecord {
                         let bin = St::get_full_binary_key_id(key);
                         // Since these are constructed from a safe key, they should never fail
                         // so we'll leave the unwrap to simplify
-                        let back: NodeKey = TreeNode::key_from_full_binary(&bin).unwrap();
+                        let back: NodeKey =
+                            TreeNodeWithPreviousValue::key_from_full_binary(&bin).unwrap();
                         vec![
                             (format!("label_len{}", idx), Value::from(back.0.len)),
                             (format!("label_val{}", idx), Value::from(back.0.val)),
@@ -432,7 +491,13 @@ impl MySqlStorable for DbRecord {
             }
             StorageType::TreeNode => {
                 // `label_len`, `label_val`, `last_epoch`, `least_descendent_ep`, `parent_label_len`, `parent_label_val`, `node_type`,
-                // `left_child_len`, `left_child_label_val`, `right_child_len`, `right_child_label_val`, `hash`
+                // `left_child_len`, `left_child_label_val`, `right_child_len`, `right_child_label_val`, `hash`,
+                // `p_last_epoch`, `p_least_descendent_ep`, `p_parent_label_len`, `p_parent_label_val`, `p_node_type`,
+                // `p_left_child_len`, `p_left_child_label_val`, `p_right_child_len`, `p_right_child_label_val`, `p_hash`
+
+                // A NOTE ABOUT THE SYNTAX HERE: The outer-most Some(**) of the row.take(..) indicates the COLUMN EXISTS, not that it actually has a value.
+                // Therefore the signature of these fields you want is Some(Option<value>) for a nullable column. The inner option type is not necessary
+                // for types which have NOT NULL in the SQL definition
                 if let (
                     Some(Ok(label_len)),
                     Some(Ok(label_val)),
@@ -446,6 +511,16 @@ impl MySqlStorable for DbRecord {
                     right_child_len_res,
                     right_child_val_res,
                     Some(Ok(hash)),
+                    Some(p_last_epoch),
+                    Some(p_least_descendent_ep),
+                    Some(p_parent_label_len),
+                    Some(p_parent_label_val),
+                    Some(p_node_type),
+                    p_left_child_len,
+                    p_left_child_label_val,
+                    p_right_child_len,
+                    p_right_child_label_val,
+                    Some(p_hash),
                 ) = (
                     row.take_opt(0),
                     row.take_opt(1),
@@ -459,15 +534,41 @@ impl MySqlStorable for DbRecord {
                     row.take(9),
                     row.take(10),
                     row.take_opt(11),
+                    row.take(12),
+                    row.take(13),
+                    row.take(14),
+                    row.take(15),
+                    row.take(16),
+                    row.take(17),
+                    row.take(18),
+                    row.take(19),
+                    row.take(20),
+                    row.take(21),
                 ) {
                     let left_child = optional_child_label(left_child_val_res, left_child_len_res)?;
                     let right_child =
                         optional_child_label(right_child_val_res, right_child_len_res)?;
+                    let p_left_child =
+                        optional_child_label(p_left_child_label_val, p_left_child_len)?;
+                    let p_right_child =
+                        optional_child_label(p_right_child_label_val, p_right_child_len)?;
 
                     let label_val_vec: Vec<u8> = label_val;
-                    let parent_label_val_vec: Vec<u8> = parent_label_val;
 
+                    let parent_label_val_vec: Vec<u8> = parent_label_val;
+                    let prev_parent_label_val_vec: Option<Vec<u8>> = p_parent_label_val;
                     let hash_vec: Vec<u8> = hash;
+                    let prev_hash_vec: Option<Vec<u8>> = p_hash;
+
+                    let massaged_prev_parent_label_val: Option<[u8; 32]> =
+                        match prev_parent_label_val_vec {
+                            Some(v) => Some(v.try_into().map_err(|_| cast_err())?),
+                            None => None,
+                        };
+                    let massaged_prev_hash_vec: Option<[u8; 32]> = match prev_hash_vec {
+                        Some(v) => Some(v.try_into().map_err(|_| cast_err())?),
+                        None => None,
+                    };
 
                     let node = DbRecord::build_history_tree_node(
                         label_val_vec.try_into().map_err(|_| cast_err())?,
@@ -480,6 +581,14 @@ impl MySqlStorable for DbRecord {
                         left_child,
                         right_child,
                         hash_vec.try_into().map_err(|_| cast_err())?,
+                        p_last_epoch,
+                        p_least_descendent_ep,
+                        massaged_prev_parent_label_val,
+                        p_parent_label_len,
+                        p_node_type,
+                        p_left_child,
+                        p_right_child,
+                        massaged_prev_hash_vec,
                     );
                     return Ok(DbRecord::TreeNode(node));
                 }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "^0.6.2" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "^0.7.0" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "^0.6.2" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "^0.7.0" }

--- a/akd_test_tools/src/fixture_generator/examples/test.yaml
+++ b/akd_test_tools/src/fixture_generator/examples/test.yaml
@@ -30,605 +30,974 @@ epoch: 9
 records:
   - TreeNode:
       label:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
+        val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
         len: 256
-      last_epoch: 1
-      least_descendent_ep: 1
-      parent:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
+      latest_node:
+        label:
+          val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: BEEBD4D0A5D81DA3B71088C0A8AE31DE14F92AA99642B362006A371608B9C965
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+        len: 256
+      latest_node:
+        label:
+          val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FF753863F012831C90ED9BC8E7D7E2050CB718FF17F03493333680067C4DCF08
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+        len: 256
+      latest_node:
+        label:
+          val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E4C5FE4F9AAC34F5F78223F460D6FB3816D36146041D55F3C4B6AAB7068B695C
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "0000000000000000000000000000000000000000000000000000000000000000"
         len: 2
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: DF57D5005E8E700F6EDD67228BBCE452DC93B5635B8F355759B474041F3D4C79
-  - TreeNode:
-      label:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
-        len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: D83CA2E6CA89C340ADE2B533CCAA2738D94AF033C703E14A419EBBDDE4E748EF
-  - TreeNode:
-      label:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: A6876F3DFD3F07BBE33385E369CAEDA07B515A537C0E3843FAF3BFE176B03F93
-  - TreeNode:
-      label:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      last_epoch: 3
-      least_descendent_ep: 2
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Interior
-      left_child:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
-        len: 256
-      right_child:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
-        len: 256
-      hash: A5210043FFB46BCC52B0097C5CB705022E0B0312D9EB18D5FC1FBC2D239756E9
-  - TreeNode:
-      label:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 3
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      right_child:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      hash: 9FE616CD6ADD63955FF978C70A2219B05048D5C383CF9FEE1D4CE8A8C06C7494
-  - TreeNode:
-      label:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
-        len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: FABDDD49DEE4EB82CB573063178FA5465392AEB16F09701525A5138A0D39C336
-  - TreeNode:
-      label:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      node_type: Interior
-      left_child:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
-        len: 256
-      right_child:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
-        len: 256
-      hash: 5C6586CEDCF72E228AE4A571952AED11B443C3179ED8DDB87F021C0CA01B7451
-  - TreeNode:
-      label:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
-        len: 256
-      last_epoch: 3
-      least_descendent_ep: 3
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 9157D536020D7FCB07049A5D40BF123E68FD498EF121C6576DAFB5754C78CFAF
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        right_child:
+          val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
+          len: 256
+        hash: 2716B550BCB6DFEA4516BE6802AA6830DAD3933B78EA0EA6A18D41CD415282EB
+      previous_node: ~
   - TreeNode:
       label:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
         len: 2
-      last_epoch: 6
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      right_child:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      hash: 22E47878ACDABC6F6000B59E78378EA7F63CB47D020DCCF7531BE4432CA2EC9B
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        right_child:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        hash: 1255EA40EE34C81FCE41D5356C671062044AAF04F57D4317DBCEE7AA6744A786
+      previous_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        right_child:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        hash: 7629CF87E9054642CC0CAAC7F6C712A157477FB0370D6F5941D76A6F1CBDD9EA
   - TreeNode:
       label:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
+        val: "1000000000000000000000000000000000000000000000000000000000000000"
+        len: 4
+      latest_node:
+        label:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        last_epoch: 4
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        right_child:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        hash: 57B4A8836E8BE163143B369B7C4EEC5CC5ED2EA62FD90D3D99A8FC3F4220E463
+      previous_node:
+        label:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        last_epoch: 3
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        right_child:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        hash: 3394EC6EFD0E2CCCBA17BA5231B15835DC70B6F66F995F457ED73D4E1C71CDFD
+  - TreeNode:
+      label:
+        val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
         len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: E521095DD606D10BE88632E940D3E0CF5E925F05659F526BF02DDBDEBC740ED1
+      latest_node:
+        label:
+          val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+          len: 256
+        last_epoch: 1
+        least_descendent_ep: 1
+        parent:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: B74A15524C17B9E49AEE617AFBD5957E0D7AF541B1E3EAFB58DA7D627EDDB943
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+        len: 256
+      latest_node:
+        label:
+          val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+          len: 256
+        last_epoch: 1
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: ADCC175A7072C86AB5152DBA40D1A28441C1EAAD92578D3570F1052CF33472B1
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+        len: 256
+      latest_node:
+        label:
+          val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 590D7D0D4FF859DCA9A28EC26A3BF972830EEB2DCF2A9CC004C961985649B3D0
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B000000000000000000000000000000000000000000000000000000000000000
+        len: 5
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        right_child:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        hash: 40D2AD9F64333B45030A2BB5E2E31ABC74E4DB9E428CF819C284320D1FB8E8D2
+      previous_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        right_child:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        hash: 13BB3202847043568D1D6E81B84606F3F74F3B705781D2EE847B0A953D0A6BBD
+  - TreeNode:
+      label:
+        val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+        len: 256
+      latest_node:
+        label:
+          val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 515E3062BB3E9609C8A6F0E2C2C746F9CC5C23BC8315968327B7E164118F28FB
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "9000000000000000000000000000000000000000000000000000000000000000"
+        len: 6
+      latest_node:
+        label:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Interior
+        left_child:
+          val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+          len: 256
+        right_child:
+          val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+          len: 256
+        hash: D9B597EBE98EE3DC7C33FFEFE3C8739D505DD3AC869AE9CFAA2ABB7DEC721202
+      previous_node: ~
   - TreeNode:
       label:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
+        len: 3
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+          len: 256
+        right_child:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        hash: E88DF4396F961AE86EAE41B11375E101C08847E8169515FAA4FBF21B9A656E8B
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B000000000000000000000000000000000000000000000000000000000000000
+        len: 7
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Interior
+        left_child:
+          val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+          len: 256
+        right_child:
+          val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+          len: 256
+        hash: A3448031173D14A17817518A822C7947824347EDA66EBA53F9F70A70D7571DD8
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+        len: 256
+      latest_node:
+        label:
+          val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+          len: 256
+        last_epoch: 3
+        least_descendent_ep: 3
+        parent:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 48AA8A592178AB15373B0B3ACE7EC1DE7835A7EF9C01352684312B58F30FBF51
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "0000000000000000000000000000000000000000000000000000000000000000"
         len: 1
-      last_epoch: 7
-      least_descendent_ep: 2
-      parent:
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        hash: 89A0D023A5292D54C167071595F324824636AE6749E072AB91E3FB3792B34745
+      previous_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 5
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        right_child:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        hash: FB59331EACE31FD244C3C02D2A0EA5BAFC9A6F425666CA858256911BD4171806
+  - TreeNode:
+      label:
+        val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+        len: 256
+      latest_node:
+        label:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        last_epoch: 3
+        least_descendent_ep: 3
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 96E573EBF17EBFB5E4CBBA3CCC01E1C08BC02C47F7D5C78E4217E6E29EB002DD
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+        len: 256
+      latest_node:
+        label:
+          val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D9E6B0373D031DE21095D8BAE0CFEE429BEA5E5C2B6CBAF5DBD414F7B84CAC3B
+      previous_node: ~
+  - TreeNode:
+      label:
         val: "0000000000000000000000000000000000000000000000000000000000000000"
         len: 0
-      node_type: Interior
-      left_child:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      right_child:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      hash: 1806234BD48F0B5508461F6C7678504EBA904F11A6D1C17EBB855009F520BD6F
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        last_epoch: 7
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Root
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        right_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        hash: A185765E18E037D39A9192C7A42659CB6ADEEEFD228FAD8ED8CA7D1A46B677FB
+      previous_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Root
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        right_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        hash: 959F77560A5691B1C4FFFE7E2844065E42BC966CD49DD13CC7D38B7CC74EADBC
   - TreeNode:
       label:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
+        val: "6000000000000000000000000000000000000000000000000000000000000000"
+        len: 3
+      latest_node:
+        label:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        last_epoch: 5
+        least_descendent_ep: 2
+        parent:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+          len: 256
+        right_child:
+          val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+          len: 256
+        hash: FBE41C5DC65A8589EC6D16451C092369E97109C1290F3971C99B199D9E4B2B25
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
         len: 256
-      last_epoch: 6
-      least_descendent_ep: 6
-      parent:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 7515BE4C2FC5D560D33A148BF05498946C0F77CD4C40C3E9DC47E6DF57A530B5
+      latest_node:
+        label:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 53FE05220926C50E9C5714F65170CB173C7C58C3D69636378E2FDADB342123D2
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: FC00000000000000000000000000000000000000000000000000000000000000
+        len: 6
+      latest_node:
+        label:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        last_epoch: 6
+        least_descendent_ep: 3
+        parent:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        node_type: Interior
+        left_child:
+          val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+          len: 256
+        right_child:
+          val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+          len: 256
+        hash: 24F1243A36BC675BA3667A5322D30146B69F0CFEF3F99E622FBB76A112A77BE6
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+        len: 256
+      latest_node:
+        label:
+          val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: AC6813FB6B82F3C9BBF212FF0BF9B1C593E6604F0E41C4B1EE9C1614A0FFBDFD
+      previous_node: ~
   - TreeNode:
       label:
         val: "4000000000000000000000000000000000000000000000000000000000000000"
         len: 2
-      last_epoch: 7
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
-        len: 256
-      right_child:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      hash: 1204411588F2C08FD66F557BD859923DBF03F6928B2019DAA88AC38CA96E5ED4
+      latest_node:
+        label:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+          len: 256
+        right_child:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        hash: 6CFD4C94459087ACE2C7876FE55BD44F9F75369B4A8DB7E8E650D50367A664B3
+      previous_node: ~
   - TreeNode:
       label:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
-        len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
+        val: "1800000000000000000000000000000000000000000000000000000000000000"
         len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: C6E944D42547913361C7FDE58977B6330BD8D1672A1F1B51377AE14D3EE4D28A
+      latest_node:
+        label:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        last_epoch: 4
+        least_descendent_ep: 3
+        parent:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        node_type: Interior
+        left_child:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        right_child:
+          val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+          len: 256
+        hash: 63AF7A9D6E80BB1CD0785940962F82F0F8CBBDEF634CA1913A08411788D7EA58
+      previous_node: ~
   - TreeNode:
       label:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      last_epoch: 4
-      least_descendent_ep: 3
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      node_type: Interior
-      left_child:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
-        len: 256
-      right_child:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
-        len: 256
-      hash: 753BED410AF5E3A445C0AAD8926247FB3E23AC4833DBD8FB63D22EECBE40DE49
+        val: B000000000000000000000000000000000000000000000000000000000000000
+        len: 6
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        right_child:
+          val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+          len: 256
+        hash: B4822D2172E4140C185CB4B7DBAA955775CC2A8E2F05D501FB4206E4CF175C66
+      previous_node: ~
   - TreeNode:
       label:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
+        val: A000000000000000000000000000000000000000000000000000000000000000
         len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 944BEDCC24E092F62E6A9605DAD2171A317DEBBD5DC7A2B253235217CB43D114
+      latest_node:
+        label:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        right_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        hash: DFC5FC51E9608548B595904A2988985466BA3CACD805AD7CF2ACD0A30141088E
+      previous_node:
+        label:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        right_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        hash: C503FC72B3AA36E7051DFA55468956B7B5C2EDBA9120B644B2D10A8F16700953
   - TreeNode:
       label:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
+        val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
         len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 5581DF1A91AF121B2C42F6ED73BD4A9AF4A7741B367652B30DD2CF261CBC55AE
-  - TreeNode:
-      label:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 4
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Interior
-      left_child:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
-        len: 256
-      right_child:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      hash: 2FBC50A8E2676BFC27F8DA6C547DF628D77D4E91B1ECCB29FEDF4C1B62C41532
-  - TreeNode:
-      label:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      last_epoch: 6
-      least_descendent_ep: 6
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 0D92427D3158B0D6E8F3BCE9B478370AA8070DEAC25255B304E53907E5E775E4
-  - TreeNode:
-      label:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
-        len: 256
-      last_epoch: 5
-      least_descendent_ep: 5
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: BE28B7DC6E198F13C389E5E663BF4B8B212D21E8C677C34F5EE0DE6EF5BA83BE
-  - TreeNode:
-      label:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      last_epoch: 5
-      least_descendent_ep: 3
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      node_type: Interior
-      left_child:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
-        len: 256
-      right_child:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      hash: C36CC85F4F530B186EF3A702E384A53DD1431433261C91807008B4BFC9B349C2
+      latest_node:
+        label:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 9F0B76C2FF55B6E4947ECCDB290121E8FC48945B8AEA3D9E00EA833A4667D418
+      previous_node: ~
   - Azks:
       latest_epoch: 7
-      num_nodes: 31
+      num_nodes: 35
   - TreeNode:
       label:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
+        val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
         len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: E59533119D5673A4709D99754C32A8F49AEC3C5CC49873C42259105D74517EF8
+      latest_node:
+        label:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 8D0417650E053E0FD51DC5607F9817E85572708031729C804504282ABDB0230C
+      previous_node: ~
   - TreeNode:
       label:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 2
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      right_child:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      hash: C0FCE72CA8DBAEC705718DD137F7121EBC146F36B1FEFEC52BD76E5FC6647797
-  - TreeNode:
-      label:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      last_epoch: 7
-      least_descendent_ep: 4
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      node_type: Interior
-      left_child:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      right_child:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      hash: 2C5E2FEC8284D0BED671EB0397CB3B4F5A27902C00955DCB96E73FACB089CEA8
-  - TreeNode:
-      label:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 3E773DFE63A8B401BFEB63A9409223FA7B09D8A770FAE677AE1513ED9609093D
-  - TreeNode:
-      label:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 2
-      parent:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Interior
-      left_child:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      right_child:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
-        len: 256
-      hash: 0208BBC32414AA7A102058752D4235EB2DC2B410116679000BA58EA376461546
-  - TreeNode:
-      label:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      last_epoch: 7
-      least_descendent_ep: 6
-      parent:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Interior
-      left_child:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
-        len: 256
-      right_child:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
-        len: 256
-      hash: 4F27FF764BC03B99A290CD0D4FBDF32764837330F017DC9FED4FADF09BB70265
-  - TreeNode:
-      label:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 5068EB2C4DCB0588DF2B40456002E4E24D35CCA20A9AD804ED779556BFFDC5E2
-  - TreeNode:
-      label:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      last_epoch: 7
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      node_type: Root
-      left_child:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      right_child:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
         len: 1
-      hash: 5D275C27BD5D4C151A029AFFD20BDC9553E2C5362C699464845597B83ACE4ECD
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 7
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        hash: C7326F250E314264161F3C8064A943386547F742BAAC0AB1D9B408135F1DA0FA
+      previous_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        hash: F23957622E184E9E4C920B4F4E7684E5CD0DF5FF94331973A8970F3DDABAE16C
   - TreeNode:
       label:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
+        val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
         len: 256
-      last_epoch: 3
-      least_descendent_ep: 3
-      parent:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: B004A67D97F7DA70779C25AA5B000C67F7C80E7CE6FFFD827998905532B00F38
+      latest_node:
+        label:
+          val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C284727DBC89D0883249BAF208B8BCA833B78D3B7975F0743457A65138B2C74D
+      previous_node: ~
   - TreeNode:
       label:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      last_epoch: 7
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      node_type: Interior
-      left_child:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      right_child:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
+        val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+        len: 256
+      latest_node:
+        label:
+          val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A0EBBBA33A04D23D31E220AAEE12E50BDC5B220A56B4F06F0F80FBF110E2FA44
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: C000000000000000000000000000000000000000000000000000000000000000
         len: 2
-      hash: E3E693BDF87CF7498C299F362BD876B9D16F16F492DF19B18B1F7043E106A371
-  - ValueState:
-      plaintext_val: 436F46796341726C47776349616B667542645A6F4164334162665A4A44354261
-      version: 1
+      latest_node:
+        label:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 3
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+          len: 256
+        right_child:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        hash: CF9FEE075E3327A41B3F511486453E54B868FCCF98A49916E8CEC826BA6002A8
+      previous_node: ~
+  - TreeNode:
       label:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
+        val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
         len: 256
-      epoch: 2
-      username: 4E526346573458446D496356574E754A434B61364E41644C487A6C4237657950
-  - ValueState:
-      plaintext_val: 44417369483847376C5A477556545034777442736947396450556678534C4272
-      version: 1
+      latest_node:
+        label:
+          val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: CFBE6A08CFE0147C76B9ABE0B40AD9983D7FD32B60CA503AB92066E0D984807E
+      previous_node: ~
+  - TreeNode:
       label:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
+        val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
         len: 256
-      epoch: 3
-      username: 796C4C6E3575426B6A496F63334F4B6B6858444F4367526D39476A7435526C54
+      latest_node:
+        label:
+          val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+          len: 256
+        last_epoch: 4
+        least_descendent_ep: 4
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 73684149233A296A9A8118D98BA2AB703AFF012089643F08F0473A1EE8536EAC
+      previous_node: ~
   - ValueState:
-      plaintext_val: 5641636F31757A595A4638334467634F4F6173354D66556E786D70704E667142
+      plaintext_val: 77715A413769357258613866313231664A585533624F6F6B74714E6965504162
       version: 1
       label:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
-        len: 256
-      epoch: 4
-      username: 584962457A6E724A716935623063553977667A546A4B61315938713844686D54
-  - ValueState:
-      plaintext_val: 7A31303733454F3333747239776877725A3369574741475846634C616E793477
-      version: 1
-      label:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
-        len: 256
-      epoch: 6
-      username: 326A414F654173734A6642454A536267317A39614E794B525966794970767344
-  - ValueState:
-      plaintext_val: 48597155324355345369753674666731447972716B6679554D526E7848315859
-      version: 1
-      label:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
-        len: 256
-      epoch: 4
-      username: 64384676524D4671397A444332434C514555675A6F383850387445763532564D
-  - ValueState:
-      plaintext_val: 59636F6D70476468706E475044436D76384C464F6764654A4F4838524348396F
-      version: 1
-      label:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
-        len: 256
-      epoch: 4
-      username: 61676476305351445A4E6F4F384A4F5054693034636C6D31416A6D6450336B63
-  - ValueState:
-      plaintext_val: 4E3049576B476143486468636D4D6856494875464A5A70754C4F347A55754869
-      version: 1
-      label:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      epoch: 7
-      username: 3035324F55376A5578564F61384255554463326D706545683663514F534F3459
-  - ValueState:
-      plaintext_val: 696C536F56325530436F6639434570686A66455A4768636A614D764D6A773176
-      version: 1
-      label:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      epoch: 2
-      username: 56554B67354666724E4E657450417176794948655278544E7736734E75687548
-  - ValueState:
-      plaintext_val: 776579504E77645A366C4C37446830323933524B38345A61587A6F6F584B6E63
-      version: 1
-      label:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
-        len: 256
-      epoch: 7
-      username: 7177706C6B4F423636687455466771534831616B5A6E774A3156445856327370
-  - ValueState:
-      plaintext_val: 5947733966506234764E3748476B5946354F4737487A655A3859624C75415754
-      version: 1
-      label:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
-        len: 256
-      epoch: 4
-      username: 4E58624E3451416B4A6A65414D39656C6B56517A4167334E757753334D4F334E
-  - ValueState:
-      plaintext_val: 3974444D6577514C6A63596875314F3172615079776237746C4F566B64417270
-      version: 1
-      label:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      epoch: 6
-      username: 54517770726E596C706B557A54653679777A79724153566D644F3177684C4A54
-  - ValueState:
-      plaintext_val: 6B7471484C745870756D34543363534E6239336366633773466B724132413256
-      version: 1
-      label:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      epoch: 2
-      username: 4D66434B436A524E6A54504F77564C37726E69384639387667574D334D313972
-  - ValueState:
-      plaintext_val: 724B49744F454F5A53726A434861574F5179765A74494F6336784C765653657A
-      version: 1
-      label:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
-        len: 256
-      epoch: 3
-      username: 3350676566306F4E41704D4D4544493533346D776136667A504F745349544270
-  - ValueState:
-      plaintext_val: 557448744F78587A45696B7669666739415276426D634E414441594E44625A68
-      version: 1
-      label:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
+        val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
         len: 256
       epoch: 5
-      username: 764E6D4457674A35314C714577556343663245434F4E45753647707A52776F74
+      username: 6C5874436833696C44313350613166366A3946457A673053336267644348395A
   - ValueState:
-      plaintext_val: 4962626C5630534951356A4574746678457137365136587174526B42334E6F5A
+      plaintext_val: 7958696C67675A7073476D6155436C757432414B50784C58734C6B3741615655
       version: 1
       label:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
+        val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
         len: 256
-      epoch: 1
-      username: 616D73344269396848734C6B305368683161557A794144704C3148395777536B
+      epoch: 2
+      username: 6C6F6976513061574C4B554E6875726B5A72723538334A5A584159554F394550
   - ValueState:
-      plaintext_val: 6D464761634435614B576C3967307777427A4B6F75725431335779747A45366E
+      plaintext_val: 4842697374496238324C704C636871553257644E62465551615538434D444953
       version: 1
       label:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
+        val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+        len: 256
+      epoch: 2
+      username: 5039525A623165476B325A7A54747857775A6E5771636352386F527438576447
+  - ValueState:
+      plaintext_val: 5A474A7873716C7A5A62786F43427236496E6173477554614856326E38386339
+      version: 1
+      label:
+        val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+        len: 256
+      epoch: 3
+      username: 3745465548646C554E49566C4B7844684D7273454243546B45324C526D5A7363
+  - ValueState:
+      plaintext_val: 3250474A67594431685272337A4E4372726259394769316D485761724F653456
+      version: 1
+      label:
+        val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
         len: 256
       epoch: 7
-      username: 386A374F6456376A5076533171636878423933697867445A4750384A7A345455
+      username: 6B4C3269496F784867537634383476696A70666C5A76514B56733865744D4334
+  - ValueState:
+      plaintext_val: 5279686471747546534679437053705367597144344F306A436C4E66646F324C
+      version: 1
+      label:
+        val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+        len: 256
+      epoch: 3
+      username: 4D7375676D584A42454B6856784D71514F4E65354F376A755451576469753246
+  - ValueState:
+      plaintext_val: 3247565067644F6D57704B6D6C5231504A77436B3133304755726364655A4773
+      version: 1
+      label:
+        val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+        len: 256
+      epoch: 1
+      username: 766F67394331614E4B704F793353474A78376864546C334A7A76673577624E35
+  - ValueState:
+      plaintext_val: 705455344E42416C343167697438775343774C784F596E547043343735304F4A
+      version: 1
+      label:
+        val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+        len: 256
+      epoch: 7
+      username: 36755370743942677049414C4B43416E4F55327951634F46646334595A733536
+  - ValueState:
+      plaintext_val: 463873583942654A4E7A4637414F4A4365364E3966524538364F57424864576A
+      version: 1
+      label:
+        val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+        len: 256
+      epoch: 5
+      username: 6B696E6D46676F65316C467039484B4F393054424761454B42717A5833343031
+  - ValueState:
+      plaintext_val: 47317A586754464D59796E747950316B4C577A3455715A7A4C5A47525A64526B
+      version: 1
+      label:
+        val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+        len: 256
+      epoch: 6
+      username: 72786E474F6B70336D3348327450555536616557373270554B35585A6536654D
+  - ValueState:
+      plaintext_val: 72693434464E553051736D483777424D365556645239466E785477584D663869
+      version: 1
+      label:
+        val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+        len: 256
+      epoch: 2
+      username: 55366F4671315A575A7176514E56593436516C716F6A5161616A623356786A77
+  - ValueState:
+      plaintext_val: 4742476E625333457461594C41506B556F4948495435577A7154716662354C61
+      version: 1
+      label:
+        val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+        len: 256
+      epoch: 1
+      username: 6D7A3879366F653769696A34767A6A6E70633550734B61445554414F684D514E
+  - ValueState:
+      plaintext_val: 6D4F433458564D73383842735A6C4D456E44427035536F663479304E51535172
+      version: 1
+      label:
+        val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+        len: 256
+      epoch: 5
+      username: 70626A7374796E746C365065334542636A4E696341446B31444549305077626F
+  - ValueState:
+      plaintext_val: 5977347944766D72485377333038304F46626137716C4E5350474B426F43746D
+      version: 1
+      label:
+        val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+        len: 256
+      epoch: 6
+      username: 535564554F6A664C7A36734E7A4552794678616B774B4346526C64754D387668
+  - ValueState:
+      plaintext_val: 31724838384A494A394B7474476A563669684439624C4F344C6E523557634B64
+      version: 1
+      label:
+        val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+        len: 256
+      epoch: 7
+      username: 5A4846614A5A373547336E726765427641416277435358474D6C77716D754168
+  - ValueState:
+      plaintext_val: 6B68303643704742364F56474A31334941706564434F4B4F4933574745774959
+      version: 1
+      label:
+        val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+        len: 256
+      epoch: 5
+      username: 7052486F6162506E756964564355357077544C36534B6C4C694873726A7A5531
+  - ValueState:
+      plaintext_val: 725353736A73373351527333394E3269654361386C4C3733376D394177355443
+      version: 1
+      label:
+        val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+        len: 256
+      epoch: 6
+      username: 6C41613674554755535A6A755141793042786D4E39663632726A50365A35394A
+  - ValueState:
+      plaintext_val: 364752385062676B3235764F69767461757A5347345A394A6D30693757596677
+      version: 1
+      label:
+        val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+        len: 256
+      epoch: 4
+      username: 655969414F584457633632496D53754C7A4C6F506C6F584A304F585578466975
 
 # Delta - Epoch 10
 ---
 epoch: 10
 updates:
-  - - 69334E6D68506D667A54734F78483767416D464F416C36586D50484E7A635051
-    - 32746F344B79425551484633776265384634637131356D726F3175386B395978
+  - - 587837466330704A525550706C54344C5A464D39336535427378694D766D5A50
+    - 6E324777664D6C625830377375506B32346964524237654A763077496661796D
+  - - 50356F7275365A36393662304C4D4668504E6C6E39704C5842344D5A7A383275
+    - 72506C7775324C7554763633394133334E464F58644350734443693759483556
+  - - 766C703468775A5548594955324E524B783359664A7648777663554B4D636851
+    - 61374E56674E64305A704752685A7758497737314A544370764F49454457584A
+  - - 6B77386955643131616753687552613954754E6D65444F375A30463930626677
+    - 32774D474F474A766D5739523266697261675970633733416C50476A4C754E72
 
 # State - Epoch 10
 ---
@@ -636,633 +1005,1230 @@ epoch: 10
 records:
   - TreeNode:
       label:
-        val: A000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      last_epoch: 8
-      least_descendent_ep: 6
-      parent:
+        val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+        len: 256
+      latest_node:
+        label:
+          val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: BEEBD4D0A5D81DA3B71088C0A8AE31DE14F92AA99642B362006A371608B9C965
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+        len: 256
+      latest_node:
+        label:
+          val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FF753863F012831C90ED9BC8E7D7E2050CB718FF17F03493333680067C4DCF08
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+        len: 256
+      latest_node:
+        label:
+          val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E4C5FE4F9AAC34F5F78223F460D6FB3816D36146041D55F3C4B6AAB7068B695C
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "0000000000000000000000000000000000000000000000000000000000000000"
+        len: 2
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        right_child:
+          val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
+          len: 256
+        hash: A78E3A4B10479223CA6E505A5D85BA2969E640ECAA7D9F99AF3C7AC8F73142F2
+      previous_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        right_child:
+          val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
+          len: 256
+        hash: 2716B550BCB6DFEA4516BE6802AA6830DAD3933B78EA0EA6A18D41CD415282EB
+  - TreeNode:
+      label:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
         len: 2
-      node_type: Interior
-      left_child:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      right_child:
-        val: B918ADEFBBFD03FC562FD8D0DA22A9B645DA425998B3CD47D1E0CC2C8FE0092F
-        len: 256
-      hash: 925B49A0A5788B940EA8C6AE110D896983B3C6E87433DFD26F6D14B395241685
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 8
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        right_child:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        hash: 59108C4DA4BF0FEA1D8E86A63BFF0B6C514905D73FB2D66E553B9D0DE1A99F29
+      previous_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        right_child:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        hash: 1255EA40EE34C81FCE41D5356C671062044AAF04F57D4317DBCEE7AA6744A786
   - TreeNode:
       label:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
-        len: 256
-      last_epoch: 1
-      least_descendent_ep: 1
-      parent:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: DF57D5005E8E700F6EDD67228BBCE452DC93B5635B8F355759B474041F3D4C79
-  - TreeNode:
-      label:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
-        len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: D83CA2E6CA89C340ADE2B533CCAA2738D94AF033C703E14A419EBBDDE4E748EF
-  - TreeNode:
-      label:
-        val: B918ADEFBBFD03FC562FD8D0DA22A9B645DA425998B3CD47D1E0CC2C8FE0092F
-        len: 256
-      last_epoch: 8
-      least_descendent_ep: 8
-      parent:
-        val: A000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: DFC3C6414071D2A194F3FBB89A415EF36CEED9C9A7306C8B0B628698AC077C54
-  - TreeNode:
-      label:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: A6876F3DFD3F07BBE33385E369CAEDA07B515A537C0E3843FAF3BFE176B03F93
-  - TreeNode:
-      label:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      last_epoch: 3
-      least_descendent_ep: 2
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Interior
-      left_child:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
-        len: 256
-      right_child:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
-        len: 256
-      hash: A5210043FFB46BCC52B0097C5CB705022E0B0312D9EB18D5FC1FBC2D239756E9
-  - TreeNode:
-      label:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 3
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      right_child:
-        val: F000000000000000000000000000000000000000000000000000000000000000
+        val: "1000000000000000000000000000000000000000000000000000000000000000"
         len: 4
-      hash: 9FE616CD6ADD63955FF978C70A2219B05048D5C383CF9FEE1D4CE8A8C06C7494
+      latest_node:
+        label:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        right_child:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        hash: ED5DA08F67695D0D2D62C4FD7729BA499902652D954137F1A4F7A0AD9DF40FCD
+      previous_node:
+        label:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        last_epoch: 4
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        right_child:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        hash: 57B4A8836E8BE163143B369B7C4EEC5CC5ED2EA62FD90D3D99A8FC3F4220E463
   - TreeNode:
       label:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
+        val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
         len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: FABDDD49DEE4EB82CB573063178FA5465392AEB16F09701525A5138A0D39C336
+      latest_node:
+        label:
+          val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+          len: 256
+        last_epoch: 1
+        least_descendent_ep: 1
+        parent:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: B74A15524C17B9E49AEE617AFBD5957E0D7AF541B1E3EAFB58DA7D627EDDB943
+      previous_node: ~
   - TreeNode:
       label:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      node_type: Interior
-      left_child:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
+        val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
         len: 256
-      right_child:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
-        len: 256
-      hash: 5C6586CEDCF72E228AE4A571952AED11B443C3179ED8DDB87F021C0CA01B7451
+      latest_node:
+        label:
+          val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+          len: 256
+        last_epoch: 1
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: ADCC175A7072C86AB5152DBA40D1A28441C1EAAD92578D3570F1052CF33472B1
+      previous_node: ~
   - TreeNode:
       label:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
+        val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
         len: 256
-      last_epoch: 3
-      least_descendent_ep: 3
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
+      latest_node:
+        label:
+          val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: D000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 590D7D0D4FF859DCA9A28EC26A3BF972830EEB2DCF2A9CC004C961985649B3D0
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B000000000000000000000000000000000000000000000000000000000000000
         len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 9157D536020D7FCB07049A5D40BF123E68FD498EF121C6576DAFB5754C78CFAF
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        right_child:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        hash: 40D2AD9F64333B45030A2BB5E2E31ABC74E4DB9E428CF819C284320D1FB8E8D2
+      previous_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        right_child:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        hash: 13BB3202847043568D1D6E81B84606F3F74F3B705781D2EE847B0A953D0A6BBD
   - TreeNode:
       label:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      last_epoch: 8
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      right_child:
-        val: A000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      hash: F481E7D2AC90942AEDDAFC5FE29E620ADEC28DB2DE1B73C905F9A2D04DEF050B
-  - TreeNode:
-      label:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
+        val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
         len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: E521095DD606D10BE88632E940D3E0CF5E925F05659F526BF02DDBDEBC740ED1
+      latest_node:
+        label:
+          val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 515E3062BB3E9609C8A6F0E2C2C746F9CC5C23BC8315968327B7E164118F28FB
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "1800000000000000000000000000000000000000000000000000000000000000"
+        len: 6
+      latest_node:
+        label:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        last_epoch: 8
+        least_descendent_ep: 3
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        node_type: Interior
+        left_child:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        right_child:
+          val: 1BAFC2DC5E11D1A3123E22A53420C3BBABA16759A4DFBD76D8890DA6BF1F5C62
+          len: 256
+        hash: 1D2AEB990BE2DE1631B359108E81750B733C5FEAD8DAE7042363F1B530008B92
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: A800000000000000000000000000000000000000000000000000000000000000
+        len: 5
+      latest_node:
+        label:
+          val: A800000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        node_type: Interior
+        left_child:
+          val: A805CEDF56D1B1A0AAD36EF3DC45B9999C453C6BE818E987D56BADDA32DA4CB1
+          len: 256
+        right_child:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        hash: A0BBD3C3AADB9B68D556983FDC3D3295D725774DE409898478A58B1DC86E2C86
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "9000000000000000000000000000000000000000000000000000000000000000"
+        len: 6
+      latest_node:
+        label:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Interior
+        left_child:
+          val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+          len: 256
+        right_child:
+          val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
+          len: 256
+        hash: D9B597EBE98EE3DC7C33FFEFE3C8739D505DD3AC869AE9CFAA2ABB7DEC721202
+      previous_node: ~
   - TreeNode:
       label:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
+        len: 3
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+          len: 256
+        right_child:
+          val: "9000000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        hash: E88DF4396F961AE86EAE41B11375E101C08847E8169515FAA4FBF21B9A656E8B
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: D000000000000000000000000000000000000000000000000000000000000000
+        len: 5
+      latest_node:
+        label:
+          val: D000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        last_epoch: 8
+        least_descendent_ep: 7
+        parent:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        node_type: Interior
+        left_child:
+          val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+          len: 256
+        right_child:
+          val: D4C3B34E1DB12EA6BE29A6F8F11142401BDF5D7035FDADB40AFD21F9702F0261
+          len: 256
+        hash: 33B1ECF5E795F1D73587373B4AA48839A89E3C63A5ACA06A715B5B182948AFD1
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: B000000000000000000000000000000000000000000000000000000000000000
+        len: 7
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        last_epoch: 5
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Interior
+        left_child:
+          val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+          len: 256
+        right_child:
+          val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+          len: 256
+        hash: A3448031173D14A17817518A822C7947824347EDA66EBA53F9F70A70D7571DD8
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+        len: 256
+      latest_node:
+        label:
+          val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+          len: 256
+        last_epoch: 3
+        least_descendent_ep: 3
+        parent:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 48AA8A592178AB15373B0B3ACE7EC1DE7835A7EF9C01352684312B58F30FBF51
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "0000000000000000000000000000000000000000000000000000000000000000"
         len: 1
-      last_epoch: 8
-      least_descendent_ep: 2
-      parent:
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        hash: 2F0F735B4727FE265F537E1BBA77AAABE525F6238B1570E9D9AED0A9E9FD529D
+      previous_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        hash: 89A0D023A5292D54C167071595F324824636AE6749E072AB91E3FB3792B34745
+  - TreeNode:
+      label:
+        val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+        len: 256
+      latest_node:
+        label:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        last_epoch: 3
+        least_descendent_ep: 3
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 96E573EBF17EBFB5E4CBBA3CCC01E1C08BC02C47F7D5C78E4217E6E29EB002DD
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+        len: 256
+      latest_node:
+        label:
+          val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D9E6B0373D031DE21095D8BAE0CFEE429BEA5E5C2B6CBAF5DBD414F7B84CAC3B
+      previous_node: ~
+  - TreeNode:
+      label:
         val: "0000000000000000000000000000000000000000000000000000000000000000"
         len: 0
-      node_type: Interior
-      left_child:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      right_child:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      hash: EBB2FA256A895C93A56996A6171F16548983FDF8E8909EEDD91ADA205C479B88
+      latest_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        last_epoch: 8
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Root
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        right_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        hash: 29637E816E478A10660879B19AC9620856BF0C688BF0DE3426DFC162C49A51EF
+      previous_node:
+        label:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        last_epoch: 7
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Root
+        left_child:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        right_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        hash: A185765E18E037D39A9192C7A42659CB6ADEEEFD228FAD8ED8CA7D1A46B677FB
   - TreeNode:
       label:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
+        val: "6000000000000000000000000000000000000000000000000000000000000000"
+        len: 3
+      latest_node:
+        label:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+          len: 256
+        right_child:
+          val: "7400000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        hash: DBD79641389B38A9545E7F6B4B60D0E62662C4BD062C2C10A5CE10DAADC35F1E
+      previous_node:
+        label:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        last_epoch: 5
+        least_descendent_ep: 2
+        parent:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+          len: 256
+        right_child:
+          val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+          len: 256
+        hash: FBE41C5DC65A8589EC6D16451C092369E97109C1290F3971C99B199D9E4B2B25
+  - TreeNode:
+      label:
+        val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
         len: 256
-      last_epoch: 6
-      least_descendent_ep: 6
-      parent:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 7515BE4C2FC5D560D33A148BF05498946C0F77CD4C40C3E9DC47E6DF57A530B5
+      latest_node:
+        label:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: A800000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 53FE05220926C50E9C5714F65170CB173C7C58C3D69636378E2FDADB342123D2
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: FC00000000000000000000000000000000000000000000000000000000000000
+        len: 6
+      latest_node:
+        label:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        last_epoch: 6
+        least_descendent_ep: 3
+        parent:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        node_type: Interior
+        left_child:
+          val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+          len: 256
+        right_child:
+          val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+          len: 256
+        hash: 24F1243A36BC675BA3667A5322D30146B69F0CFEF3F99E622FBB76A112A77BE6
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+        len: 256
+      latest_node:
+        label:
+          val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: "7400000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: AC6813FB6B82F3C9BBF212FF0BF9B1C593E6604F0E41C4B1EE9C1614A0FFBDFD
+      previous_node: ~
   - TreeNode:
       label:
         val: "4000000000000000000000000000000000000000000000000000000000000000"
         len: 2
-      last_epoch: 7
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
-        len: 256
-      right_child:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      hash: 1204411588F2C08FD66F557BD859923DBF03F6928B2019DAA88AC38CA96E5ED4
+      latest_node:
+        label:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+          len: 256
+        right_child:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        hash: C2042B886776C5B96E3C064709F292985022B054832204008C95570E0EE1D4EC
+      previous_node:
+        label:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 2
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+          len: 256
+        right_child:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        hash: 6CFD4C94459087ACE2C7876FE55BD44F9F75369B4A8DB7E8E650D50367A664B3
   - TreeNode:
       label:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
+        val: 1BAFC2DC5E11D1A3123E22A53420C3BBABA16759A4DFBD76D8890DA6BF1F5C62
         len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
+      latest_node:
+        label:
+          val: 1BAFC2DC5E11D1A3123E22A53420C3BBABA16759A4DFBD76D8890DA6BF1F5C62
+          len: 256
+        last_epoch: 8
+        least_descendent_ep: 8
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A0735FC57C4865A6E22DD365423641A8539A2929817CD244286C7BEA4F72CE0C
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "7400000000000000000000000000000000000000000000000000000000000000"
+        len: 6
+      latest_node:
+        label:
+          val: "7400000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        last_epoch: 8
+        least_descendent_ep: 2
+        parent:
+          val: "6000000000000000000000000000000000000000000000000000000000000000"
+          len: 3
+        node_type: Interior
+        left_child:
+          val: 748C06DEB17555788B8CD34201F9FAE3097D533AE73A750FB35B73E97E160955
+          len: 256
+        right_child:
+          val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+          len: 256
+        hash: 336664D48EEFCFAB4B442AEC57205C7E9DB97832C13E0C7FC005D541012D1449
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: "1800000000000000000000000000000000000000000000000000000000000000"
         len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: C6E944D42547913361C7FDE58977B6330BD8D1672A1F1B51377AE14D3EE4D28A
+      latest_node:
+        label:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        last_epoch: 8
+        least_descendent_ep: 3
+        parent:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        node_type: Interior
+        left_child:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        right_child:
+          val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+          len: 256
+        hash: 975A693412D38C29A7D899DE6E09CC6AF62D4AB29D46C50CF719AE122E3EEAAB
+      previous_node:
+        label:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        last_epoch: 4
+        least_descendent_ep: 3
+        parent:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        node_type: Interior
+        left_child:
+          val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+          len: 256
+        right_child:
+          val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+          len: 256
+        hash: 63AF7A9D6E80BB1CD0785940962F82F0F8CBBDEF634CA1913A08411788D7EA58
   - TreeNode:
       label:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      last_epoch: 4
-      least_descendent_ep: 3
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      node_type: Interior
-      left_child:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
+        val: 748C06DEB17555788B8CD34201F9FAE3097D533AE73A750FB35B73E97E160955
         len: 256
-      right_child:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
-        len: 256
-      hash: 753BED410AF5E3A445C0AAD8926247FB3E23AC4833DBD8FB63D22EECBE40DE49
+      latest_node:
+        label:
+          val: 748C06DEB17555788B8CD34201F9FAE3097D533AE73A750FB35B73E97E160955
+          len: 256
+        last_epoch: 8
+        least_descendent_ep: 8
+        parent:
+          val: "7400000000000000000000000000000000000000000000000000000000000000"
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 6F282CD0EABF8D540FA029B58800B203B279BB9C6BB3F1710200A77D4C6C84BC
+      previous_node: ~
   - TreeNode:
       label:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 944BEDCC24E092F62E6A9605DAD2171A317DEBBD5DC7A2B253235217CB43D114
+        val: B000000000000000000000000000000000000000000000000000000000000000
+        len: 6
+      latest_node:
+        label:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Interior
+        left_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 7
+        right_child:
+          val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+          len: 256
+        hash: B4822D2172E4140C185CB4B7DBAA955775CC2A8E2F05D501FB4206E4CF175C66
+      previous_node: ~
   - TreeNode:
       label:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
-        len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 5581DF1A91AF121B2C42F6ED73BD4A9AF4A7741B367652B30DD2CF261CBC55AE
-  - TreeNode:
-      label:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 4
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Interior
-      left_child:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
-        len: 256
-      right_child:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      hash: 2FBC50A8E2676BFC27F8DA6C547DF628D77D4E91B1ECCB29FEDF4C1B62C41532
-  - TreeNode:
-      label:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      last_epoch: 6
-      least_descendent_ep: 6
-      parent:
         val: A000000000000000000000000000000000000000000000000000000000000000
         len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 0D92427D3158B0D6E8F3BCE9B478370AA8070DEAC25255B304E53907E5E775E4
+      latest_node:
+        label:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        last_epoch: 8
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: A800000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        right_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        hash: 8D100216ABE0F17F9EE436AECDEDE255086098D6DD8AFD006A5A4CF0BCF432AE
+      previous_node:
+        label:
+          val: A000000000000000000000000000000000000000000000000000000000000000
+          len: 3
+        last_epoch: 6
+        least_descendent_ep: 1
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Interior
+        left_child:
+          val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+          len: 256
+        right_child:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        hash: DFC5FC51E9608548B595904A2988985466BA3CACD805AD7CF2ACD0A30141088E
   - TreeNode:
       label:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
+        val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
         len: 256
-      last_epoch: 5
-      least_descendent_ep: 5
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: BE28B7DC6E198F13C389E5E663BF4B8B212D21E8C677C34F5EE0DE6EF5BA83BE
-  - TreeNode:
-      label:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 5
-      last_epoch: 5
-      least_descendent_ep: 3
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      node_type: Interior
-      left_child:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
-        len: 256
-      right_child:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      hash: C36CC85F4F530B186EF3A702E384A53DD1431433261C91807008B4BFC9B349C2
+      latest_node:
+        label:
+          val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+          len: 256
+        last_epoch: 5
+        least_descendent_ep: 5
+        parent:
+          val: B000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 9F0B76C2FF55B6E4947ECCDB290121E8FC48945B8AEA3D9E00EA833A4667D418
+      previous_node: ~
   - Azks:
       latest_epoch: 8
-      num_nodes: 33
+      num_nodes: 43
   - TreeNode:
       label:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
+        val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
         len: 256
-      last_epoch: 4
-      least_descendent_ep: 4
-      parent:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: E59533119D5673A4709D99754C32A8F49AEC3C5CC49873C42259105D74517EF8
+      latest_node:
+        label:
+          val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
+          len: 256
+        last_epoch: 2
+        least_descendent_ep: 2
+        parent:
+          val: "1000000000000000000000000000000000000000000000000000000000000000"
+          len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 8D0417650E053E0FD51DC5607F9817E85572708031729C804504282ABDB0230C
+      previous_node: ~
   - TreeNode:
       label:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 2
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      node_type: Interior
-      left_child:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      right_child:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      hash: C0FCE72CA8DBAEC705718DD137F7121EBC146F36B1FEFEC52BD76E5FC6647797
-  - TreeNode:
-      label:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      last_epoch: 7
-      least_descendent_ep: 4
-      parent:
-        val: E000000000000000000000000000000000000000000000000000000000000000
-        len: 3
-      node_type: Interior
-      left_child:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      right_child:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      hash: 2C5E2FEC8284D0BED671EB0397CB3B4F5A27902C00955DCB96E73FACB089CEA8
-  - TreeNode:
-      label:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      last_epoch: 7
-      least_descendent_ep: 7
-      parent:
-        val: F000000000000000000000000000000000000000000000000000000000000000
-        len: 4
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 3E773DFE63A8B401BFEB63A9409223FA7B09D8A770FAE677AE1513ED9609093D
-  - TreeNode:
-      label:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      last_epoch: 7
-      least_descendent_ep: 2
-      parent:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
-        len: 2
-      node_type: Interior
-      left_child:
-        val: "6000000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      right_child:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
-        len: 256
-      hash: 0208BBC32414AA7A102058752D4235EB2DC2B410116679000BA58EA376461546
-  - TreeNode:
-      label:
-        val: "3800000000000000000000000000000000000000000000000000000000000000"
-        len: 5
-      last_epoch: 7
-      least_descendent_ep: 6
-      parent:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Interior
-      left_child:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
-        len: 256
-      right_child:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
-        len: 256
-      hash: 4F27FF764BC03B99A290CD0D4FBDF32764837330F017DC9FED4FADF09BB70265
-  - TreeNode:
-      label:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      last_epoch: 2
-      least_descendent_ep: 2
-      parent:
-        val: "8000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: 5068EB2C4DCB0588DF2B40456002E4E24D35CCA20A9AD804ED779556BFFDC5E2
-  - TreeNode:
-      label:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      last_epoch: 8
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      node_type: Root
-      left_child:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      right_child:
         val: "8000000000000000000000000000000000000000000000000000000000000000"
         len: 1
-      hash: 8E8E58380BB2397A1D05C159A4D9B8814A5AEC9F910169D19FABAC1ED0F31941
+      latest_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 8
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        hash: 20D01710BB2FE080F66D36B7000CE5D1A2E7929DF608551438EF22E20F589067
+      previous_node:
+        label:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        last_epoch: 7
+        least_descendent_ep: 1
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 0
+        node_type: Interior
+        left_child:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        right_child:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        hash: C7326F250E314264161F3C8064A943386547F742BAAC0AB1D9B408135F1DA0FA
   - TreeNode:
       label:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
+        val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
         len: 256
-      last_epoch: 3
-      least_descendent_ep: 3
-      parent:
-        val: E400000000000000000000000000000000000000000000000000000000000000
-        len: 7
-      node_type: Leaf
-      left_child: ~
-      right_child: ~
-      hash: B004A67D97F7DA70779C25AA5B000C67F7C80E7CE6FFFD827998905532B00F38
+      latest_node:
+        label:
+          val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: "4000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C284727DBC89D0883249BAF208B8BCA833B78D3B7975F0743457A65138B2C74D
+      previous_node: ~
   - TreeNode:
       label:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 1
-      last_epoch: 7
-      least_descendent_ep: 1
-      parent:
-        val: "0000000000000000000000000000000000000000000000000000000000000000"
-        len: 0
-      node_type: Interior
-      left_child:
-        val: "2000000000000000000000000000000000000000000000000000000000000000"
-        len: 3
-      right_child:
-        val: "4000000000000000000000000000000000000000000000000000000000000000"
+        val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+        len: 256
+      latest_node:
+        label:
+          val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+          len: 256
+        last_epoch: 6
+        least_descendent_ep: 6
+        parent:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A0EBBBA33A04D23D31E220AAEE12E50BDC5B220A56B4F06F0F80FBF110E2FA44
+      previous_node: ~
+  - TreeNode:
+      label:
+        val: C000000000000000000000000000000000000000000000000000000000000000
         len: 2
-      hash: E3E693BDF87CF7498C299F362BD876B9D16F16F492DF19B18B1F7043E106A371
-  - ValueState:
-      plaintext_val: 436F46796341726C47776349616B667542645A6F4164334162665A4A44354261
-      version: 1
+      latest_node:
+        label:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        last_epoch: 8
+        least_descendent_ep: 3
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: D000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        right_child:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        hash: 99769D461FF6A75411ACC5495023F4BDBE663C7CAB811ECC45255C11AFA875B7
+      previous_node:
+        label:
+          val: C000000000000000000000000000000000000000000000000000000000000000
+          len: 2
+        last_epoch: 7
+        least_descendent_ep: 3
+        parent:
+          val: "8000000000000000000000000000000000000000000000000000000000000000"
+          len: 1
+        node_type: Interior
+        left_child:
+          val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+          len: 256
+        right_child:
+          val: FC00000000000000000000000000000000000000000000000000000000000000
+          len: 6
+        hash: CF9FEE075E3327A41B3F511486453E54B868FCCF98A49916E8CEC826BA6002A8
+  - TreeNode:
       label:
-        val: 63844284FF3D54212BF4FF7FFAAF0D7DB7F4441B6B2E0DA8E2BA2CDB31DCC244
+        val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
         len: 256
-      epoch: 2
-      username: 4E526346573458446D496356574E754A434B61364E41644C487A6C4237657950
-  - ValueState:
-      plaintext_val: 44417369483847376C5A477556545034777442736947396450556678534C4272
-      version: 1
+      latest_node:
+        label:
+          val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
+          len: 256
+        last_epoch: 7
+        least_descendent_ep: 7
+        parent:
+          val: "0000000000000000000000000000000000000000000000000000000000000000"
+          len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: CFBE6A08CFE0147C76B9ABE0B40AD9983D7FD32B60CA503AB92066E0D984807E
+      previous_node: ~
+  - TreeNode:
       label:
-        val: 649BC8B16CFE5A911BE417323724D0096F9431D7E9BE77933EF540439DA863E8
+        val: A805CEDF56D1B1A0AAD36EF3DC45B9999C453C6BE818E987D56BADDA32DA4CB1
         len: 256
-      epoch: 3
-      username: 796C4C6E3575426B6A496F63334F4B6B6858444F4367526D39476A7435526C54
-  - ValueState:
-      plaintext_val: 5641636F31757A595A4638334467634F4F6173354D66556E786D70704E667142
-      version: 1
+      latest_node:
+        label:
+          val: A805CEDF56D1B1A0AAD36EF3DC45B9999C453C6BE818E987D56BADDA32DA4CB1
+          len: 256
+        last_epoch: 8
+        least_descendent_ep: 8
+        parent:
+          val: A800000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C54B52124D8394A9068E96E8FF3230385C1FF88B133C54AA9295A4B6EF8C04EA
+      previous_node: ~
+  - TreeNode:
       label:
-        val: E5ED30568701848C355882AB9EA0F45AC0C1455B1B5E1B9C6D893A4E59997E4D
+        val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
         len: 256
-      epoch: 4
-      username: 584962457A6E724A716935623063553977667A546A4B61315938713844686D54
-  - ValueState:
-      plaintext_val: 7A31303733454F3333747239776877725A3369574741475846634C616E793477
-      version: 1
+      latest_node:
+        label:
+          val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+          len: 256
+        last_epoch: 4
+        least_descendent_ep: 4
+        parent:
+          val: "1800000000000000000000000000000000000000000000000000000000000000"
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 73684149233A296A9A8118D98BA2AB703AFF012089643F08F0473A1EE8536EAC
+      previous_node: ~
+  - TreeNode:
       label:
-        val: 3E7EE5504873408087932E2D706A41A54722FBC5DA0B7A353B8D92DC2803FF60
+        val: D4C3B34E1DB12EA6BE29A6F8F11142401BDF5D7035FDADB40AFD21F9702F0261
         len: 256
-      epoch: 6
-      username: 326A414F654173734A6642454A536267317A39614E794B525966794970767344
+      latest_node:
+        label:
+          val: D4C3B34E1DB12EA6BE29A6F8F11142401BDF5D7035FDADB40AFD21F9702F0261
+          len: 256
+        last_epoch: 8
+        least_descendent_ep: 8
+        parent:
+          val: D000000000000000000000000000000000000000000000000000000000000000
+          len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 53A52452E860752A5A442EA2907518870C294600D88FBE7641871913A9CD7AC5
+      previous_node: ~
   - ValueState:
-      plaintext_val: 48597155324355345369753674666731447972716B6679554D526E7848315859
+      plaintext_val: 77715A413769357258613866313231664A585533624F6F6B74714E6965504162
       version: 1
       label:
-        val: F0095EEAD1AB85170C2D572A4E257AB36043CA6BD2444A983584AFAAC92B703E
-        len: 256
-      epoch: 4
-      username: 64384676524D4671397A444332434C514555675A6F383850387445763532564D
-  - ValueState:
-      plaintext_val: 59636F6D70476468706E475044436D76384C464F6764654A4F4838524348396F
-      version: 1
-      label:
-        val: 880A7A7501BF780609DEF26B6C6C08584AAFCBAC6E3BAD7B9A24984DED153775
-        len: 256
-      epoch: 4
-      username: 61676476305351445A4E6F4F384A4F5054693034636C6D31416A6D6450336B63
-  - ValueState:
-      plaintext_val: 4E3049576B476143486468636D4D6856494875464A5A70754C4F347A55754869
-      version: 1
-      label:
-        val: FC93F0D7442BBEF5B05B10D79BEDCC296FDBFCF7A352B73BF73D95F0AF41AD27
-        len: 256
-      epoch: 7
-      username: 3035324F55376A5578564F61384255554463326D706545683663514F534F3459
-  - ValueState:
-      plaintext_val: 696C536F56325530436F6639434570686A66455A4768636A614D764D6A773176
-      version: 1
-      label:
-        val: 9BC0A6C985B7BED9FF1BB81B7F07785866B5FE080B7D6CB9E616332602BCF5D8
-        len: 256
-      epoch: 2
-      username: 56554B67354666724E4E657450417176794948655278544E7736734E75687548
-  - ValueState:
-      plaintext_val: 776579504E77645A366C4C37446830323933524B38345A61587A6F6F584B6E63
-      version: 1
-      label:
-        val: 391161F6C34B64ECECC8FB2D261B64047AF7D28F193DC570B4D05A224E30BEDB
-        len: 256
-      epoch: 7
-      username: 7177706C6B4F423636687455466771534831616B5A6E774A3156445856327370
-  - ValueState:
-      plaintext_val: 5947733966506234764E3748476B5946354F4737487A655A3859624C75415754
-      version: 1
-      label:
-        val: F13037887CEE2708EC08E6E37A84E2949AF2B4792EA74578C72D7C508AD90FA7
-        len: 256
-      epoch: 4
-      username: 4E58624E3451416B4A6A65414D39656C6B56517A4167334E757753334D4F334E
-  - ValueState:
-      plaintext_val: 3974444D6577514C6A63596875314F3172615079776237746C4F566B64417270
-      version: 1
-      label:
-        val: A2F68070FADF2631FC9D868F445576B4BB5C919E7680D8EBE594A06E5E8656D4
-        len: 256
-      epoch: 6
-      username: 54517770726E596C706B557A54653679777A79724153566D644F3177684C4A54
-  - ValueState:
-      plaintext_val: 32746F344B79425551484633776265384634637131356D726F3175386B395978
-      version: 1
-      label:
-        val: B918ADEFBBFD03FC562FD8D0DA22A9B645DA425998B3CD47D1E0CC2C8FE0092F
-        len: 256
-      epoch: 8
-      username: 69334E6D68506D667A54734F78483767416D464F416C36586D50484E7A635051
-  - ValueState:
-      plaintext_val: 6B7471484C745870756D34543363534E6239336366633773466B724132413256
-      version: 1
-      label:
-        val: 27D0AC3AB449A7F3AC03EE389379D875B8FDC52199F65FD29FC0D757EBC98F1D
-        len: 256
-      epoch: 2
-      username: 4D66434B436A524E6A54504F77564C37726E69384639387667574D334D313972
-  - ValueState:
-      plaintext_val: 724B49744F454F5A53726A434861574F5179765A74494F6336784C765653657A
-      version: 1
-      label:
-        val: E45785A7245D1571B2CA7815911A0893F3463482E8F8539022A13BB48BE29DEF
-        len: 256
-      epoch: 3
-      username: 3350676566306F4E41704D4D4544493533346D776136667A504F745349544270
-  - ValueState:
-      plaintext_val: 557448744F78587A45696B7669666739415276426D634E414441594E44625A68
-      version: 1
-      label:
-        val: E3FBCFB286D55D0F0D122418F01DA32100C4E5B96CE169CC6B74FF5317912DF4
+        val: 922E47D8E10917FA31CDEC4E61AF793824772D10A8B923E68C8D6149D3437D08
         len: 256
       epoch: 5
-      username: 764E6D4457674A35314C714577556343663245434F4E45753647707A52776F74
+      username: 6C5874436833696C44313350613166366A3946457A673053336267644348395A
   - ValueState:
-      plaintext_val: 4962626C5630534951356A4574746678457137365136587174526B42334E6F5A
+      plaintext_val: 7958696C67675A7073476D6155436C757432414B50784C58734C6B3741615655
       version: 1
       label:
-        val: 4D8FE7E924913420EA65BB44DD7CBA138D0C3DA3A77EDBF342CAEF1E71EEBB11
+        val: 14BD2735D0FE23762E9D36B4F65F01C68EC7641C0046517A5FBA0F0F7EBA36AF
         len: 256
-      epoch: 1
-      username: 616D73344269396848734C6B305368683161557A794144704C3148395777536B
+      epoch: 2
+      username: 6C6F6976513061574C4B554E6875726B5A72723538334A5A584159554F394550
   - ValueState:
-      plaintext_val: 6D464761634435614B576C3967307777427A4B6F75725431335779747A45366E
+      plaintext_val: 6E324777664D6C625830377375506B32346964524237654A763077496661796D
       version: 1
       label:
-        val: 79647258AC452BF3FBE09EB9891C1F9D16C919977D9681087AE41B2BC8713A0C
+        val: 748C06DEB17555788B8CD34201F9FAE3097D533AE73A750FB35B73E97E160955
+        len: 256
+      epoch: 8
+      username: 587837466330704A525550706C54344C5A464D39336535427378694D766D5A50
+  - ValueState:
+      plaintext_val: 4842697374496238324C704C636871553257644E62465551615538434D444953
+      version: 1
+      label:
+        val: 76492A48AE9A86EA43209EF05FBB366AB71C9B758F815E4EA74D7D5F61CE4B9B
+        len: 256
+      epoch: 2
+      username: 5039525A623165476B325A7A54747857775A6E5771636352386F527438576447
+  - ValueState:
+      plaintext_val: 5A474A7873716C7A5A62786F43427236496E6173477554614856326E38386339
+      version: 1
+      label:
+        val: FCA1598D989B140AC95530C4ABC5472CDC6FA55561464966412D8171D8951837
+        len: 256
+      epoch: 3
+      username: 3745465548646C554E49566C4B7844684D7273454243546B45324C526D5A7363
+  - ValueState:
+      plaintext_val: 3250474A67594431685272337A4E4372726259394769316D485761724F653456
+      version: 1
+      label:
+        val: 223E2D18098E82AC260B10573735A69B8127F06550264A932A0D05D9D718D810
         len: 256
       epoch: 7
-      username: 386A374F6456376A5076533171636878423933697867445A4750384A7A345455
+      username: 6B4C3269496F784867537634383476696A70666C5A76514B56733865744D4334
+  - ValueState:
+      plaintext_val: 5279686471747546534679437053705367597144344F306A436C4E66646F324C
+      version: 1
+      label:
+        val: 18F14022442807AA07B7ADB1046851FE172930B772454B2BD7BD37F7768490FC
+        len: 256
+      epoch: 3
+      username: 4D7375676D584A42454B6856784D71514F4E65354F376A755451576469753246
+  - ValueState:
+      plaintext_val: 3247565067644F6D57704B6D6C5231504A77436B3133304755726364655A4773
+      version: 1
+      label:
+        val: 918DE3C1290259B5620F21668C5A43085C27ABA934922EEA910FE5F400C5433E
+        len: 256
+      epoch: 1
+      username: 766F67394331614E4B704F793353474A78376864546C334A7A76673577624E35
+  - ValueState:
+      plaintext_val: 705455344E42416C343167697438775343774C784F596E547043343735304F4A
+      version: 1
+      label:
+        val: D3862020C781983F009DB56C33B4DFF345549F1DBCA8081C1DD9BA822D7688D8
+        len: 256
+      epoch: 7
+      username: 36755370743942677049414C4B43416E4F55327951634F46646334595A733536
+  - ValueState:
+      plaintext_val: 463873583942654A4E7A4637414F4A4365364E3966524538364F57424864576A
+      version: 1
+      label:
+        val: B18AA89F7E57D1719DC6DC419DC43673F995BA7CA6ED458050876E5362654F96
+        len: 256
+      epoch: 5
+      username: 6B696E6D46676F65316C467039484B4F393054424761454B42717A5833343031
+  - ValueState:
+      plaintext_val: 47317A586754464D59796E747950316B4C577A3455715A7A4C5A47525A64526B
+      version: 1
+      label:
+        val: FE7F27808FC2730D6D4A765D7CE15CCD52A9AD64276FF22470E4F3834E7469AD
+        len: 256
+      epoch: 6
+      username: 72786E474F6B70336D3348327450555536616557373270554B35585A6536654D
+  - ValueState:
+      plaintext_val: 72693434464E553051736D483777424D365556645239466E785477584D663869
+      version: 1
+      label:
+        val: AFA3177CD8706F1408B9BA702E68F956E7F0F0DCD880D62B6F466070D227BD25
+        len: 256
+      epoch: 2
+      username: 55366F4671315A575A7176514E56593436516C716F6A5161616A623356786A77
+  - ValueState:
+      plaintext_val: 4742476E625333457461594C41506B556F4948495435577A7154716662354C61
+      version: 1
+      label:
+        val: B03533A33EC84B1B4DC42AE51EE8C0A134D958CF9063AF6EDEF92AA7F29A9BB5
+        len: 256
+      epoch: 1
+      username: 6D7A3879366F653769696A34767A6A6E70633550734B61445554414F684D514E
+  - ValueState:
+      plaintext_val: 6D4F433458564D73383842735A6C4D456E44427035536F663479304E51535172
+      version: 1
+      label:
+        val: B47830A50C1E0B775A2803A8765118C462921A2C59C47948716090FA796A90F9
+        len: 256
+      epoch: 5
+      username: 70626A7374796E746C365065334542636A4E696341446B31444549305077626F
+  - ValueState:
+      plaintext_val: 5977347944766D72485377333038304F46626137716C4E5350474B426F43746D
+      version: 1
+      label:
+        val: 88C2E779D415023E331C94CBBD069621A3924998C7E113533F8475068C6AE6DC
+        len: 256
+      epoch: 6
+      username: 535564554F6A664C7A36734E7A4552794678616B774B4346526C64754D387668
+  - ValueState:
+      plaintext_val: 31724838384A494A394B7474476A563669684439624C4F344C6E523557634B64
+      version: 1
+      label:
+        val: 4857961BE8C6C9ADF6890A1A68A33196D96C59CE697EA44D9E2CF1B2D90508BC
+        len: 256
+      epoch: 7
+      username: 5A4846614A5A373547336E726765427641416277435358474D6C77716D754168
+  - ValueState:
+      plaintext_val: 61374E56674E64305A704752685A7758497737314A544370764F49454457584A
+      version: 1
+      label:
+        val: 1BAFC2DC5E11D1A3123E22A53420C3BBABA16759A4DFBD76D8890DA6BF1F5C62
+        len: 256
+      epoch: 8
+      username: 766C703468775A5548594955324E524B783359664A7648777663554B4D636851
+  - ValueState:
+      plaintext_val: 32774D474F474A766D5739523266697261675970633733416C50476A4C754E72
+      version: 1
+      label:
+        val: D4C3B34E1DB12EA6BE29A6F8F11142401BDF5D7035FDADB40AFD21F9702F0261
+        len: 256
+      epoch: 8
+      username: 6B77386955643131616753687552613954754E6D65444F375A30463930626677
+  - ValueState:
+      plaintext_val: 6B68303643704742364F56474A31334941706564434F4B4F4933574745774959
+      version: 1
+      label:
+        val: 61B6CF9432424B3139006A631373FA7C62226FEBCD8942868BC2EA1812C3919A
+        len: 256
+      epoch: 5
+      username: 7052486F6162506E756964564355357077544C36534B6C4C694873726A7A5531
+  - ValueState:
+      plaintext_val: 72506C7775324C7554763633394133334E464F58644350734443693759483556
+      version: 1
+      label:
+        val: A805CEDF56D1B1A0AAD36EF3DC45B9999C453C6BE818E987D56BADDA32DA4CB1
+        len: 256
+      epoch: 8
+      username: 50356F7275365A36393662304C4D4668504E6C6E39704C5842344D5A7A383275
+  - ValueState:
+      plaintext_val: 725353736A73373351527333394E3269654361386C4C3733376D394177355443
+      version: 1
+      label:
+        val: B3115786A09AB0A9C0E0F6E76360F158576F9FB0D7F2A7047CC30672997C4782
+        len: 256
+      epoch: 6
+      username: 6C41613674554755535A6A755141793042786D4E39663632726A50365A35394A
+  - ValueState:
+      plaintext_val: 364752385062676B3235764F69767461757A5347345A394A6D30693757596677
+      version: 1
+      label:
+        val: 1F9B54A8A00C993C2B9FAF9563275A9DBA07F63E9CA36169A5A42DC6DC267121
+        len: 256
+      epoch: 4
+      username: 655969414F584457633632496D53754C7A4C6F506C6F584A304F585578466975

--- a/akd_test_tools/src/fixture_generator/reader/yaml.rs
+++ b/akd_test_tools/src/fixture_generator/reader/yaml.rs
@@ -7,10 +7,11 @@
 
 //! This module contains an implementor of the Reader trait for the YAML format.
 
+use std::fmt::Write as _;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Lines, Seek, SeekFrom};
 use std::iter::Peekable;
-use std::result::Result;
+use std::result::Result; // import without risk of name clashing
 
 use serde::de::DeserializeOwned;
 
@@ -83,7 +84,8 @@ impl YamlFileReader {
                     return Ok(doc);
                 }
                 Some(Ok(line)) => {
-                    doc.push_str(&format!("{}\n", line));
+                    // avoid the extra allocation call with a format!
+                    let _ = write!(doc, "{}\n", line);
                     self.buffer.next();
                 }
                 None => {

--- a/akd_test_tools/src/fixture_generator/reader/yaml.rs
+++ b/akd_test_tools/src/fixture_generator/reader/yaml.rs
@@ -85,7 +85,7 @@ impl YamlFileReader {
                 }
                 Some(Ok(line)) => {
                     // avoid the extra allocation call with a format!
-                    let _ = write!(doc, "{}\n", line);
+                    let _ = writeln!(doc, "{}", line);
                     self.buffer.next();
                 }
                 None => {


### PR DESCRIPTION
Added TreeNodeWithPreviousValue to handle keeping the "previous" state of a tree node. This allows us to access the previous value when a node might be in a future state, since the entire tree hasn't completed update yet.

Related: #213 