### PR TITLE
Add serialized proof verification to akd_client

### DIFF
--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -21,7 +21,7 @@ winter-utils = { version = "0.2", optional = true }
 sha2 = { version = "0.10.1", optional = true, default-features = false }
 sha3 = { version = "0.10.0", optional = true, default-features = false }
 blake3 = { version = "1.3.1", optional = true, default-features = false }
-serde_json = "1.0"
+serde_json = "1"
 
 wasm-bindgen = { version = "0.2.79", optional = true, features = ["serde-serialize"] }
 serde = { version = "1.0", features = ["derive"]}

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -16,9 +16,10 @@ crate-type = ["cdylib", "rlib"]
 sha2 = { version = "0.10.1", optional = true, default-features = false }
 sha3 = { version = "0.10.0", optional = true, default-features = false }
 blake3 = { version = "1.3.1", optional = true, default-features = false }
+serde_json = "1.0"
 
 wasm-bindgen = { version = "0.2.79", optional = true, features = ["serde-serialize"] }
-serde = { version = "1.0", optional = true, features = ["derive"]}
+serde = { version = "1.0", features = ["derive"]}
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
@@ -40,7 +41,7 @@ sha3_512 = ["sha3"]
 default = ["blake3", "vrf"]
 
 # Enable web assembly compilation of the AKD client crate
-wasm = ["wasm-bindgen", "serde"]
+wasm = ["wasm-bindgen"]
 
 # Verify with Verifiable random functions (VRFs)
 vrf = ["curve25519-dalek", "ed25519-dalek"]

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -13,6 +13,11 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# Currently only used in the "converters" feature
+akd = { path = "../akd", features = ["vrf", "public-tests"], optional = true }
+winter-crypto = { version = "0.2", optional = true }
+winter-utils = { version = "0.2", optional = true }
+
 sha2 = { version = "0.10.1", optional = true, default-features = false }
 sha3 = { version = "0.10.0", optional = true, default-features = false }
 blake3 = { version = "1.3.1", optional = true, default-features = false }
@@ -34,7 +39,7 @@ ed25519-dalek = { version = "1", features = ["serde"], optional = true}
 [features]
 nostd = []
 # Enable converters API from akd to akd_client types
-converters = []
+converters = ["akd", "winter-crypto", "winter-utils"]
 # Optional hash functions
 sha512 = ["sha2"]
 sha256 = ["sha2"]

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -33,6 +33,8 @@ ed25519-dalek = { version = "1", features = ["serde"], optional = true}
 
 [features]
 nostd = []
+# Enable converters API from akd to akd_client types
+converters = []
 # Optional hash functions
 sha512 = ["sha2"]
 sha256 = ["sha2"]

--- a/akd_client/src/converters.rs
+++ b/akd_client/src/converters.rs
@@ -7,10 +7,9 @@
 
 //! Converters from akd types to akd_client types
 
+use crate::hash::DIGEST_BYTES;
 use akd;
 use winter_utils::Serializable;
-use crate::hash::DIGEST_BYTES;
-
 
 /// Converts a Digest type to a byte array of size DIGEST_BYTES.
 pub fn to_digest<H>(hash: H::Digest) -> crate::types::Digest
@@ -96,7 +95,9 @@ where
 }
 
 /// Converts and AKD lookup proof to AKD_CLIENT lookup proof.
