### PR TITLE
Fix significant cache utilization drop for TreeNodes

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -81,7 +81,7 @@ impl Clone for Azks {
 impl Azks {
     /// Creates a new azks
     pub async fn new<S: Storage + Sync + Send, H: Hasher>(storage: &S) -> Result<Self, AkdError> {
-        let root = get_empty_root::<H>(Option::Some(0), Option::Some(0));
+        let root = get_empty_root::<H, S>(storage, Option::Some(0), Option::Some(0)).await?;
         let azks = Azks {
             latest_epoch: 0,
             num_nodes: 1,
@@ -104,7 +104,9 @@ impl Azks {
         // Calls insert_single_leaf on the root node and updates the root and tree_nodes
         // Since this function is only for testing batch_insert_leaves, which is one epoch
         // increment for the entire batch. Hence, we want to take care of epochs outside.
-        let new_leaf = get_leaf_node::<H>(node.label, &node.hash, NodeLabel::root(), epoch);
+        let new_leaf =
+            get_leaf_node::<H, S>(storage, node.label, &node.hash, NodeLabel::root(), epoch)
+                .await?;
 
         let mut root_node = TreeNode::get_from_storage(
             storage,
@@ -113,7 +115,7 @@ impl Azks {
         )
         .await?;
         root_node
-            .insert_single_leaf_and_hash::<_, H>(
+            .insert_single_leaf_and_hash::<S, H>(
                 storage,
                 new_leaf,
                 epoch,
@@ -220,8 +222,14 @@ impl Azks {
         )
         .await?;
         for node in insertion_set {
-            let new_leaf =
-                get_leaf_node::<H>(node.label, &node.hash, NodeLabel::root(), self.latest_epoch);
+            let new_leaf = get_leaf_node::<H, S>(
+                storage,
+                node.label,
+                &node.hash,
+                NodeLabel::root(),
+                self.latest_epoch,
+            )
+            .await?;
             debug!("BEGIN insert leaf");
             root_node
                 .insert_leaf::<_, H>(

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -81,13 +81,11 @@ impl Clone for Azks {
 impl Azks {
     /// Creates a new azks
     pub async fn new<S: Storage + Sync + Send, H: Hasher>(storage: &S) -> Result<Self, AkdError> {
-        let root = create_empty_root::<H, S>(storage, Option::Some(0), Option::Some(0)).await?;
+        create_empty_root::<H, S>(storage, Option::Some(0), Option::Some(0)).await?;
         let azks = Azks {
             latest_epoch: 0,
             num_nodes: 1,
         };
-
-        root.write_to_storage(storage).await?;
 
         Ok(azks)
     }

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -81,7 +81,7 @@ impl Clone for Azks {
 impl Azks {
     /// Creates a new azks
     pub async fn new<S: Storage + Sync + Send, H: Hasher>(storage: &S) -> Result<Self, AkdError> {
-        let root = get_empty_root::<H, S>(storage, Option::Some(0), Option::Some(0)).await?;
+        let root = create_empty_root::<H, S>(storage, Option::Some(0), Option::Some(0)).await?;
         let azks = Azks {
             latest_epoch: 0,
             num_nodes: 1,
@@ -105,7 +105,7 @@ impl Azks {
         // Since this function is only for testing batch_insert_leaves, which is one epoch
         // increment for the entire batch. Hence, we want to take care of epochs outside.
         let new_leaf =
-            get_leaf_node::<H, S>(storage, node.label, &node.hash, NodeLabel::root(), epoch)
+            create_leaf_node::<H, S>(storage, node.label, &node.hash, NodeLabel::root(), epoch)
                 .await?;
 
         let mut root_node = TreeNode::get_from_storage(
@@ -222,7 +222,7 @@ impl Azks {
         )
         .await?;
         for node in insertion_set {
-            let new_leaf = get_leaf_node::<H, S>(
+            let new_leaf = create_leaf_node::<H, S>(
                 storage,
                 node.label,
                 &node.hash,

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -48,12 +48,12 @@ pub fn verify_membership<H: Hasher>(
     if final_hash == root_hash {
         Ok(())
     } else {
-        return Err(AkdError::AzksErr(AzksError::VerifyMembershipProof(
+        Err(AkdError::AzksErr(AzksError::VerifyMembershipProof(
             format!(
                 "Membership proof for label {:?} did not verify",
                 proof.label
             ),
-        )));
+        )))
     }
 }
 

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -201,7 +201,7 @@ pub fn key_history_verify<H: Hasher>(
                     ))));
             }
         }
-    }
+}
 
     // Verify all individual update proofs
     let mut maybe_previous_update_epoch = None;

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -201,7 +201,7 @@ pub fn key_history_verify<H: Hasher>(
                     ))));
             }
         }
-}
+    }
 
     // Verify all individual update proofs
     let mut maybe_previous_update_epoch = None;

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -239,10 +239,8 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         let lookup_info = self
             .get_lookup_info::<H>(uname.clone(), current_epoch)
             .await?;
-        let lookup_proof = self
-            .lookup_with_info::<H>(uname, &current_azks, current_epoch, lookup_info)
-            .await;
-        lookup_proof
+        self.lookup_with_info::<H>(uname, &current_azks, current_epoch, lookup_info)
+            .await
     }
 
     async fn lookup_with_info<H: Hasher>(

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -169,7 +169,7 @@ impl<H: Hasher> Clone for SingleAppendOnlyProof<H> {
 /// * not too far ahead of the most recent marker version,
 /// * not stale when served.
 /// This proof is sent in response to a lookup query for a particular key.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -218,7 +218,7 @@ impl<H: Hasher> Clone for LookupProof<H> {
 
 /// This proof is an array of [`UpdateProof`]s
 /// and proofs of non-membership of future entries
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -52,7 +52,7 @@ impl<H: Hasher> Clone for LayerProof<H> {
 
 /// Merkle proof of membership of a [`NodeLabel`] with a particular hash value
 /// in the tree at a given epoch.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -121,7 +121,7 @@ impl<H: Hasher> Clone for NonMembershipProof<H> {
 /// This is done using a list of SingleAppendOnly proofs, one proof
 /// for each epoch between the initial epoch and final epochs which are
 /// being audited.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -88,7 +88,7 @@ impl<H: Hasher> Clone for MembershipProof<H> {
 
 /// Merkle Patricia proof of non-membership for a [`NodeLabel`] in the tree
 /// at a given epoch.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -262,7 +262,7 @@ impl<H: Hasher> Clone for HistoryProof<H> {
 /// * the version did not exist prior to this epoch,
 /// * the next few versions (up until the next marker), did not exist at this epoch,
 /// * the future marker versions did  not exist at this epoch.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -24,7 +24,7 @@ use winter_crypto::Hasher;
 /// ancestor of the node for which a proof is being generated.
 /// The parent is the parent of the level in the tree at which you are.
 /// See documentation for [`MembershipProof`] to see how this is used.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -140,7 +140,7 @@ pub struct AppendOnlyProof<H: Hasher> {
 /// If we built the tree using the nodes in inserted and the nodes in unchanged_nodes
 /// as the leaves with the correct epoch of insertion,
 /// it should result in the final root hash.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -244,10 +244,12 @@ impl TreeNode {
         &self,
         storage: &S,
     ) -> Result<(), StorageError> {
-        self.save_to_storage(storage, false).await
+        self.write_to_storage_impl(storage, false).await
     }
 
-    async fn save_to_storage<S: Storage + Send + Sync>(
+    /// Internal function to be used for storage operations. If a node is new (i.e., is_new_node=true), the node's previous version
+    /// will be used as None without the cost of finding this information in the cache or worse yet in the database.
+    async fn write_to_storage_impl<S: Storage + Send + Sync>(
         &self,
         storage: &S,
         is_new_node: bool,
@@ -371,7 +373,7 @@ impl TreeNode {
             right_child,
             hash,
         };
-        new_node.save_to_storage(storage, true).await?;
+        new_node.write_to_storage_impl(storage, true).await?;
         Ok(new_node)
     }
 

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -587,8 +587,7 @@ impl TreeNode {
                 .update_node_hash::<_, H>(storage, epoch, exclude_ep)
                 .await?;
         } else {
-            // If no hashing, we need to manually save the nodes.
-            new_leaf.write_to_storage(storage).await?;
+            // If no hashing, we need to manually save the nodes (new leaf already saved above).
             new_node.write_to_storage(storage).await?;
             parent.write_to_storage(storage).await?;
         }

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -879,8 +879,8 @@ pub(crate) fn optional_child_state_hash<H: Hasher>(
     }
 }
 
-/// Retrieve an empty root node
-pub async fn get_empty_root<H: Hasher, S: Storage + Sync + Send>(
+/// Create an empty root node.
+pub async fn create_empty_root<H: Hasher, S: Storage + Sync + Send>(
     storage: &S,
     ep: Option<u64>,
     least_descendant_ep: Option<u64>,
@@ -909,8 +909,8 @@ pub async fn get_empty_root<H: Hasher, S: Storage + Sync + Send>(
     Ok(node)
 }
 
-/// Get a specific leaf node
-pub async fn get_leaf_node<H: Hasher, S: Storage + Sync + Send>(
+/// Create a specific leaf node.
+pub async fn create_leaf_node<H: Hasher, S: Storage + Sync + Send>(
     storage: &S,
     label: NodeLabel,
     value: &H::Digest,
@@ -950,9 +950,9 @@ mod tests {
     async fn test_least_descendant_ep() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
         let mut root =
-            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+            create_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
                 .await?;
-        let new_leaf = get_leaf_node::<Blake3, InMemoryDb>(
+        let new_leaf = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &Blake3::hash(&EMPTY_VALUE),
@@ -961,7 +961,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_1 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &Blake3::hash(&[1u8]),
@@ -970,7 +970,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_2 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &Blake3::hash(&[1u8, 1u8]),
@@ -1053,7 +1053,7 @@ mod tests {
         let db = InMemoryDb::new();
 
         let mut root =
-            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+            create_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
                 .await?;
         root.write_to_storage(&db).await?;
 
@@ -1061,7 +1061,7 @@ mod tests {
         let mut num_nodes = 1;
 
         // Prepare the leaf to be inserted with label 0.
-        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_0 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32),
             &Blake3::hash(&EMPTY_VALUE),
@@ -1075,7 +1075,7 @@ mod tests {
         assert_eq!(num_nodes, 2);
 
         // Prepare another leaf to insert with label 1.
-        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_1 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32),
             &Blake3::hash(&[1u8]),
@@ -1123,9 +1123,9 @@ mod tests {
     async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
         let mut root =
-            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+            create_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
                 .await?;
-        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_0 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &Blake3::hash(&EMPTY_VALUE),
@@ -1134,7 +1134,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_1 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &Blake3::hash(&[1u8]),
@@ -1143,7 +1143,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_2 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &Blake3::hash(&[1u8, 1u8]),
@@ -1206,10 +1206,10 @@ mod tests {
     async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
         let mut root =
-            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+            create_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
                 .await?;
 
-        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_0 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b000u64), 3u32),
             &Blake3::hash(&EMPTY_VALUE),
@@ -1218,7 +1218,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_1 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b111u64 << 61), 3u32),
             &Blake3::hash(&[1u8]),
@@ -1227,7 +1227,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_2 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b100u64 << 61), 3u32),
             &Blake3::hash(&[1u8, 1u8]),
@@ -1236,7 +1236,7 @@ mod tests {
         )
         .await?;
 
-        let leaf_3 = get_leaf_node::<Blake3, InMemoryDb>(
+        let leaf_3 = create_leaf_node::<Blake3, InMemoryDb>(
             &db,
             NodeLabel::new(byte_arr_from_u64(0b010u64 << 61), 3u32),
             &Blake3::hash(&[0u8, 1u8]),
@@ -1312,7 +1312,7 @@ mod tests {
     async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
         let mut root =
-            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+            create_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
                 .await?;
         root.write_to_storage(&db).await?;
         let mut num_nodes = 1;
@@ -1320,7 +1320,7 @@ mod tests {
         let mut leaf_hashes = Vec::new();
         for i in 0u64..8u64 {
             let leaf_u64 = i.clone() << 61;
-            let new_leaf = get_leaf_node::<Blake3, InMemoryDb>(
+            let new_leaf = create_leaf_node::<Blake3, InMemoryDb>(
                 &db,
                 NodeLabel::new(byte_arr_from_u64(leaf_u64), 3u32),
                 &Blake3::hash(&leaf_u64.to_be_bytes()),

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -352,6 +352,7 @@ impl Clone for TreeNode {
 impl TreeNode {
     // FIXME: Figure out how to better group arguments.
     #[allow(clippy::too_many_arguments)]
+    /// Creates a new TreeNode and writes it to the storage.
     async fn new<S: Storage + Send + Sync>(
         storage: &S,
         label: NodeLabel,

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -244,6 +244,14 @@ impl TreeNode {
         &self,
         storage: &S,
     ) -> Result<(), StorageError> {
+        self.save_to_storage(storage, false).await
+    }
+
+    async fn save_to_storage<S: Storage + Send + Sync>(
+        &self,
+        storage: &S,
+        is_new_node: bool,
+    ) -> Result<(), StorageError> {
         // MOTIVATION:
         // We want to retrieve the previous latest_node value, so we want to investigate where (epoch - 1).
         // When a request comes in to write the node with a future epoch, (epoch - 1) will be the latest node in storage
@@ -258,16 +266,24 @@ impl TreeNode {
             e if e > 0 => e - 1,
             other => other,
         };
-        let previous = match TreeNodeWithPreviousValue::get_appropriate_tree_node_from_storage(
-            storage,
-            &NodeKey(self.label),
-            target_epoch,
-        )
-        .await
-        {
-            Ok(p) => Some(p),
-            Err(StorageError::NotFound(_)) => None,
-            Err(other) => return Err(other),
+        // Previous value of a new node are None.
+        // Note that if a request for a non-existent node is issued,
+        // it will skip the cache and directly go to the database
+        // which means a big hit in performance!
+        let previous = if is_new_node {
+            None
+        } else {
+            match TreeNodeWithPreviousValue::get_appropriate_tree_node_from_storage(
+                storage,
+                &NodeKey(self.label),
+                target_epoch,
+            )
+            .await
+            {
+                Ok(p) => Some(p),
+                Err(StorageError::NotFound(_)) => None,
+                Err(other) => return Err(other),
+            }
         };
         // construct the "new" record, shifting the most recent stored value into the "previous" field
         let left_shifted = TreeNodeWithPreviousValue {
@@ -334,7 +350,8 @@ impl Clone for TreeNode {
 impl TreeNode {
     // FIXME: Figure out how to better group arguments.
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    async fn new<S: Storage + Send + Sync>(
+        storage: &S,
         label: NodeLabel,
         parent: NodeLabel,
         node_type: NodeType,
@@ -343,8 +360,8 @@ impl TreeNode {
         left_child: Option<NodeLabel>,
         right_child: Option<NodeLabel>,
         hash: [u8; 32],
-    ) -> Self {
-        TreeNode {
+    ) -> Result<Self, StorageError> {
+        let new_node = TreeNode {
             label,
             last_epoch: birth_epoch,
             least_descendant_ep,
@@ -353,7 +370,9 @@ impl TreeNode {
             left_child,
             right_child,
             hash,
-        }
+        };
+        new_node.save_to_storage(storage, true).await?;
+        Ok(new_node)
     }
 
     /// Inserts a single leaf node and updates the required hashes, creating new nodes where needed.
@@ -521,6 +540,7 @@ impl TreeNode {
 
         debug!("BEGIN create new node");
         let mut new_node = TreeNode::new(
+            storage,
             lcs_label,
             parent.label,
             NodeType::Interior,
@@ -530,7 +550,8 @@ impl TreeNode {
             None,
             None,
             [0u8; 32],
-        );
+        )
+        .await?;
         // Set up child-parent connections from top to bottom
         // (set child sets both child for the parent and parent for the child)
         // 1. Replace the self with the new node.
@@ -858,10 +879,15 @@ pub(crate) fn optional_child_state_hash<H: Hasher>(
 }
 
 /// Retrieve an empty root node
-pub fn get_empty_root<H: Hasher>(ep: Option<u64>, least_descendant_ep: Option<u64>) -> TreeNode {
+pub async fn get_empty_root<H: Hasher, S: Storage + Sync + Send>(
+    storage: &S,
+    ep: Option<u64>,
+    least_descendant_ep: Option<u64>,
+) -> Result<TreeNode, StorageError> {
     // Empty root hash is the same as empty node hash
     let empty_root_hash = from_digest::<H>(crate::utils::empty_node_hash_no_label::<H>());
     let mut node = TreeNode::new(
+        storage,
         NodeLabel::root(),
         NodeLabel::root(),
         NodeType::Root,
@@ -871,34 +897,38 @@ pub fn get_empty_root<H: Hasher>(ep: Option<u64>, least_descendant_ep: Option<u6
         None,
         None,
         empty_root_hash,
-    );
+    )
+    .await?;
     if let Some(epoch) = ep {
         node.last_epoch = epoch;
     }
     if let Some(least_ep) = least_descendant_ep {
         node.least_descendant_ep = least_ep;
     }
-    node
+    Ok(node)
 }
 
 /// Get a specific leaf node
-pub fn get_leaf_node<H: Hasher>(
+pub async fn get_leaf_node<H: Hasher, S: Storage + Sync + Send>(
+    storage: &S,
     label: NodeLabel,
     value: &H::Digest,
     parent: NodeLabel,
     birth_epoch: u64,
-) -> TreeNode {
-    TreeNode {
+) -> Result<TreeNode, StorageError> {
+    let new_node = TreeNode::new(
+        storage,
         label,
-        last_epoch: birth_epoch,
-        least_descendant_ep: birth_epoch,
         parent,
-        node_type: NodeType::Leaf,
-        // Leaf has no children.
-        left_child: None,
-        right_child: None,
-        hash: from_digest::<H>(*value),
-    }
+        NodeType::Leaf,
+        birth_epoch,
+        birth_epoch,
+        None,
+        None,
+        from_digest::<H>(*value),
+    )
+    .await?;
+    Ok(new_node)
 }
 
 #[cfg(test)]
@@ -918,27 +948,35 @@ mod tests {
     #[tokio::test]
     async fn test_least_descendant_ep() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
-        let mut root = get_empty_root::<Blake3>(Option::Some(0u64), Option::Some(0u64));
-        let new_leaf = get_leaf_node::<Blake3>(
+        let mut root =
+            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+                .await?;
+        let new_leaf = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             1,
-        );
+        )
+        .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3>(
+        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &Blake3::hash(&[1u8]),
             NodeLabel::root(),
             2,
-        );
+        )
+        .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3>(
+        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &Blake3::hash(&[1u8, 1u8]),
             NodeLabel::root(),
             3,
-        );
+        )
+        .await?;
 
         root.write_to_storage(&db).await?;
         let mut num_nodes = 1;
@@ -1013,31 +1051,37 @@ mod tests {
     async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
 
-        let mut root = get_empty_root::<Blake3>(Option::Some(0u64), Option::Some(0u64));
+        let mut root =
+            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+                .await?;
         root.write_to_storage(&db).await?;
 
         // Num nodes in total (currently only the root).
         let mut num_nodes = 1;
 
         // Prepare the leaf to be inserted with label 0.
-        let leaf_0 = get_leaf_node::<Blake3>(
+        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32),
             &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
         root.insert_single_leaf_and_hash::<_, Blake3>(&db, leaf_0.clone(), 0, &mut num_nodes, None)
             .await?;
         assert_eq!(num_nodes, 2);
 
         // Prepare another leaf to insert with label 1.
-        let leaf_1 = get_leaf_node::<Blake3>(
+        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32),
             &Blake3::hash(&[1u8]),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
         // Insert leaf 1.
         root.insert_single_leaf_and_hash::<_, Blake3>(&db, leaf_1.clone(), 0, &mut num_nodes, None)
@@ -1077,27 +1121,35 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
-        let mut root = get_empty_root::<Blake3>(Option::Some(0u64), Option::Some(0u64));
-        let leaf_0 = get_leaf_node::<Blake3>(
+        let mut root =
+            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+                .await?;
+        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             1,
-        );
+        )
+        .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3>(
+        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &Blake3::hash(&[1u8]),
             NodeLabel::root(),
             2,
-        );
+        )
+        .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3>(
+        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &Blake3::hash(&[1u8, 1u8]),
             NodeLabel::root(),
             3,
-        );
+        )
+        .await?;
 
         let leaf_0_hash = Blake3::merge(&[
             Blake3::merge_with_int(Blake3::hash(&EMPTY_VALUE), 1),
@@ -1152,35 +1204,45 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
-        let mut root = get_empty_root::<Blake3>(Option::Some(0u64), Option::Some(0u64));
+        let mut root =
+            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+                .await?;
 
-        let leaf_0 = get_leaf_node::<Blake3>(
+        let leaf_0 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b000u64), 3u32),
             &Blake3::hash(&EMPTY_VALUE),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
-        let leaf_1 = get_leaf_node::<Blake3>(
+        let leaf_1 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b111u64 << 61), 3u32),
             &Blake3::hash(&[1u8]),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
-        let leaf_2 = get_leaf_node::<Blake3>(
+        let leaf_2 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b100u64 << 61), 3u32),
             &Blake3::hash(&[1u8, 1u8]),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
-        let leaf_3 = get_leaf_node::<Blake3>(
+        let leaf_3 = get_leaf_node::<Blake3, InMemoryDb>(
+            &db,
             NodeLabel::new(byte_arr_from_u64(0b010u64 << 61), 3u32),
             &Blake3::hash(&[0u8, 1u8]),
             NodeLabel::root(),
             0,
-        );
+        )
+        .await?;
 
         let leaf_0_hash = Blake3::merge(&[
             Blake3::merge_with_int(Blake3::hash(&EMPTY_VALUE), 1),
@@ -1248,19 +1310,23 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
         let db = InMemoryDb::new();
-        let mut root = get_empty_root::<Blake3>(Option::Some(0u64), Option::Some(0u64));
+        let mut root =
+            get_empty_root::<Blake3, InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64))
+                .await?;
         root.write_to_storage(&db).await?;
         let mut num_nodes = 1;
         let mut leaves = Vec::<TreeNode>::new();
         let mut leaf_hashes = Vec::new();
         for i in 0u64..8u64 {
             let leaf_u64 = i.clone() << 61;
-            let new_leaf = get_leaf_node::<Blake3>(
+            let new_leaf = get_leaf_node::<Blake3, InMemoryDb>(
+                &db,
                 NodeLabel::new(byte_arr_from_u64(leaf_u64), 3u32),
                 &Blake3::hash(&leaf_u64.to_be_bytes()),
                 NodeLabel::root(),
                 7 - i,
-            );
+            )
+            .await?;
             leaf_hashes.push(Blake3::merge(&[
                 Blake3::merge_with_int(Blake3::hash(&leaf_u64.to_be_bytes()), 8 - i),
                 hash_label::<Blake3>(new_leaf.label),

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -456,23 +456,21 @@ impl TreeNode {
                 // not equal to the label of the calling node.
                 // This means that the current node needs to be pushed down one level (away from root)
                 // in the tree and replaced with a new node whose label is equal to the longest common prefix.
-                return self
-                    .insert_single_leaf_helper_base_case_handler::<S, H>(
-                        storage, new_leaf, epoch, num_nodes, hashing, exclude_ep, lcs_label,
-                        dir_leaf, dir_self,
-                    )
-                    .await;
+                self.insert_single_leaf_helper_base_case_handler::<S, H>(
+                    storage, new_leaf, epoch, num_nodes, hashing, exclude_ep, lcs_label, dir_leaf,
+                    dir_self,
+                )
+                .await
             }
             // Case where the current node is equal to the lcs
             // Recurse!
             None => {
                 // This is the case where the calling node is the longest common prefix of itself
                 // and the inserted leaf, so we just need to modify the tree structure further down the tree.
-                return self
-                    .insert_single_leaf_helper_recursive_case_handler::<S, H>(
-                        storage, new_leaf, epoch, num_nodes, hashing, exclude_ep, dir_leaf,
-                    )
-                    .await;
+                self.insert_single_leaf_helper_recursive_case_handler::<S, H>(
+                    storage, new_leaf, epoch, num_nodes, hashing, exclude_ep, dir_leaf,
+                )
+                .await
             }
         }
     }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -911,6 +911,10 @@ impl Storage for AsyncMySqlDatabase {
         )
         .await;
 
+        if St::data_type() == StorageType::TreeNode {
+            println!("Get direct tree node.");
+        }
+
         debug!("BEGIN MySQL get {:?}", id);
         let result = async {
             let tic = Instant::now();

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -911,10 +911,6 @@ impl Storage for AsyncMySqlDatabase {
         )
         .await;
 
-        if St::data_type() == StorageType::TreeNode {
-            println!("Get direct tree node.");
-        }
-
         debug!("BEGIN MySQL get {:?}", id);
         let result = async {
             let tic = Instant::now();

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use akd::ecvrf::HardCodedAkdVRF;
+use akd::{ecvrf::HardCodedAkdVRF, storage::Storage};
 use akd_mysql::mysql::*;
 use log::{error, info, warn};
 
@@ -51,6 +51,8 @@ async fn test_directory_operations() {
             &mysql_db, 50, &vrf,
         )
         .await;
+
+        mysql_db.log_metrics(log::Level::Trace).await;
 
         // clean the test infra
         if let Err(mysql_async::Error::Server(error)) = mysql_db.drop_tables().await {


### PR DESCRIPTION
Recently we enabled concurrent reads (proof generations) and writes (publish) by keeping also the previous value of a `TreeNode`. During experiments, we noticed that the cache utilization significantly dropped. For comparison, this is pre-:

```
MySQL writes: 887, MySQL reads: 16, Time read: 0.076431639 s, Time write: 0.921964539 s
        Tree size: 499
        Value state count: 150
Read call stats: [("get_direct:~Azks", 1), ("get_user_data~", 2), ("get_user_state_versions~", 3), ("get_user_state~", 10)]
Write call stats: [("internal_batch_set~", 9), ("internal_set~", 2)]
```

Post:

```
MySQL writes: 878, MySQL reads: 515, Time read: 0.992529763 s, Time write: 2.507405077 s
        Tree size: 499
        Value state count: 150
Read call stats: [("get_direct:~Azks", 1), ("get_direct:~TreeNode", 499), ("get_user_data~", 2), ("get_user_state_versions~", 3), ("get_user_state~", 10)]
Write call stats: [("internal_batch_set~", 9), ("internal_set~", 2)]
```
Note the **("get_direct:~TreeNode", 499)** change.

After some digging, I noticed that this is due to for each node we write we look up the previous version of the node. However, this is unnecessary for **new** nodes since their previous value is already known and is `None`. More concerningly, all these calls hit the database -- since this information is not in the cache either.

This change ensures that (1) we don't go to the database for previous values of new nodes (and just return `None` for them), (2) new nodes are always saved so they can be fetched from the cache.


For comparison, new values:

```
MySQL writes: 891, MySQL reads: 16, Time read: 0.072592335 s, Time write: 2.734630483 s
        Tree size: 499
        Value state count: 150
Read call stats: [("get_direct:~Azks", 1), ("get_user_data~", 2), ("get_user_state_versions~", 3), ("get_user_state~", 10)]
Write call stats: [("internal_batch_set~", 9), ("internal_set~", 3)]
```