### PR TITLE
[RFC] Remove epochs vector from HistoryProof struct

### DIFF
--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -203,7 +203,7 @@ pub fn key_history_verify<H: Hasher>(
         }
     }
 
-    // Check that all the individual update proofs check
+    // Verify all individual update proofs
     let mut maybe_previous_update_epoch = None;
     for update_proof in proof.update_proofs.into_iter() {
         last_version = if update_proof.version > last_version {

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -188,17 +188,6 @@ pub fn key_history_verify<H: Hasher>(
         )));
     }
 
-    // Make sure this proof has the same number of epochs as update proofs.
-    if num_proofs != proof.epochs.len() {
-        return Err(AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(
-            format!(
-                "The number of epochs included in the proofs for user {:?} 
-                did not match the number of update proofs!",
-                akd_key
-            ),
-        )));
-    }
-
     // Check that the sent proofs are for a contiguous sequence of decreasing versions
     for count in 0..num_proofs {
         if count > 0 {
@@ -215,26 +204,27 @@ pub fn key_history_verify<H: Hasher>(
     }
 
     // Check that all the individual update proofs check
-    for (count, update_proof) in proof.update_proofs.into_iter().enumerate() {
+    let mut maybe_previous_update_epoch = None;
+    for update_proof in proof.update_proofs.into_iter() {
         last_version = if update_proof.version > last_version {
             update_proof.version
         } else {
             last_version
         };
-        let ep_match = proof.epochs[count] == update_proof.epoch;
 
-        if count > 0 {
+        if let Some(previous_update_epoch) = maybe_previous_update_epoch {
             // Make sure this this epoch is more than the previous epoch you checked
-            if proof.epochs[count] > proof.epochs[count - 1] {
+            if update_proof.epoch > previous_update_epoch {
                 return Err(AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(
                     format!(
                         "Why are your versions decreasing in updates and epochs not?!,
-                    epochs = {:?}",
-                        proof.epochs
+                        epoch = {}, previous epoch = {}",
+                        update_proof.epoch, previous_update_epoch
                     ),
                 )));
             }
         }
+        maybe_previous_update_epoch = Some(update_proof.epoch);
         let is_tombstone = verify_single_update_proof::<H>(
             root_hash,
             vrf_pk,
@@ -242,7 +232,7 @@ pub fn key_history_verify<H: Hasher>(
             &akd_key,
             allow_tombstones,
         )?;
-        tombstones.push(is_tombstone && ep_match);
+        tombstones.push(is_tombstone);
     }
 
     // Get the least and greatest marker entries for the current version

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -422,7 +422,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
             let mut update_proofs = Vec::<UpdateProof<H>>::new();
             let mut last_version = 0;
-            let mut epochs = Vec::<u64>::new();
             for user_state in user_data {
                 // Ignore states in storage that are ahead of current directory epoch
                 if user_state.epoch <= current_epoch {
@@ -433,7 +432,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                     } else {
                         last_version
                     };
-                    epochs.push(user_state.epoch);
                 }
             }
             let next_marker = get_marker_version(last_version) + 1;
@@ -478,7 +476,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
             Ok(HistoryProof {
                 update_proofs,
-                epochs,
                 next_few_vrf_proofs,
                 non_existence_of_next_few,
                 future_marker_vrf_proofs,
@@ -533,7 +530,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         } else {
             let mut update_proofs = Vec::<UpdateProof<H>>::new();
             let mut last_version = 0;
-            let mut epochs = Vec::<u64>::new();
             for user_state in limited_history {
                 // Ignore states in storage that are ahead of current directory epoch
                 if user_state.epoch <= current_epoch {
@@ -544,7 +540,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
                     } else {
                         last_version
                     };
-                    epochs.push(user_state.epoch);
                 }
             }
             let next_marker = get_marker_version(last_version) + 1;
@@ -589,7 +584,6 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
             Ok(HistoryProof {
                 update_proofs,
-                epochs,
                 next_few_vrf_proofs,
                 non_existence_of_next_few,
                 future_marker_vrf_proofs,

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -230,8 +230,6 @@ pub struct HistoryProof<H: Hasher> {
     /// was retired at the same time as this version
     /// was added. (for version 1, it's just a mem proof).
     pub update_proofs: Vec<UpdateProof<H>>,
-    /// The epochs at which updates were made.
-    pub epochs: Vec<u64>,
     /// VRF Proofs for the labels of the next few values, these are
     /// values in the set [latest_version + 1, ..., 2^(log(latest_version+1))-1]
     pub next_few_vrf_proofs: Vec<Vec<u8>>,
@@ -249,7 +247,6 @@ impl<H: Hasher> Clone for HistoryProof<H> {
     fn clone(&self) -> Self {
         Self {
             update_proofs: self.update_proofs.clone(),
-            epochs: self.epochs.clone(),
             next_few_vrf_proofs: self.next_few_vrf_proofs.clone(),
             non_existence_of_next_few: self.non_existence_of_next_few.clone(),
             future_marker_vrf_proofs: self.future_marker_vrf_proofs.clone(),

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -295,9 +295,22 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         root_hash,
         current_epoch,
         AkdLabel::from_utf8_str("hello4"),
-        key_history_proof,
+        key_history_proof.clone(),
         false,
     )?;
+
+    // history proof with updates of non-decreasing versions/epochs fail to verify
+    let mut borked_proof = key_history_proof.clone();
+    borked_proof.update_proofs = borked_proof.update_proofs.into_iter().rev().collect();
+    let result = key_history_verify::<Blake3>(
+        &vrf_pk,
+        root_hash,
+        current_epoch,
+        AkdLabel::from_utf8_str("hello4"),
+        borked_proof,
+        false,
+    );
+    assert!(matches!(result, Err(_)), "{:?}", result);
 
     Ok(())
 }

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -364,13 +364,27 @@ async fn test_history_proof_multiple_epochs() -> Result<(), AkdError> {
             &vrf_pk.to_bytes(),
             from_digest::<Hash>(root_hash),
             current_epoch,
-            key_bytes,
-            internal_proof,
+            key_bytes.clone(),
+            internal_proof.clone(),
             false,
         );
         assert!(akd_result.is_err(), "{:?}", akd_result);
         assert!(lean_result.is_err(), "{:?}", lean_result);
     }
+
+    // history proof with updates of non-decreasing versions/epochs fail to verify
+    let mut borked_proof = internal_proof.clone();
+    borked_proof.update_proofs = borked_proof.update_proofs.into_iter().rev().collect();
+    let akd_result = crate::verify::key_history_verify(
+        &vrf_pk.to_bytes(),
+        from_digest::<Hash>(root_hash),
+        current_epoch,
+        key_bytes,
+        borked_proof,
+        false,
+    );
+    assert!(matches!(akd_result, Err(_)), "{:?}", akd_result);
+
     Ok(())
 }
 

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -169,7 +169,6 @@ where
     }
     crate::types::HistoryProof {
         update_proofs: res_update_proofs,
-        epochs: history_proof.epochs.clone(),
         next_few_vrf_proofs: history_proof.next_few_vrf_proofs.clone(),
         non_existence_of_next_few: history_proof
             .non_existence_of_next_few

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -244,8 +244,6 @@ pub struct UpdateProof {
 pub struct HistoryProof {
     /// The update proofs in the key history
     pub update_proofs: Vec<UpdateProof>,
-    /// The epochs at which updates were made.
-    pub epochs: Vec<u64>,
     /// VRF Proofs for the labels of the next few values
     pub next_few_vrf_proofs: Vec<Vec<u8>>,
     /// Proof that the next few values did not exist at this time

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -239,18 +239,6 @@ pub fn key_history_verify(
         });
     }
 
-    // Make sure this proof has the same number of epochs as update proofs.
-    if num_proofs != proof.epochs.len() {
-        return Err(VerificationError {
-            error_message: format!(
-                "The number of epochs included in the proofs for user {:?} 
-                did not match the number of update proofs!",
-                akd_key
-            ),
-            error_type: VerificationErrorType::HistoryProof,
-        });
-    }
-
     // Check that the sent proofs are for a contiguous sequence of decreasing versions
     for count in 0..num_proofs {
         if count > 0 {
@@ -268,27 +256,29 @@ pub fn key_history_verify(
     }
 
     // Check that all the individual update proofs check
-    for (count, update_proof) in proof.update_proofs.into_iter().enumerate() {
+    let mut maybe_previous_update_epoch = None;
+    for update_proof in proof.update_proofs.into_iter() {
         // Get the highest version sent among the update proofs.
         last_version = if update_proof.version > last_version {
             update_proof.version
         } else {
             last_version
         };
-        let ep_match = proof.epochs[count] == update_proof.epoch;
-        if count > 0 {
+
+        if let Some(previous_update_epoch) = maybe_previous_update_epoch {
             // Make sure this this epoch is more than the previous epoch you checked
-            if proof.epochs[count] > proof.epochs[count - 1] {
+            if update_proof.epoch > previous_update_epoch {
                 return Err(VerificationError {
                     error_message: format!(
                         "Why are your versions decreasing in updates and epochs not?!,
-                    epochs = {:?}",
-                        proof.epochs
+                        epoch = {}, previous epoch = {}",
+                        update_proof.epoch, previous_update_epoch
                     ),
                     error_type: VerificationErrorType::HistoryProof,
                 });
             }
         }
+        maybe_previous_update_epoch = Some(update_proof.epoch);
         let is_tombstone = verify_single_update_proof(
             root_hash,
             vrf_public_key,
@@ -296,7 +286,7 @@ pub fn key_history_verify(
             &akd_key,
             allow_tombstones,
         )?;
-        tombstones.push(is_tombstone && ep_match);
+        tombstones.push(is_tombstone);
     }
 
     // Get the least and greatest marker entries for the current version

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -255,7 +255,7 @@ pub fn key_history_verify(
         }
     }
 
-    // Check that all the individual update proofs check
+    // Verify all individual update proofs
     let mut maybe_previous_update_epoch = None;
     for update_proof in proof.update_proofs.into_iter() {
         // Get the highest version sent among the update proofs.


### PR DESCRIPTION
HistoryProof contains a vector of `UpdateProof`s and a vector of epochs:

https://github.com/novifinancial/akd/blob/97b2e90589083fef4600f732618715fac29a24f2/akd/src/proof_structs.rs#L227-L234

An `UpdateProof` itself contains an epoch:

https://github.com/novifinancial/akd/blob/97b2e90589083fef4600f732618715fac29a24f2/akd/src/proof_structs.rs#L274-L276

From what I can tell, these two fields are populated with the same value:

https://github.com/novifinancial/akd/blob/97b2e90589083fef4600f732618715fac29a24f2/akd/src/directory.rs#L429-L436

- An update proof is created (line 429) with `create_single_update_proof()` and appended to the end of `update_proofs` (line 430)
- `user_state.epoch` is appended to the end of `epochs` vector (line 436)

https://github.com/novifinancial/akd/blob/97b2e90589083fef4600f732618715fac29a24f2/akd/src/directory.rs#L716-L721

- In `create_single_update_proof()`, `user_state.epoch` is assigned to the `epoch` attribute (line 721)

As such, I propose removing the `epochs` vector of the `HistoryProof` struct in favor of relying on the `epoch` attribute of the contained `UpdateProof` structs.