-pub fn convert_lookup_proof<H>(proof: &akd::proof_structs::LookupProof<H>) -> crate::types::LookupProof
+pub fn convert_lookup_proof<H>(
+    proof: &akd::proof_structs::LookupProof<H>,
+) -> crate::types::LookupProof
 where
     H: winter_crypto::Hasher,
 {

--- a/akd_client/src/converters.rs
+++ b/akd_client/src/converters.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! Converters from akd types to akd_client types
+
+use akd;
+use winter_utils::Serializable;
+use crate::hash::DIGEST_BYTES;
+
+
+/// Converts a Digest type to a byte array of size DIGEST_BYTES.
+pub fn to_digest<H>(hash: H::Digest) -> crate::types::Digest
+where
+    H: winter_crypto::Hasher,
+{
+    let digest = hash.to_bytes();
+    if digest.len() == DIGEST_BYTES {
+        // OK
+        let ptr = digest.as_ptr() as *const [u8; DIGEST_BYTES];
+        unsafe { *ptr }
+    } else {
+        panic!("Hash digest is not {} bytes", DIGEST_BYTES);
+    }
+}
+
+fn convert_label(proof: akd::node_label::NodeLabel) -> crate::types::NodeLabel {
+    crate::types::NodeLabel {
+        label_len: proof.label_len,
+        label_val: proof.label_val,
+    }
+}
+
+fn convert_node<H>(node: akd::Node<H>) -> crate::types::Node
+where
+    H: winter_crypto::Hasher,
+{
+    crate::types::Node {
+        label: convert_label(node.label),
+        hash: to_digest::<H>(node.hash),
+    }
+}
+
+fn convert_layer_proof<H>(
+    parent: akd::NodeLabel,
+    direction: akd::Direction,
+    sibling: akd::Node<H>,
+) -> crate::types::LayerProof
+where
+    H: winter_crypto::Hasher,
+{
+    crate::types::LayerProof {
+        direction,
+        label: convert_label(parent),
+        siblings: [convert_node(sibling)],
+    }
+}
+
+fn convert_membership_proof<H>(
+    proof: &akd::proof_structs::MembershipProof<H>,
+) -> crate::types::MembershipProof
+where
+    H: winter_crypto::Hasher,
+{
+    crate::types::MembershipProof {
+        hash_val: to_digest::<H>(proof.hash_val),
+        label: convert_label(proof.label),
+        layer_proofs: proof
+            .layer_proofs
+            .iter()
+            .map(|lp| convert_layer_proof(lp.label, lp.direction, lp.siblings[0]))
+            .collect::<Vec<_>>(),
+    }
+}
+
+fn convert_non_membership_proof<H>(
+    proof: &akd::proof_structs::NonMembershipProof<H>,
+) -> crate::types::NonMembershipProof
+where
+    H: winter_crypto::Hasher,
+{
+    crate::types::NonMembershipProof {
+        label: convert_label(proof.label),
+        longest_prefix: convert_label(proof.longest_prefix),
+        longest_prefix_children: [
+            convert_node::<H>(proof.longest_prefix_children[0]),
+            convert_node::<H>(proof.longest_prefix_children[1]),
+        ],
+        longest_prefix_membership_proof: convert_membership_proof(
+            &proof.longest_prefix_membership_proof,
+        ),
+    }
+}
+
+/// Converts and AKD lookup proof to AKD_CLIENT lookup proof.
+pub fn convert_lookup_proof<H>(proof: &akd::proof_structs::LookupProof<H>) -> crate::types::LookupProof
+where
+    H: winter_crypto::Hasher,
+{
+    crate::types::LookupProof {
+        epoch: proof.epoch,
+        version: proof.version,
+        plaintext_value: proof.plaintext_value.to_vec(),
+        existence_vrf_proof: proof.existence_vrf_proof.clone(),
+        existence_proof: convert_membership_proof(&proof.existence_proof),
+        marker_vrf_proof: proof.marker_vrf_proof.clone(),
+        marker_proof: convert_membership_proof(&proof.marker_proof),
+        freshness_vrf_proof: proof.freshness_vrf_proof.clone(),
+        freshness_proof: convert_non_membership_proof(&proof.freshness_proof),
+        commitment_proof: proof.commitment_proof.clone(),
+    }
+}
+
+/// Converts an AKD history proof to an AKD_CLIENT history proof
+pub fn convert_history_proof<H>(
+    history_proof: &akd::proof_structs::HistoryProof<H>,
+) -> crate::types::HistoryProof
+where
+    H: winter_crypto::Hasher,
+{
+    let mut res_update_proofs = Vec::<crate::types::UpdateProof>::new();
+    for proof in &history_proof.update_proofs {
+        let update_proof = crate::types::UpdateProof {
+            epoch: proof.epoch,
+            plaintext_value: proof.plaintext_value.to_vec(),
+            version: proof.version,
+            existence_vrf_proof: proof.existence_vrf_proof.clone(),
+            existence_at_ep: convert_membership_proof(&proof.existence_at_ep),
+            previous_version_vrf_proof: proof.previous_version_vrf_proof.clone(),
+            previous_version_stale_at_ep: proof
+                .previous_version_stale_at_ep
+                .clone()
+                .map(|val| convert_membership_proof(&val)),
+            commitment_proof: proof.commitment_proof.clone(),
+        };
+        res_update_proofs.push(update_proof);
+    }
+    crate::types::HistoryProof {
+        update_proofs: res_update_proofs,
+        next_few_vrf_proofs: history_proof.next_few_vrf_proofs.clone(),
+        non_existence_of_next_few: history_proof
+            .non_existence_of_next_few
+            .iter()
+            .map(|non_memb_proof| convert_non_membership_proof(non_memb_proof))
+            .collect(),
+        future_marker_vrf_proofs: history_proof.future_marker_vrf_proofs.clone(),
+        non_existence_of_future_markers: history_proof
+            .non_existence_of_future_markers
+            .iter()
+            .map(|non_exist_markers| convert_non_membership_proof(non_exist_markers))
+            .collect(),
+    }
+}

--- a/akd_client/src/converters.rs
+++ b/akd_client/src/converters.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Meta, Inc. and its affiliates.
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -130,6 +130,9 @@ pub enum VerificationErrorType {
     /// An error occurred verifying a VRF label
     Vrf,
 
+    /// Deserialization of the proof failed
+    ProofDeserializationFailed,
+
     /// An unknown verification error occurred
     Unknown,
 }
@@ -161,6 +164,7 @@ impl Display for VerificationError {
             VerificationErrorType::LookupProof => "Lookup Proof",
             VerificationErrorType::HistoryProof => "History Proof",
             VerificationErrorType::Vrf => "VRF",
+            VerificationErrorType::ProofDeserializationFailed => "Proof Deserialization",
             VerificationErrorType::Unknown => "Unknown",
         };
         write!(f, "Verification error ({}) - {}", code, self.error_message)

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -101,6 +101,8 @@ pub mod verify;
 pub(crate) mod ecvrf;
 pub(crate) mod hash;
 pub(crate) mod utils;
+#[cfg(any(test, feature = "converters"))]
+pub(crate) mod converters;
 
 /// The arity of the tree. Should EXACTLY match the ARITY within
 /// the AKD crate (i.e. akd::ARITY)

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -102,7 +102,7 @@ pub(crate) mod ecvrf;
 pub(crate) mod hash;
 pub(crate) mod utils;
 #[cfg(any(test, feature = "converters"))]
-pub(crate) mod converters;
+pub mod converters;
 
 /// The arity of the tree. Should EXACTLY match the ARITY within
 /// the AKD crate (i.e. akd::ARITY)

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -97,12 +97,12 @@ pub use types::*;
 // verify types are not re-exported, to not clutter the root path
 pub mod verify;
 
+#[cfg(any(test, feature = "converters"))]
+pub mod converters;
 #[cfg(feature = "vrf")]
 pub(crate) mod ecvrf;
 pub(crate) mod hash;
 pub(crate) mod utils;
-#[cfg(any(test, feature = "converters"))]
-pub mod converters;
 
 /// The arity of the tree. Should EXACTLY match the ARITY within
 /// the AKD crate (i.e. akd::ARITY)

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -258,10 +258,9 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
         to_digest::<Hash>(root_hash),
         target_label_bytes.clone(),
         &serialized_internal_lookup_proof,
-    )
-    .map_err(|i_err| AkdError::Storage(StorageError::Other(format!("Internal: {:?}", i_err))));
+    );
     assert!(
-        matches!(serialized_lean_result, Ok(())),
+        serialized_lean_result.is_ok(),
         "Lean serialized result was {:?}",
         serialized_lean_result
     );

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -23,10 +23,10 @@ use akd::storage::Storage;
 use akd::{AkdLabel, AkdValue};
 use winter_crypto::Hasher;
 
