### PR TITLE
Migrate to usage of rustyrepl for easy REPL processing + S3 integration tests

### DIFF
--- a/.github/workflows/s3.yml
+++ b/.github/workflows/s3.yml
@@ -1,0 +1,58 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'akd_local_auditor/'
+  pull_request:
+    types: [opened, repoened, synchronize]
+    paths:
+      - 'akd_local_auditor/'
+
+jobs:
+  test-auditor:
+    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+
+      - name: Cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      # Borrowed from: https://github.com/engula/engula/pull/124/files
+      - name: Setup minio
+        run: |
+          docker run --detach \
+            -p 9000:9000 \
+            -p 9001:9001 \
+            -v "$(mktemp -d)":/data \
+            -e "MINIO_ROOT_USER=test" \
+            -e "MINIO_ROOT_PASSWORD=someLongAccessKey" \
+            -e "MINIO_REGION_NAME=us-east-2" \
+            quay.io/minio/minio server /data --console-address ":9001"
+      - name: Liveness probe
+        timeout-minutes: 1
+        run: |
+          until curl http://127.0.0.1:9000/minio/health/live; do
+              sleep 1
+          done
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path Cargo.toml -p akd_local_auditor integration_test_ -- --ignored

--- a/.github/workflows/s3.yml
+++ b/.github/workflows/s3.yml
@@ -34,7 +34,7 @@ jobs:
           command: build
 
       # Borrowed from: https://github.com/engula/engula/pull/124/files
-      - name: Setup minio
+      - name: Set up minio
         run: |
           docker run --detach \
             -p 9000:9000 \

