### PR TITLE
Fix the in-memory database implementations to properly handle transactions

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -87,9 +87,10 @@ impl Storage for AsyncInMemoryDatabase {
     async fn commit_transaction(&self) -> Result<(), StorageError> {
         // this retrieves all the trans operations, and "de-activates" the transaction flag
         let ops = self.trans.commit_transaction().await?;
+
         let _epoch = match ops.last() {
             Some(DbRecord::Azks(azks)) => Ok(azks.latest_epoch),
-            other => Err(StorageError::Other(format!(
+            other => Err(StorageError::Transaction(format!(
                 "The last record in the transaction log is NOT an Azks record {:?}",
                 other
             ))),
@@ -534,7 +535,7 @@ impl Storage for AsyncInMemoryDbWithCache {
         let ops = self.trans.commit_transaction().await?;
         let _epoch = match ops.last() {
             Some(DbRecord::Azks(azks)) => Ok(azks.latest_epoch),
-            other => Err(StorageError::Other(format!(
+            other => Err(StorageError::Transaction(format!(
                 "The last record in the transaction log is NOT an Azks record {:?}",
                 other
             ))),

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -341,7 +341,7 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &S) {
 
     data.push(DbRecord::Azks(Azks {
         latest_epoch: 1,
-        num_nodes: 34
+        num_nodes: 34,
     }));
 
     let new_data = data
@@ -354,13 +354,11 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &S) {
                     copied_state.epoch += 10000;
                     DbRecord::ValueState(copied_state)
                 }
-                DbRecord::Azks(azks) => {
-                    DbRecord::Azks(Azks {
-                        latest_epoch: azks.latest_epoch + 10000,
-                        num_nodes: azks.num_nodes,
-                    })
-                }
-                _ => new_item
+                DbRecord::Azks(azks) => DbRecord::Azks(Azks {
+                    latest_epoch: azks.latest_epoch + 10000,
+                    num_nodes: azks.num_nodes,
+                }),
+                _ => new_item,
             }
         })
         .collect();

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -339,16 +339,28 @@ async fn test_transactions<S: Storage + Sync + Send>(storage: &S) {
         epoch += 1;
     }
 
+    data.push(DbRecord::Azks(Azks {
+        latest_epoch: 1,
+        num_nodes: 34
+    }));
+
     let new_data = data
         .iter()
         .map(|item| {
             let new_item = item.clone();
-            if let DbRecord::ValueState(new_state) = &item {
-                let mut copied_state = new_state.clone();
-                copied_state.epoch += 10000;
-                DbRecord::ValueState(copied_state)
-            } else {
-                new_item
+            match &item {
+                DbRecord::ValueState(new_state) => {
+                    let mut copied_state = new_state.clone();
+                    copied_state.epoch += 10000;
+                    DbRecord::ValueState(copied_state)
+                }
+                DbRecord::Azks(azks) => {
+                    DbRecord::Azks(Azks {
+                        latest_epoch: azks.latest_epoch + 10000,
+                        num_nodes: azks.num_nodes,
+                    })
+                }
+                _ => new_item
             }
         })
         .collect();

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -40,6 +40,12 @@ impl std::fmt::Debug for Transaction {
     }
 }
 
+impl Default for Transaction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Transaction {
     /// Instantiate a new transaction instance
     pub fn new() -> Self {
@@ -53,15 +59,7 @@ impl Transaction {
             num_writes: Arc::new(tokio::sync::RwLock::new(0)),
         }
     }
-}
 
-impl Default for Transaction {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Transaction {
     /// Log metrics about the current transaction instance. Metrics will be cleared after log call
     pub async fn log_metrics(&self, level: log::Level) {
         let mut r = self.num_reads.write().await;

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -15,6 +15,7 @@ use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[derive(Default)]
 struct TransactionState {
     mods: HashMap<Vec<u8>, DbRecord>,
     active: bool,
@@ -24,6 +25,7 @@ struct TransactionState {
 /// of the changes. When you "commit" this transaction, you return the
 /// collection of values which need to be written to the storage layer
 /// including all mutations. Rollback simply empties the transaction state.
+#[derive(Default)]
 pub struct Transaction {
     state: Arc<tokio::sync::RwLock<TransactionState>>,
 
@@ -37,12 +39,6 @@ unsafe impl Sync for Transaction {}
 impl std::fmt::Debug for Transaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "a lone transaction")
-    }
-}
-
-impl Default for Transaction {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -743,7 +743,7 @@ impl Storage for AsyncMySqlDatabase {
 
         let _epoch = match ops.last() {
             Some(DbRecord::Azks(azks)) => Ok(azks.latest_epoch),
-            other => Err(StorageError::Other(format!(
+            other => Err(StorageError::Transaction(format!(
                 "The last record in the transaction log is NOT an Azks record {:?}",
                 other
             ))),

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The `batch_set` implementations in both memory databases wasn't updating the transaction logs, causing improper construction of the transaction log. This makes both `batch_set` implementations adhere to the spec for transaction handling, as well as adding some test coverage around the ordering of the aZKS commitment to storage (aZKS record must be **last**).