+use crate::converters;
 use crate::VerificationError;
 use crate::VerificationErrorType;
 use winter_math::fields::f128::BaseElement;
-use crate::converters;
 
 // Feature specific test imports
 #[cfg(feature = "blake3")]

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -53,8 +53,7 @@ pub const TOMBSTONE: &[u8] = &[];
 // ============================================
 
 /// Represents the label of a AKD node
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NodeLabel {
     /// val stores a binary string as a u64
     pub label_val: [u8; 32],
@@ -129,8 +128,7 @@ impl NodeLabel {
 }
 
 /// Represents a node (label + hash) in the AKD
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Node {
     /// The label of the node
     pub label: NodeLabel,
@@ -140,8 +138,7 @@ pub struct Node {
 
 /// Represents a specific level of the tree with the parental sibling and the direction
 /// of the parent for use in tree hash calculations
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LayerProof {
     /// The parent's label
     pub label: NodeLabel,
@@ -153,8 +150,7 @@ pub struct LayerProof {
 
 /// Merkle proof of membership of a [`NodeLabel`] with a particular hash
 /// value in the tree at a given epoch
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MembershipProof {
     /// The node label
     pub label: NodeLabel,
@@ -166,8 +162,7 @@ pub struct MembershipProof {
 
 /// Merkle Patricia proof of non-membership for a [`NodeLabel`] in the tree
 /// at a given epoch.
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NonMembershipProof {
     /// The label in question
     pub label: NodeLabel,
@@ -185,8 +180,7 @@ pub struct NonMembershipProof {
 /// * not too far ahead of the most recent marker version,
 /// * not stale when served.
 /// This proof is sent in response to a lookup query for a particular key.
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LookupProof {
     /// The epoch of this record
     pub epoch: u64,
@@ -217,8 +211,7 @@ pub struct LookupProof {
 /// * the version did not exist prior to this epoch,
 /// * the next few versions (up until the next marker), did not exist at this epoch,
 /// * the future marker versions did  not exist at this epoch.
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UpdateProof {
     /// Epoch of this update
     pub epoch: u64,
@@ -239,8 +232,7 @@ pub struct UpdateProof {
 }
 
 /// This proof is just an array of [`UpdateProof`]s.
-#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HistoryProof {
     /// The update proofs in the key history
     pub update_proofs: Vec<UpdateProof>,

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -250,7 +250,7 @@ pub fn serialized_key_history_verify(
     } else {
         Err(VerificationError::build(
             Some(VerificationErrorType::ProofDeserializationFailed),
-            Some("JSON lookup proof deserialization failed.".to_string()),
+            Some("JSON history proof deserialization failed.".to_string()),
         ))
     }
 }


### PR DESCRIPTION
Adding the API and tests for verifying serialized proofs. JSON is used as the medium to serialize with since it offers easier debugging and more interoperability (maybe).


Since an AKD user will need to convert the AKD types to AKD_CLIENT types first before serializing proofs, this PR also adds support for the `converters` feature.

Testing:

`cargo build/test` passes as well as `cargo build/test --features=converters`