--- a/akd/src/proto/mod.rs
+++ b/akd/src/proto/mod.rs
@@ -328,7 +328,7 @@ pub fn generate_audit_blobs(
     for i in 0..hashes.len() - 1 {
         let previous_hash = hashes[i];
         let current_hash = hashes[i + 1];
-        // The epoch provided is the destination epoch, i.e. the proof is validating from (T-1, T)
+        // The epoch provided is the source epoch, i.e. the proof is validating from (T, T+1)
         let epoch = proof.epochs[i];
 
         let blob = AuditBlob::new(previous_hash, current_hash, epoch, &proof.proofs[i])?;
@@ -426,7 +426,7 @@ mod tests {
 
         let full_proof = crate::proof_structs::AppendOnlyProof {
             proofs: vec![proof_1.clone(), proof_2.clone()],
-            epochs: vec![1, 2],
+            epochs: vec![0, 1],
         };
 
         let blobs = super::generate_audit_blobs(vec![digest, digest_2, digest_3], full_proof)?;
@@ -435,7 +435,7 @@ mod tests {
         let first_blob: AuditBlob = blobs.first().unwrap().clone();
         let (epoch, phash, chash, proof) = first_blob.decode()?;
 
-        assert_eq!(1, epoch);
+        assert_eq!(0, epoch);
         assert_eq!(digest, phash);
         assert_eq!(digest_2, chash);
         assert_eq!(proof_1, proof);
@@ -443,7 +443,7 @@ mod tests {
         let second_blob: AuditBlob = blobs[1..].first().unwrap().clone();
         let (epoch, phash, chash, proof) = second_blob.decode()?;
 
-        assert_eq!(2, epoch);
+        assert_eq!(1, epoch);
         assert_eq!(digest_2, phash);
         assert_eq!(digest_3, chash);
         assert_eq!(proof_2, proof);

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akd_local_auditor"
 default-run = "akd_local_auditor"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 edition = "2018"
 publish = false
@@ -9,15 +9,17 @@ publish = false
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-aws-config = "0.47.0"
-aws-sdk-s3 = "0.17.0"
+aws-config = "0.47"
+aws-sdk-s3 = "0.17"
+aws-smithy-http = "0.47"
+aws-types = { version = "0.47", features = ["hardcoded-credentials"] }
 bytes = "1"
 clap = { version="3", features = ["derive"] }
 colored = "2.0.0"
 dirs = "4"
 hex = "0.4.3"
+http = "0.2"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-multi_log = "0.1"
 once_cell = "1"
 qr2term = "0.3"
 rand = "0.8"
@@ -29,3 +31,6 @@ winter-crypto = "0.2"
 winter-math = "0.2"
 
 akd = { path = "../akd", features = ["public-tests", "public_auditing"] }
+
+[dev-dependencies]
+ctor = "0.1"

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -21,7 +21,7 @@ multi_log = "0.1"
 once_cell = "1"
 qr2term = "0.3"
 rand = "0.8"
-rustyline = "10"
+rustyrepl = { version = "0.1", features = ["async"] }
 thread-id = "3"
 tokio = { version = "1.10", features = ["full"] }
 tokio-stream = "0.1"

--- a/akd_local_auditor/docker-compose.yml
+++ b/akd_local_auditor/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.3'
+
+services:
+  s3:
+    container_name: minio-s3-storage
+    platform: linux/x86_64
+    image: quay.io/minio/minio
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: test
+      MINIO_ROOT_PASSWORD: someLongAccessKey
+      MINIO_REGION_NAME: us-east-2

--- a/akd_local_auditor/src/auditor/mod.rs
+++ b/akd_local_auditor/src/auditor/mod.rs
@@ -9,13 +9,12 @@
 
 use anyhow::{anyhow, bail, Result};
 use clap::{Parser, Subcommand};
-use log::{debug, error, info, warn};
+use log::{error, info, warn};
 use std::marker::{Send, Sync};
 
-use rustyline::error::ReadlineError;
-use rustyline::Editor;
+use rustyrepl::ReplCommandProcessor;
 
-const HISTORY_FILE: &str = ".akd_local_auditor_history";
+pub(crate) const HISTORY_FILE: &str = ".akd_local_auditor_history";
 
 fn format_qr_record<H>(p_hash: H::Digest, c_hash: H::Digest, epoch: u64) -> Vec<u8>
 where
@@ -93,6 +92,33 @@ pub struct AuditArgs {
     command: AuditCommand,
 }
 
+/// Audit processing crate
+#[derive(Debug)]
+pub struct AuditProcessor {
+    pub(crate) storage: Box<dyn crate::storage::AuditProofStorage>,
+}
+
+#[async_trait::async_trait]
+impl ReplCommandProcessor<AuditArgs> for AuditProcessor {
+    fn is_quit(&self, command: &str) -> bool {
+        matches!(command, "quit" | "exit")
+    }
+
+    async fn process_command(&self, cmd: AuditArgs) -> Result<()> {
+        match &cmd.command {
+            AuditCommand::Audit { epoch, qr } => {
+                let proof = self.storage.get_proof(*epoch).await?;
+                audit_epoch::<crate::Hasher>(proof, *qr).await?;
+            }
+            AuditCommand::ShowEpochs => {
+                let mut proofs = self.storage.list_proofs().await?;
+                display_audit_proofs_info(&mut proofs)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 fn display_audit_proofs_info(info: &mut Vec<crate::storage::EpochSummary>) -> Result<()> {
     info.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
     if info.is_empty() {
@@ -127,94 +153,94 @@ fn display_audit_proofs_info(info: &mut Vec<crate::storage::EpochSummary>) -> Re
     Ok(())
 }
 
-async fn process_command(
-    storage: &dyn crate::storage::AuditProofStorage,
-    cmd: &AuditArgs,
-) -> Result<()> {
-    match &cmd.command {
-        AuditCommand::Audit { epoch, qr } => {
-            let proof = storage.get_proof(*epoch).await?;
-            audit_epoch::<crate::Hasher>(proof, *qr).await?;
-        }
-        AuditCommand::ShowEpochs => {
-            let mut proofs = storage.list_proofs().await?;
-            display_audit_proofs_info(&mut proofs)?;
-        }
-    }
-    Ok(())
-}
+// async fn process_command(
+//     storage: &dyn crate::storage::AuditProofStorage,
+//     cmd: &AuditArgs,
+// ) -> Result<()> {
+//     match &cmd.command {
+//         AuditCommand::Audit { epoch, qr } => {
+//             let proof = storage.get_proof(*epoch).await?;
+//             audit_epoch::<crate::Hasher>(proof, *qr).await?;
+//         }
+//         AuditCommand::ShowEpochs => {
+//             let mut proofs = storage.list_proofs().await?;
+//             display_audit_proofs_info(&mut proofs)?;
+//         }
+//     }
+//     Ok(())
+// }
 
-pub async fn auditor_repl(storage: &dyn crate::storage::AuditProofStorage) -> Result<()> {
-    info!("Starting auditing REPL. Enter [exit] or [x] to exit.");
-    let history_file = dirs::home_dir().map(|mut home_dir| {
-        home_dir.push(HISTORY_FILE);
-        home_dir
-    });
+// pub async fn auditor_repl(storage: &dyn crate::storage::AuditProofStorage) -> Result<()> {
+//     info!("Starting auditing REPL. Enter [exit] or [x] to exit.");
+//     let history_file = dirs::home_dir().map(|mut home_dir| {
+//         home_dir.push(HISTORY_FILE);
+//         home_dir
+//     });
 
-    let mut rl = Editor::<()>::new()?;
-    if let Some(history) = &history_file {
-        if rl.load_history(history).is_ok() {
-            debug!("Command history loaded");
-        }
-    }
+//     let mut rl = Editor::<()>::new()?;
+//     if let Some(history) = &history_file {
+//         if rl.load_history(history).is_ok() {
+//             debug!("Command history loaded");
+//         }
+//     }
 
-    loop {
-        let readline = rl.readline(">> ");
-        match readline {
-            Ok(line) => {
-                // process command
-                let parts: Vec<&str> = line.split(' ').collect();
-                let mut command = String::new();
-                if let Some(head) = parts.first() {
-                    command = String::from(*head);
-                }
-                match command.to_lowercase().as_ref() {
-                    "exit" | "x" => break,
-                    "" => {} // just loop, someone hit enter with no input
-                    _ => {
-                        // the first part of the iterator _must_ be the binary name, the rest are args
-                        let mut cmd_parts: Vec<&str> = vec!["auditor"];
-                        cmd_parts.extend(parts.iter().copied());
-                        match AuditArgs::try_parse_from(cmd_parts.into_iter()) {
-                            Ok(cli) => {
-                                // We're only appending valid commands to the history trail
-                                rl.add_history_entry(line.as_str());
+//     loop {
+//         let readline = rl.readline(">> ");
+//         match readline {
+//             Ok(line) => {
+//                 // process command
+//                 let parts: Vec<&str> = line.split(' ').collect();
+//                 let mut command = String::new();
+//                 if let Some(head) = parts.first() {
+//                     command = String::from(*head);
+//                 }
+//                 match command.to_lowercase().as_ref() {
+//                     "exit" | "x" => break,
+//                     "" => {} // just loop, someone hit enter with no input
+//                     _ => {
+//                         // the first part of the iterator _must_ be the binary name, the rest are args
+//                         let mut cmd_parts: Vec<&str> = vec!["auditor"];
+//                         cmd_parts.extend(parts.iter().copied());
+//                         match AuditArgs::try_parse_from(cmd_parts.into_iter()) {
+//                             Ok(cli) => {
+//                                 // We're only appending valid commands to the history trail
+//                                 rl.add_history_entry(line.as_str());
 
-                                warn!("Received input {}", line);
+//                                 warn!("Received input {}", line);
 
-                                if let Err(err) = process_command(storage, &cli).await {
-                                    error!("Error processing command '{}'", err);
-                                }
-                            }
-                            Err(clap_err) => match clap::Error::kind(&clap_err) {
-                                clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
-                                    info!("{}", clap_err);
-                                }
-                                _ => {
-                                    warn!(
-                                        "Invalid command (type 'help' for the help menu)\r\n{}",
-                                        clap_err
-                                    );
-                                }
-                            },
-                        }
-                    }
-                }
-            }
-            Err(ReadlineError::Interrupted) => break,
-            Err(ReadlineError::Eof) => break,
-            Err(err) => {
-                println!("Error: {:?}", err);
-                break;
-            }
-        }
-    }
+//                                 if let Err(err) = process_command(storage, &cli).await {
+//                                     error!("Error processing command '{}'", err);
+//                                 }
+//                             }
+//                             Err(clap_err) => match clap::Error::kind(&clap_err) {
+//                                 clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
+//                                     info!("{}", clap_err);
+//                                 }
+//                                 _ => {
+//                                     warn!(
+//                                         "Invalid command (type 'help' for the help menu)\r\n{}",
+//                                         clap_err
+//                                     );
+//                                 }
+//                             },
+//                         }
+//                     }
+//                 }
+//             }
+//             Err(ReadlineError::Interrupted) => break,
+//             Err(ReadlineError::Eof) => break,
+//             Err(err) => {
+//                 println!("Error: {:?}", err);
+//                 break;
+//             }
+//         }
+//     }
 
-    println!("Terminating the Soteria client REPL");
-    if let Some(history) = &history_file {
-        if let Err(save_err) = rl.save_history(history) {
-            error!("Failed to save command history: {:?}", save_err);
-        }
-    }
-    Ok(())
-}
+//     println!("Terminating the Soteria client REPL");
+//     if let Some(history) = &history_file {
+//         if let Err(save_err) = rl.save_history(history) {
+//             error!("Failed to save command history: {:?}", save_err);
+//         }
+//     }
+//     Ok(())
+// }

--- a/akd_local_auditor/src/auditor/mod.rs
+++ b/akd_local_auditor/src/auditor/mod.rs
@@ -145,102 +145,10 @@ fn display_audit_proofs_info(info: &mut Vec<crate::storage::EpochSummary>) -> Re
         bail!("The audit proofs appear to not be continguous. There's a break in the linear history at epoch {}", maybe_broken_epoch.name.epoch);
     }
 
-    info!(
+    println!(
         "Audit history is available between epochs ({}) and ({}), inclusively.",
         min.name.epoch, max.name.epoch
     );
 
     Ok(())
 }
-
-// async fn process_command(
-//     storage: &dyn crate::storage::AuditProofStorage,
-//     cmd: &AuditArgs,
-// ) -> Result<()> {
-//     match &cmd.command {
-//         AuditCommand::Audit { epoch, qr } => {
-//             let proof = storage.get_proof(*epoch).await?;
-//             audit_epoch::<crate::Hasher>(proof, *qr).await?;
-//         }
-//         AuditCommand::ShowEpochs => {
-//             let mut proofs = storage.list_proofs().await?;
-//             display_audit_proofs_info(&mut proofs)?;
-//         }
-//     }
-//     Ok(())
-// }
-
-// pub async fn auditor_repl(storage: &dyn crate::storage::AuditProofStorage) -> Result<()> {
-//     info!("Starting auditing REPL. Enter [exit] or [x] to exit.");
-//     let history_file = dirs::home_dir().map(|mut home_dir| {
-//         home_dir.push(HISTORY_FILE);
-//         home_dir
-//     });
-
-//     let mut rl = Editor::<()>::new()?;
-//     if let Some(history) = &history_file {
-//         if rl.load_history(history).is_ok() {
-//             debug!("Command history loaded");
-//         }
-//     }
-
-//     loop {
-//         let readline = rl.readline(">> ");
-//         match readline {
-//             Ok(line) => {
-//                 // process command
-//                 let parts: Vec<&str> = line.split(' ').collect();
-//                 let mut command = String::new();
-//                 if let Some(head) = parts.first() {
-//                     command = String::from(*head);
-//                 }
-//                 match command.to_lowercase().as_ref() {
-//                     "exit" | "x" => break,
-//                     "" => {} // just loop, someone hit enter with no input
-//                     _ => {
-//                         // the first part of the iterator _must_ be the binary name, the rest are args
-//                         let mut cmd_parts: Vec<&str> = vec!["auditor"];
-//                         cmd_parts.extend(parts.iter().copied());
-//                         match AuditArgs::try_parse_from(cmd_parts.into_iter()) {
-//                             Ok(cli) => {
-//                                 // We're only appending valid commands to the history trail
-//                                 rl.add_history_entry(line.as_str());
-
-//                                 warn!("Received input {}", line);
-
-//                                 if let Err(err) = process_command(storage, &cli).await {
-//                                     error!("Error processing command '{}'", err);
-//                                 }
-//                             }
-//                             Err(clap_err) => match clap::Error::kind(&clap_err) {
-//                                 clap::ErrorKind::DisplayHelp | clap::ErrorKind::DisplayVersion => {
-//                                     info!("{}", clap_err);
-//                                 }
-//                                 _ => {
-//                                     warn!(
-//                                         "Invalid command (type 'help' for the help menu)\r\n{}",
-//                                         clap_err
-//                                     );
-//                                 }
-//                             },
-//                         }
-//                     }
-//                 }
-//             }
-//             Err(ReadlineError::Interrupted) => break,
-//             Err(ReadlineError::Eof) => break,
-//             Err(err) => {
-//                 println!("Error: {:?}", err);
-//                 break;
-//             }
-//         }
-//     }
-
-//     println!("Terminating the Soteria client REPL");
-//     if let Some(history) = &history_file {
-//         if let Err(save_err) = rl.save_history(history) {
-//             error!("Failed to save command history: {:?}", save_err);
-//         }
-//     }
-//     Ok(())
-// }

--- a/akd_local_auditor/src/console_log.rs
+++ b/akd_local_auditor/src/console_log.rs
@@ -11,20 +11,22 @@ use log::Metadata;
 use log::Record;
 use once_cell::sync::OnceCell;
 use std::io::Write;
+use std::sync::Once;
 use tokio::time::Duration;
 use tokio::time::Instant;
 
 static EPOCH: OnceCell<Instant> = OnceCell::new();
+static INIT_ONCE: Once = Once::new();
+
+pub(crate) static LOGGER: ConsoleLogger = ConsoleLogger {
+    level: log::Level::Debug,
+};
 
 pub struct ConsoleLogger {
     pub level: Level,
 }
 
 impl ConsoleLogger {
-    pub fn touch() {
-        EPOCH.get_or_init(Instant::now);
-    }
-
     pub(crate) fn format_log_record(io: &mut (dyn Write + Send), record: &Record, colored: bool) {
         let target = {
             if let Some(target_str) = record.target().split(':').last() {
@@ -90,4 +92,30 @@ impl log::Log for ConsoleLogger {
     fn flush(&self) {
         let _ = std::io::stdout().flush();
     }
+}
+
+/// Initialize the logger for console logging within test environments.
+/// This is safe to call multiple times, but it will only initialize the logger
+/// to the log-level _first_ set. If you want a specific log-level (e.g. Debug)
+/// for a specific test, make sure to only run that single test after editing that
+/// test's log-level.
+///
+/// The default level applied everywhere is Info
+pub(crate) fn init_logger(level: Level) {
+    EPOCH.get_or_init(Instant::now);
+
+    INIT_ONCE.call_once(|| {
+        log::set_logger(&LOGGER)
+            .map(|()| log::set_max_level(level.to_level_filter()))
+            .unwrap();
+    });
+}
+
+/// Global test startup constructor. Only runs in the TEST profile. Each
+/// crate which wants logging enabled in tests being run should make this call
+/// itself.
+#[cfg(test)]
+#[ctor::ctor]
+fn test_start() {
+    init_logger(Level::Debug);
 }

--- a/akd_local_auditor/src/main.rs
+++ b/akd_local_auditor/src/main.rs
@@ -17,11 +17,10 @@ use clap::{ArgEnum, Parser};
 use log::debug;
 use winter_crypto::hashers::Blake3_256;
 use winter_math::fields::f128::BaseElement;
-type Hasher = Blake3_256<BaseElement>;
-
-static LOGGER: console_log::ConsoleLogger = console_log::ConsoleLogger {
-    level: log::Level::Debug,
-};
+/// The hashing type (currently Blake3 256)
+pub type Hasher = Blake3_256<BaseElement>;
+/// The hash digest format (currently 32-byte digests)
+pub type Digest = <Blake3_256<BaseElement> as winter_crypto::Hasher>::Digest;
 
 #[derive(ArgEnum, Clone, Debug)]
 enum PublicLogLevel {
@@ -64,16 +63,12 @@ pub struct Arguments {
 // MAIN //
 #[tokio::main]
 async fn main() -> Result<()> {
-    console_log::ConsoleLogger::touch();
-
     let args = Arguments::parse();
 
     // initialize the logger
     let log_level: log::Level = (&args.log_level).into();
+    console_log::init_logger(log_level);
 
-    log::set_logger(&LOGGER)
-        .map(|()| log::set_max_level(log_level.to_level_filter()))
-        .expect("Failed to set up logging");
     debug!("Parsed args: {:?}", args);
 
     let storage: Box<dyn storage::AuditProofStorage> = match &args.storage {

--- a/akd_local_auditor/src/storage/mod.rs
+++ b/akd_local_auditor/src/storage/mod.rs
@@ -54,7 +54,7 @@ impl TryFrom<&str> for EpochSummary {
 
 /// Represents a storage of audit proofs and READ ONLY interaction to retrieve the proof objects
 #[async_trait]
-pub trait AuditProofStorage: Sync + Send {
+pub trait AuditProofStorage: Sync + Send + std::fmt::Debug {
     /// List the proofs in the storage medium.
     async fn list_proofs(&self) -> Result<Vec<EpochSummary>>;
 

--- a/akd_local_auditor/src/storage/s3.rs
+++ b/akd_local_auditor/src/storage/s3.rs
@@ -55,6 +55,7 @@ pub struct S3ClapSettings {
     bucket: String,
 }
 
+#[derive(Debug)]
 pub struct S3AuditStorage {
     /// The bucket where the audit proofs are stored
     bucket: String,

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -54,9 +54,11 @@ fn validate_bucket_name(s: &str) -> Result<String, String> {
 fn validate_uri(s: &str) -> Result<String, String> {
     let uri: http::Uri = s.parse::<http::Uri>().map_err(|err| err.to_string())?;
     match (uri.scheme(), uri.authority()) {
-        (None, None) => Err("URI has no scheme or authority. Relative URIs not supported".to_string()),
+        (None, None) => {
+            Err("URI has no scheme or authority. Relative URIs not supported".to_string())
+        }
         // if there's at least a scheme (http[s]://) or authority (www.test.com) we can construct what we need
-        _ => Ok(s.to_string())
+        _ => Ok(s.to_string()),
     }
 }
 

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -15,9 +15,12 @@ use aws_sdk_s3 as s3;
 use clap::Args;
 use log::{debug, error};
 use s3::output::ListObjectsV2Output;
+use s3::Region;
 use std::convert::TryInto;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use aws_config::meta::region::RegionProviderChain;
+use aws_smithy_http::endpoint::Endpoint;
 
 const MIN_BUCKET_CHARS: usize = 3;
 const MAX_BUCKET_CHARS: usize = 63;
@@ -25,6 +28,9 @@ const ALLOWED_BUCKET_CHARS: [char; 38] = [
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
     't', 'u', 'v', 'w', 'x', 'y', 'z', '.', '-', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
 ];
+
+#[cfg(test)]
+mod test;
 
 fn is_bucket_name_valid(s: &str) -> Result<String, String> {
     let str = s.to_string();
@@ -45,6 +51,11 @@ fn is_bucket_name_valid(s: &str) -> Result<String, String> {
     Ok(str)
 }
 
+fn is_uri_valid(s: &str) -> Result<String, String> {
+    let _uri: http::Uri = s.parse::<http::Uri>().map_err(|err| err.to_string())?;
+    Ok(s.to_string())
+}
+
 #[derive(Args, Debug, Clone)]
 pub struct S3ClapSettings {
     /// The S3 bucket where the audit proofs are stored
@@ -53,12 +64,36 @@ pub struct S3ClapSettings {
         value_parser = is_bucket_name_valid
     )]
     bucket: String,
+
+    /// The AWS region to operate in
+    #[clap(long)]
+    region: String,
+
+    /// [OPTIONAL] An custom URI for the AWS endpoint
+    #[clap(long, value_parser = is_uri_valid)]
+    endpoint: Option<String>,
+
+    /// [OPTIONAL] AWS Access key for the session
+    #[clap(long)]
+    access_key: Option<String>,
+
+    /// [OPTIONAL] AWS secret key for the session
+    #[clap(long)]
+    secret_key: Option<String>,
 }
 
 #[derive(Debug)]
 pub struct S3AuditStorage {
     /// The bucket where the audit proofs are stored
     bucket: String,
+    /// The AWS region
+    region: String,
+    /// Customize the endpoint (useful for testing)
+    endpoint: Option<String>,
+    /// The access key
+    access_key: Option<String>,
+    /// The access secret
+    secret_key: Option<String>,
     /// The configuration, cached for subsequent accesses
     config: Arc<RwLock<Option<aws_config::SdkConfig>>>,
 
@@ -70,6 +105,10 @@ impl From<&S3ClapSettings> for S3AuditStorage {
     fn from(clap: &S3ClapSettings) -> Self {
         Self {
             bucket: clap.bucket.clone(),
+            region: clap.region.clone(),
+            endpoint: clap.endpoint.as_ref().map(|a| a.clone()),
+            access_key: clap.access_key.as_ref().map(|a| a.clone()),
+            secret_key: clap.secret_key.as_ref().map(|a| a.clone()),
             config: Arc::new(RwLock::new(None)),
             cache: Arc::new(RwLock::new(None)),
         }
@@ -77,15 +116,39 @@ impl From<&S3ClapSettings> for S3AuditStorage {
 }
 
 impl S3AuditStorage {
-    async fn get_config(&self) -> s3::Config {
+    async fn get_shared_config(&self) -> aws_types::SdkConfig {
         let mut lock = self.config.write().await;
-        let shared_config = if let Some(config) = &*lock {
+        if let Some(config) = &*lock {
             config.clone()
         } else {
-            let sc = aws_config::load_from_env().await;
-            *lock = Some(sc.clone());
-            sc
-        };
+            // Get the shared AWS config
+            let region_provider = RegionProviderChain::first_try(Region::new(self.region.clone()));
+
+            let mut shared_config_loader = aws_config::from_env()
+                .region(region_provider);
+
+            if let (Some(access_key), Some(secret_key)) = (&self.access_key, &self.secret_key) {
+                let credentials = aws_types::Credentials::from_keys(access_key, secret_key, None);
+                shared_config_loader = shared_config_loader.credentials_provider(credentials);
+            }
+
+            if let Some(endpoint) = &self.endpoint {
+                // THE URI IS ALREADY VALIDATED BY CLAP ARGS, hence the expect here
+                let endpoint_resolver =
+                    Endpoint::immutable(endpoint.parse().expect("valid URI"));
+                shared_config_loader = shared_config_loader.endpoint_resolver(endpoint_resolver);
+            }
+
+            let shared_config = shared_config_loader.load()
+                .await;
+
+            *lock = Some(shared_config.clone());
+            shared_config
+        }
+    }
+
+    async fn get_config(&self) -> s3::Config {
+        let shared_config = self.get_shared_config().await;
         s3::config::Builder::from(&shared_config)
             .retry_config(RetryConfig::disabled())
             .build()

--- a/akd_local_auditor/src/storage/s3/test.rs
+++ b/akd_local_auditor/src/storage/s3/test.rs
@@ -116,12 +116,16 @@ async fn maybe_flush_storage(shared_config: &SdkConfig, bucket_name: &str) -> Re
     if let Some(bucket_names) = buckets.buckets() {
         log::info!("Found {} buckets in the test storage", bucket_names.len());
 
-        if let Some(_) = bucket_names.iter().find(|bucket| {
-            if let Some(maybe_bucket) = bucket.name() {
-                return maybe_bucket == bucket_name;
-            }
-            false
-        }) {
+        if bucket_names
+            .iter()
+            .find(|bucket| {
+                if let Some(maybe_bucket) = bucket.name() {
+                    return maybe_bucket == bucket_name;
+                }
+                false
+            })
+            .is_some()
+        {
             log::info!("Found target bucket {}, deleting.", bucket_name);
 
             // From: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/rust_s3_code_examples.html

--- a/akd_local_auditor/src/storage/s3/test.rs
+++ b/akd_local_auditor/src/storage/s3/test.rs
@@ -1,0 +1,354 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! A note to readers:
+//!
+//! We are marking most of the following tests as `#[ignored]` so they don't run automatically
+//! with `cargo test`. These require a docker container running `minio` to be running which is
+//! run in our CI pipeline when changes to this crate are made, but not otherwise since they
+//! are relatively expensive integration test operations. See [s3.yml](.github/workflows/s3.yml)
+//! for more information
+
+use crate::{
+    storage::{AuditProofStorage, EpochSummary},
+    Digest, Hasher,
+};
+
+use super::*;
+use akd::directory::Directory;
+use akd::ecvrf::HardCodedAkdVRF;
+use akd::storage::memory::AsyncInMemoryDatabase;
+use akd::AkdLabel;
+use akd::AkdValue;
+use anyhow::Result;
+use aws_config::SdkConfig;
+use aws_sdk_s3::{
+    config::Builder as S3ConfigBuilder,
+    model::{Delete, ObjectIdentifier},
+    Client,
+};
+use aws_smithy_http::byte_stream::ByteStream;
+
+// These are constants that are matched in both this crate's `docker-compose.yml`
+// and the s3.yml workflow pipeline
+const ACCESS_KEY: &str = "test";
+const SECRET_KEY: &str = "someLongAccessKey";
+const TEST_REGION: &str = "us-east-2";
+const TEST_ENDPOINT: &str = "http://127.0.0.1:9000";
+
+macro_rules! bucket_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        name[..name.len() - 3].trim_end_matches("::{{closure}}").split("::").last().unwrap().replace("_", "")
+    }}
+}
+
+struct AuditInformation {
+    proof: akd::proof_structs::AppendOnlyProof<Hasher>,
+    phash: Digest,
+    chash: Digest,
+}
+
+/// Generate N audit proofs from a new tree
+async fn generate_audit_proofs(
+    n: usize,
+) -> Result<Vec<AuditInformation>, akd::errors::AkdError> {
+    let db = AsyncInMemoryDatabase::new();
+    let vrf = HardCodedAkdVRF {};
+    let akd = Directory::<_, _>::new::<Hasher>(&db, &vrf, false).await?;
+    let mut proofs = vec![];
+    // gather the hash + azks for epoch "0" (init)
+    let mut azks = akd.retrieve_current_azks().await?;
+    let mut phash = akd.get_root_hash::<Hasher>(&azks).await?;
+
+    for _epoch in 1..=n {
+        // generate (n) epochs of updates on the same user
+        let t_value = format!("certificate{}", _epoch);
+        akd.publish::<Hasher>(vec![(
+            AkdLabel::from_utf8_str("user"),
+            AkdValue::from_utf8_str(&t_value),
+        )])
+        .await?;
+        // generate the append-only proof
+        let proof = akd
+            .audit::<Hasher>((_epoch - 1) as u64, _epoch as u64)
+            .await?;
+        // update the azks + retrieve the "next" hash
+        azks = akd.retrieve_current_azks().await?;
+        let chash = akd.get_root_hash::<Hasher>(&azks).await?;
+
+        // we have everything we need, pass it along
+        let info = AuditInformation {
+            phash,
+            chash,
+            proof,
+        };
+        proofs.push(info);
+
+        // reset the "previous" hash for the next iteration
+        phash = chash;
+    }
+    Ok(proofs)
+}
+
+/// Flush the storage bucket of all blobs + delete the bucket (if it exists)
+async fn maybe_flush_storage(shared_config: &SdkConfig, bucket_name: &str) -> Result<()> {
+    // Build the S3 config from the shared SdkConfig
+    let config = S3ConfigBuilder::from(shared_config)
+        .retry_config(RetryConfig::disabled())
+        .build();
+    // get the S3 client
+    let client = Client::from_conf(config);
+    // check if the bucket exists
+    let buckets = client.list_buckets().send().await?;
+
+    if let Some(bucket_names) = buckets.buckets() {
+        log::info!("Found {} buckets in the test storage", bucket_names.len());
+
+        for bucket in bucket_names {
+            if let Some(maybe_name) = bucket.name() {
+                if maybe_name == bucket_name {
+                    log::info!("Found target bucket {}, deleting.", bucket_name);
+
+                    // From: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/rust_s3_code_examples.html
+                    let objects = client.list_objects_v2().bucket(bucket_name).send().await?;
+                    let mut delete_objects: Vec<ObjectIdentifier> = vec![];
+                    for obj in objects.contents().unwrap_or_default() {
+                        let obj_id = ObjectIdentifier::builder()
+                            .set_key(Some(obj.key().unwrap().to_string()))
+                            .build();
+                        delete_objects.push(obj_id);
+                    }
+                    if !delete_objects.is_empty() {
+                        log::info!(
+                            "Bucket {} has {} objects in it which must be delete first",
+                            bucket_name,
+                            delete_objects.len()
+                        );
+                        client
+                            .delete_objects()
+                            .bucket(bucket_name)
+                            .delete(Delete::builder().set_objects(Some(delete_objects)).build())
+                            .send()
+                            .await?;
+                    }
+                    client.delete_bucket().bucket(bucket_name).send().await?;
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Populate a test bucket with `n` audit proofs
+async fn populate_test_storage(
+    shared_config: &SdkConfig,
+    bucket: &str,
+    n_blobs: usize,
+) -> Result<()> {
+    maybe_flush_storage(shared_config, bucket).await?;
+
+    // Build the S3 config from the shared SdkConfig
+    let config = S3ConfigBuilder::from(shared_config)
+        .retry_config(RetryConfig::disabled())
+        .build();
+    // get the S3 client
+    let client = Client::from_conf(config);
+    // create the bucket
+    client
+        .create_bucket()
+        .bucket(bucket.to_string())
+        .send()
+        .await?;
+    // Generate a block of real, verifiable audit proofs
+    let proofs = generate_audit_proofs(n_blobs)
+        .await
+        .map_err(|akd_err| anyhow::anyhow!("AKD Error generating proofs: {}", akd_err))?;
+
+    // upload each proof blob into S3
+    for AuditInformation {
+        chash,
+        phash,
+        proof,
+    } in proofs
+    {
+        // Generate the s3 compat format
+        let blobs = akd::proto::generate_audit_blobs(vec![phash, chash], proof)
+            .map_err(|err| anyhow::anyhow!("Error generating audit blob {}", err))?;
+        // Grab the blob + upload it
+        if let Some(blob) = blobs.first() {
+            let byte_stream = ByteStream::from(blob.data.clone());
+            let name = blob.name.to_string();
+            client
+                .put_object()
+                .bucket(bucket.to_string())
+                .key(name)
+                .body(byte_stream)
+                .send()
+                .await?;
+        } else {
+            assert!(
+                false,
+                "We should never generate an empty blob array, but if we do crash hard & fast!"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn get_s3_storage(bucket: &str) -> S3AuditStorage {
+    let clap_args = S3ClapSettings {
+        bucket: bucket.to_string(),
+        region: TEST_REGION.to_string(),
+        endpoint: Some(TEST_ENDPOINT.to_string()),
+        access_key: Some(ACCESS_KEY.to_string()),
+        secret_key: Some(SECRET_KEY.to_string()),
+    };
+    let storage: S3AuditStorage = (&clap_args).into();
+    storage
+}
+
+// =========================== Test Cases =========================== //
+
+#[tokio::test]
+#[ignore]
+async fn integration_test_bucket_listing() -> Result<()> {
+    // make sure we have a valid bucket name, that's "somewhat" unique
+    let bucket = bucket_name!();
+    log::debug!("Test bucket name is {}", bucket);
+    assert!(matches!(is_bucket_name_valid(&bucket), Ok(_)));
+
+    // Get the storage reader
+    let storage = get_s3_storage(&bucket);
+    let shared_config = storage.get_shared_config().await;
+
+    // Populate the test storage
+    populate_test_storage(&shared_config, &bucket, 10).await?;
+
+    // List the epochs found in the storage layer
+    let mut epoch_summaries: Vec<EpochSummary> = storage.list_proofs().await?;
+    epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
+
+    // There should be 10 proofs in the storage layer
+    log::info!("There are {} epochs in the storage layer", epoch_summaries.len());
+    assert_eq!(10, epoch_summaries.len());
+
+    // check the linear history of the proofs
+    log::info!("Checking linear history of audit proofs");
+    let mut i = 0u64;
+    for summary in epoch_summaries {
+        assert_eq!(i, summary.name.epoch);
+        i += 1;
+    }
+
+    // if the test is successful, try a cleanup of the storage now
+    maybe_flush_storage(&shared_config, &bucket).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn integration_test_audit_verification() -> Result<()> {
+    // make sure we have a valid bucket name, that's "somewhat" unique
+    let bucket = bucket_name!();
+    log::debug!("Test bucket name is {}", bucket);
+    assert!(matches!(is_bucket_name_valid(&bucket), Ok(_)));
+
+    // Get the storage reader
+    let storage = get_s3_storage(&bucket);
+    let shared_config = storage.get_shared_config().await;
+
+    // Populate the test storage
+    populate_test_storage(&shared_config, &bucket, 3).await?;
+
+    // List the epochs found in the storage layer
+    let mut epoch_summaries: Vec<EpochSummary> = storage.list_proofs().await?;
+    epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
+
+    // There should be 3 proofs in the storage layer
+    log::info!("There are {} epochs in the storage layer", epoch_summaries.len());
+    assert_eq!(3, epoch_summaries.len());
+
+    // verify all fo the audit proofs
+    for epoch in 0..=2 {
+        let proof_blob = storage.get_proof(epoch).await?;
+        log::info!("Verification epoch {} -> {}", epoch, epoch+1);
+        crate::auditor::audit_epoch::<Hasher>(proof_blob.clone(), false).await?;
+        crate::auditor::audit_epoch::<Hasher>(proof_blob, true).await?;
+    }
+
+    // if the test is successful, try a cleanup of the storage now
+    maybe_flush_storage(&shared_config, &bucket).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn populate_test_bucket() -> Result<()> {
+    // Populates the test bucket for use with the command-line REPL via the command
+    // cargo run -p akd_local_auditor -- s3 --bucket populatetestbucket --region us-east-2 --endpoint http://127.0.0.1:9000 --access-key test --secret-key someLongAccessKey
+
+    // make sure we have a valid bucket name, that's "somewhat" unique
+    let bucket = bucket_name!();
+    log::debug!("Test bucket name is {}", bucket);
+    assert!(matches!(is_bucket_name_valid(&bucket), Ok(_)));
+
+    // Get the storage reader
+    let storage = get_s3_storage(&bucket);
+    let shared_config = storage.get_shared_config().await;
+
+    // Populate the test storage
+    populate_test_storage(&shared_config, &bucket, 50).await?;
+
+    Ok(())
+}
+
+#[test]
+fn test_bucket_name_parsing() -> Result<()> {
+    let too_short = "a";
+    assert!(matches!(super::is_bucket_name_valid(too_short), Err(_)));
+
+    let too_long = "1234567890123456789012345678901234567890123456789012345678901234567890";
+    assert!(matches!(super::is_bucket_name_valid(too_long), Err(_)));
+
+    let bad_chars = "!@#$%^&*()_+";
+    assert!(matches!(super::is_bucket_name_valid(bad_chars), Err(_)));
+
+    let ok_1 = "12345";
+    let ok_2 = "some-bucket-name";
+    let ok_3 = "some.bucket.name";
+
+    assert!(matches!(super::is_bucket_name_valid(ok_1), Ok(_)));
+    assert!(matches!(super::is_bucket_name_valid(ok_2), Ok(_)));
+    assert!(matches!(super::is_bucket_name_valid(ok_3), Ok(_)));
+
+
+    Ok(())
+}
+
+#[test]
+fn test_uri_parsing() -> Result<()> {
+    let non_uri = "hasdf!@#";
+    let bad_port = "http://localhost:1234%567891230";
+
+    assert!(matches!(super::is_uri_valid(non_uri), Err(_)));
+    assert!(matches!(super::is_uri_valid(bad_port), Err(_)));
+
+    assert!(matches!(super::is_uri_valid("www.ok.com"), Ok(_)));
+    assert!(matches!(super::is_uri_valid("http://ok.com"), Ok(_)));
+    assert!(matches!(super::is_uri_valid("http://127.0.0.1:9000"), Ok(_)));
+    assert!(matches!(super::is_uri_valid("http://east-us-2.aws.com:123"), Ok(_)));
+
+    Ok(())
+}

--- a/akd_local_auditor/src/storage/s3/test.rs
+++ b/akd_local_auditor/src/storage/s3/test.rs
@@ -47,8 +47,13 @@ macro_rules! bucket_name {
             std::any::type_name::<T>()
         }
         let name = type_name_of(f);
-        name[..name.len() - 3].trim_end_matches("::{{closure}}").split("::").last().unwrap().replace("_", "")
-    }}
+        name[..name.len() - 3]
+            .trim_end_matches("::{{closure}}")
+            .split("::")
+            .last()
+            .unwrap()
+            .replace("_", "")
+    }};
 }
 
 struct AuditInformation {
@@ -58,9 +63,7 @@ struct AuditInformation {
 }
 
 /// Generate N audit proofs from a new tree
-async fn generate_audit_proofs(
-    n: usize,
-) -> Result<Vec<AuditInformation>, akd::errors::AkdError> {
+async fn generate_audit_proofs(n: usize) -> Result<Vec<AuditInformation>, akd::errors::AkdError> {
     let db = AsyncInMemoryDatabase::new();
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new::<Hasher>(&db, &vrf, false).await?;
@@ -239,7 +242,10 @@ async fn integration_test_bucket_listing() -> Result<()> {
     epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
 
     // There should be 10 proofs in the storage layer
-    log::info!("There are {} epochs in the storage layer", epoch_summaries.len());
+    log::info!(
+        "There are {} epochs in the storage layer",
+        epoch_summaries.len()
+    );
     assert_eq!(10, epoch_summaries.len());
 
     // check the linear history of the proofs
@@ -276,13 +282,16 @@ async fn integration_test_audit_verification() -> Result<()> {
     epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
 
     // There should be 3 proofs in the storage layer
-    log::info!("There are {} epochs in the storage layer", epoch_summaries.len());
+    log::info!(
+        "There are {} epochs in the storage layer",
+        epoch_summaries.len()
+    );
     assert_eq!(3, epoch_summaries.len());
 
     // verify all fo the audit proofs
     for epoch in 0..=2 {
         let proof_blob = storage.get_proof(epoch).await?;
-        log::info!("Verification epoch {} -> {}", epoch, epoch+1);
+        log::info!("Verification epoch {} -> {}", epoch, epoch + 1);
         crate::auditor::audit_epoch::<Hasher>(proof_blob.clone(), false).await?;
         crate::auditor::audit_epoch::<Hasher>(proof_blob, true).await?;
     }
@@ -333,7 +342,6 @@ fn test_bucket_name_parsing() -> Result<()> {
     assert!(matches!(super::is_bucket_name_valid(ok_2), Ok(_)));
     assert!(matches!(super::is_bucket_name_valid(ok_3), Ok(_)));
 
-
     Ok(())
 }
 
@@ -347,8 +355,14 @@ fn test_uri_parsing() -> Result<()> {
 
     assert!(matches!(super::is_uri_valid("www.ok.com"), Ok(_)));
     assert!(matches!(super::is_uri_valid("http://ok.com"), Ok(_)));
-    assert!(matches!(super::is_uri_valid("http://127.0.0.1:9000"), Ok(_)));
-    assert!(matches!(super::is_uri_valid("http://east-us-2.aws.com:123"), Ok(_)));
+    assert!(matches!(
+        super::is_uri_valid("http://127.0.0.1:9000"),
+        Ok(_)
+    ));
+    assert!(matches!(
+        super::is_uri_valid("http://east-us-2.aws.com:123"),
+        Ok(_)
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
`rustyrepl` is a new crate to facilitate a lot of the boiler plate with REPL processing. It provides a cleaner syntax and is easy to manage.

Additionally this PR adds integration tests around the `s3` integration logic utilizing an s3-minic (`minio`) docker container.