### PR TITLE
Include AZKS storage get error message in read only mode

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -68,7 +68,10 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
         if read_only && azks.is_err() {
             return Err(AkdError::Directory(DirectoryError::ReadOnlyDirectory(
-                "Cannot start directory in read-only mode when AZKS is missing".to_string(),
+                format!(
+                    "Cannot start directory in read-only mode when AZKS is missing, error: {:?}",
+                    azks.err().take()
+                ),
             )));
         } else if azks.is_err() {
             // generate a new azks if one is not found


### PR DESCRIPTION
Will help with debugging any errors thrown from the Storage layer.