### PR TITLE
Missing copyright headers

### DIFF
--- a/akd/src/proto/mod.rs
+++ b/akd/src/proto/mod.rs
@@ -1,3 +1,5 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 


### PR DESCRIPTION
`akd/src/proto/mod.rs` is missing the copyright header. Adding it