### PR TITLE
Add support for passing the epoch to the transaction operations

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -191,7 +191,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             return Ok(EpochHash(current_epoch, root_hash));
         }
 
-        if let false = self.storage.begin_transaction().await {
+        if let false = self.storage.begin_transaction(next_epoch).await {
             error!("Transaction is already active");
             return Err(AkdError::Storage(StorageError::Transaction(
                 "Transaction is already active".to_string(),
@@ -212,7 +212,7 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
         // now commit the transaction
         debug!("Committing transaction");
-        if let Err(err) = self.storage.commit_transaction().await {
+        if let Err(err) = self.storage.commit_transaction(next_epoch).await {
             // ignore any rollback error(s)
             let _ = self.storage.rollback_transaction().await;
             return Err(AkdError::Storage(err));

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -80,11 +80,11 @@ impl Storage for AsyncInMemoryDatabase {
         }
     }
 
-    async fn begin_transaction(&self) -> bool {
+    async fn begin_transaction(&self, _epoch: u64) -> bool {
         self.trans.begin_transaction().await
     }
 
-    async fn commit_transaction(&self) -> Result<(), StorageError> {
+    async fn commit_transaction(&self, _epoch: u64) -> Result<(), StorageError> {
         // this retrieves all the trans operations, and "de-activates" the transaction flag
         let ops = self.trans.commit_transaction().await?;
         self.batch_set(ops).await
@@ -506,11 +506,11 @@ impl Storage for AsyncInMemoryDbWithCache {
         }
     }
 
-    async fn begin_transaction(&self) -> bool {
+    async fn begin_transaction(&self, _epoch: u64) -> bool {
         self.trans.begin_transaction().await
     }
 
-    async fn commit_transaction(&self) -> Result<(), StorageError> {
+    async fn commit_transaction(&self, _epoch: u64) -> Result<(), StorageError> {
         // this retrieves all the trans operations, and "de-activates" the transaction flag
         let ops = self.trans.commit_transaction().await?;
         self.batch_set(ops).await

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -86,10 +86,10 @@ pub trait Storage: Clone {
     async fn log_metrics(&self, level: log::Level);
 
     /// Start a transaction in the storage layer
-    async fn begin_transaction(&self) -> bool;
+    async fn begin_transaction(&self, epoch: u64) -> bool;
 
     /// Commit a transaction in the storage layer
-    async fn commit_transaction(&self) -> Result<(), StorageError>;
+    async fn commit_transaction(&self, epoch: u64) -> Result<(), StorageError>;
 
     /// Rollback a transaction
     async fn rollback_transaction(&self) -> Result<(), StorageError>;

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -365,9 +365,9 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &S) {
     }
 
     let tic = Instant::now();
-    assert!(storage.begin_transaction().await);
+    assert!(storage.begin_transaction(1).await);
     assert_eq!(Ok(()), storage.batch_set(new_data).await);
-    assert_eq!(Ok(()), storage.commit_transaction().await);
+    assert_eq!(Ok(()), storage.commit_transaction(1).await);
     let toc: Duration = Instant::now() - tic;
     println!("Transactional storage batch op: {} ms", toc.as_millis());
 

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.29"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "^0.7.0", features = ["serde_serialization"] }
+akd = { path = "../akd", version = "^0.7.1", features = ["serde_serialization"] }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "^0.7.0", features = ["public-tests"] }
+akd = { path = "../akd", version = "^0.7.1", features = ["public-tests"] }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -720,7 +720,7 @@ impl Storage for AsyncMySqlDatabase {
     }
 
     /// Start a transaction in the storage layer
-    async fn begin_transaction(&self) -> bool {
+    async fn begin_transaction(&self, _epoch: u64) -> bool {
         // disable the cache cleaning since we're in a write transaction
         // and will want to keep cache'd objects for the life of the transaction
         if let Some(cache) = &self.cache {
@@ -731,7 +731,7 @@ impl Storage for AsyncMySqlDatabase {
     }
 
     /// Commit a transaction in the storage layer
-    async fn commit_transaction(&self) -> core::result::Result<(), StorageError> {
+    async fn commit_transaction(&self, _epoch: u64) -> core::result::Result<(), StorageError> {
         // The transaction is now complete (or reverted) and therefore we can re-enable
         // the cache cleaning status
         if let Some(cache) = &self.cache {


### PR DESCRIPTION
In some cases, we may want to offload the transaction to a backup storage as it's a snapshot of all of the changes occurring in that epoch. In this event, it's helpful to know **which** epoch a batch of changes is associated with. This is more future effort than actually applied in the repo, but provides downstream support for others.