### PR TITLE
Remove forced logger initialization in test suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -28,10 +28,6 @@ async fn my_async_test() {
 /// Global test startup constructor. Only runs in the TEST profile. Each
 /// crate which wants logging enabled in tests being run should make this call
 /// itself.
-///
-/// However we additionally call the init_logger(..) fn in the external storage
-/// based test suite in case an external entity doesn't want to deal with the
-/// ctor construction (or initializing the logger themselves)
 #[cfg(test)]
 #[ctor::ctor]
 fn test_start() {

--- a/akd/src/client.rs
+++ b/akd/src/client.rs
@@ -286,7 +286,7 @@ fn verify_single_update_proof<H: Hasher>(
     let existence_at_ep = &proof.existence_at_ep;
     let existence_at_ep_label = existence_at_ep.label;
 
-    let previous_val_stale_at_ep = &proof.previous_version_stale_at_ep;
+    let previous_version_stale_at_ep = &proof.previous_version_stale_at_ep;
 
     let (is_tombstone, value_hash_valid) = match (allow_tombstones, &proof.plaintext_value) {
         (true, bytes) if bytes.0 == crate::TOMBSTONE => {
@@ -332,9 +332,10 @@ fn verify_single_update_proof<H: Hasher>(
             epoch
         );
         let previous_null_err = AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(err_str));
-        let previous_val_stale_at_ep =
-            previous_val_stale_at_ep.as_ref().ok_or(previous_null_err)?;
-        verify_membership(root_hash, previous_val_stale_at_ep)?;
+        let previous_version_stale_at_ep = previous_version_stale_at_ep
+            .as_ref()
+            .ok_or(previous_null_err)?;
+        verify_membership(root_hash, previous_version_stale_at_ep)?;
         let vrf_err_str = format!(
             "Staleness proof of user {:?}'s version {:?} at epoch {:?} is None",
             akd_key,
@@ -345,7 +346,7 @@ fn verify_single_update_proof<H: Hasher>(
         // Verify the VRF for the stale label corresponding to the previous version for this username
         let vrf_previous_null_err =
             AkdError::Directory(DirectoryError::VerifyKeyHistoryProof(vrf_err_str));
-        let previous_val_vrf_proof = proof
+        let previous_version_vrf_proof = proof
             .previous_version_vrf_proof
             .as_ref()
             .ok_or(vrf_previous_null_err)?;
@@ -353,8 +354,8 @@ fn verify_single_update_proof<H: Hasher>(
             akd_key,
             true,
             version - 1,
-            previous_val_vrf_proof,
-            previous_val_stale_at_ep.label,
+            previous_version_vrf_proof,
+            previous_version_stale_at_ep.label,
         )?;
     }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -728,19 +728,19 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         let existence_at_ep = current_azks
             .get_membership_proof(&self.storage, label_at_ep, epoch)
             .await?;
-        let mut previous_val_stale_at_ep = Option::None;
-        let mut previous_val_vrf_proof = Option::None;
+        let mut previous_version_stale_at_ep = Option::None;
+        let mut previous_version_vrf_proof = Option::None;
         if version > 1 {
             let prev_label_at_ep = self
                 .vrf
                 .get_node_label::<H>(uname, true, version - 1)
                 .await?;
-            previous_val_stale_at_ep = Option::Some(
+            previous_version_stale_at_ep = Option::Some(
                 current_azks
                     .get_membership_proof(&self.storage, prev_label_at_ep, epoch)
                     .await?,
             );
-            previous_val_vrf_proof = Option::Some(
+            previous_version_vrf_proof = Option::Some(
                 self.vrf
                     .get_label_proof::<H>(uname, true, version - 1)
                     .await?
@@ -764,8 +764,8 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             plaintext_value: plaintext_value.clone(),
             existence_vrf_proof,
             existence_at_ep,
-            previous_version_vrf_proof: previous_val_vrf_proof,
-            previous_version_stale_at_ep: previous_val_stale_at_ep,
+            previous_version_vrf_proof,
+            previous_version_stale_at_ep,
             commitment_proof,
         })
     }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -48,7 +48,6 @@ mod memory_storage_tests {
 /// This is public because it can be used by other implemented storage layers
 /// for consistency checks (e.g. mysql, memcached, etc)
 pub async fn run_test_cases_for_storage_impl<S: Storage + Sync + Send>(db: &S) {
-    crate::test_utils::init_logger(log::Level::Info);
     test_get_and_set_item(db).await;
     test_user_data(db).await;
     test_transactions(db).await;

--- a/akd/src/test_utils.rs
+++ b/akd/src/test_utils.rs
@@ -101,10 +101,6 @@ pub fn init_logger(level: Level) {
 /// Global test startup constructor. Only runs in the TEST profile. Each
 /// crate which wants logging enabled in tests being run should make this call
 /// itself.
-///
-/// However we additionally call the init_logger(..) fn in the external storage
-/// based test suite in case an external entity doesn't want to deal with the
-/// ctor construction (or initializing the logger themselves)
 #[cfg(test)]
 #[ctor::ctor]
 fn test_start() {

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -158,8 +158,8 @@ where
             version: proof.version,
             existence_vrf_proof: proof.existence_vrf_proof.clone(),
             existence_at_ep: convert_membership_proof(&proof.existence_at_ep),
-            previous_val_vrf_proof: proof.previous_version_vrf_proof.clone(),
-            previous_val_stale_at_ep: proof
+            previous_version_vrf_proof: proof.previous_version_vrf_proof.clone(),
+            previous_version_stale_at_ep: proof
                 .previous_version_stale_at_ep
                 .clone()
                 .map(|val| convert_membership_proof(&val)),

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -231,9 +231,9 @@ pub struct UpdateProof {
     /// Membership proof to show that the key was included in this epoch
     pub existence_at_ep: MembershipProof,
     /// VRF proof for the label for the previous version which became stale
-    pub previous_val_vrf_proof: Option<Vec<u8>>,
+    pub previous_version_vrf_proof: Option<Vec<u8>>,
     /// Proof that previous value was set to old at this epoch
-    pub previous_val_stale_at_ep: Option<MembershipProof>,
+    pub previous_version_stale_at_ep: Option<MembershipProof>,
     /// Proof for commitment value derived from raw AkdLabel and AkdValue
     pub commitment_proof: Vec<u8>,
 }

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -344,7 +344,7 @@ fn verify_single_update_proof(
 
     let existence_at_ep = &proof.existence_at_ep;
 
-    let previous_val_stale_at_ep = &proof.previous_val_stale_at_ep;
+    let previous_version_stale_at_ep = &proof.previous_version_stale_at_ep;
 
     let (is_tombstone, value_hash_valid) = match (allow_tombstone, &proof.plaintext_value) {
         (true, bytes) if bytes == crate::TOMBSTONE => {
@@ -398,9 +398,10 @@ fn verify_single_update_proof(
             error_message: err_str,
             error_type: VerificationErrorType::HistoryProof,
         };
-        let previous_val_stale_at_ep =
-            previous_val_stale_at_ep.as_ref().ok_or(previous_null_err)?;
-        verify_membership(root_hash, previous_val_stale_at_ep)?;
+        let previous_version_stale_at_ep = previous_version_stale_at_ep
+            .as_ref()
+            .ok_or(previous_null_err)?;
+        verify_membership(root_hash, previous_version_stale_at_ep)?;
 
         #[cfg(feature = "vrf")]
         {
@@ -416,8 +417,8 @@ fn verify_single_update_proof(
                 error_message: vrf_err_str,
                 error_type: VerificationErrorType::HistoryProof,
             };
-            let previous_val_vrf_proof = proof
-                .previous_val_vrf_proof
+            let previous_version_vrf_proof = proof
+                .previous_version_vrf_proof
                 .as_ref()
                 .ok_or(vrf_previous_null_err)?;
             verify_vrf(
@@ -425,8 +426,8 @@ fn verify_single_update_proof(
                 uname,
                 true,
                 version - 1,
-                previous_val_vrf_proof,
-                previous_val_stale_at_ep.label,
+                previous_version_vrf_proof,
+                previous_version_stale_at_ep.label,
             )?;
         }
     }

--- a/akd_mysql/src/mysql_db_tests.rs
+++ b/akd_mysql/src/mysql_db_tests.rs
@@ -17,6 +17,7 @@ use crate::mysql::*;
 // FIXME: Why is serial here??
 #[serial]
 async fn test_mysql_db() {
+    akd::test_utils::init_logger(log::Level::Info);
     if AsyncMySqlDatabase::test_guard() {
         if let Err(error) = AsyncMySqlDatabase::create_test_db(
             "localhost",


### PR DESCRIPTION
This PR removes the logger initialization in the `run_test_cases_for_storage_impl` test suite. This is so that clients calling this test suite can initialize their own logger without conflicting with the AKD logger. The AKD logger can still be manually initialized by calling `akd::test_utils::init_logger` in client code.

This PR also renames remaining instances of `previous_val_*` variables to `previous_version_*`. This variable/attribute was renamed in #215 but a few instances were left behind.