### PR TITLE
Add API for serializing proofs

### DIFF
--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -81,7 +81,8 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
     // create the "lean" lookup proof version
     let internal_lookup_proof = converters::convert_lookup_proof::<Hash>(&lookup_proof);
     // Serialize the generated proof.
-    let serialized_internal_lookup_proof = crate::verify::serialize_lookup_proof(&internal_lookup_proof).unwrap();
+    let serialized_internal_lookup_proof =
+        crate::verify::serialize_lookup_proof(&internal_lookup_proof).unwrap();
     println!(
         "Serialized internal lookup proof: {:?}",
         serialized_internal_lookup_proof
@@ -232,7 +233,8 @@ async fn test_history_proof_multiple_epochs() -> Result<(), AkdError> {
         akd::directory::get_directory_root_hash_and_ep::<_, Hash, HardCodedAkdVRF>(&akd).await?;
 
     // Serialize the generated proof.
-    let serialized_internal_history_proof = crate::verify::serialize_history_proof(&internal_proof).unwrap();
+    let serialized_internal_history_proof =
+        crate::verify::serialize_history_proof(&internal_proof).unwrap();
     println!(
         "Serialized internal history proof: {:?}",
         serialized_internal_history_proof

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -81,7 +81,7 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
     // create the "lean" lookup proof version
     let internal_lookup_proof = converters::convert_lookup_proof::<Hash>(&lookup_proof);
     // Serialize the generated proof.
-    let serialized_internal_lookup_proof = serde_json::to_string(&internal_lookup_proof).unwrap();
+    let serialized_internal_lookup_proof = crate::verify::serialize_lookup_proof(&internal_lookup_proof).unwrap();
     println!(
         "Serialized internal lookup proof: {:?}",
         serialized_internal_lookup_proof
@@ -232,7 +232,7 @@ async fn test_history_proof_multiple_epochs() -> Result<(), AkdError> {
         akd::directory::get_directory_root_hash_and_ep::<_, Hash, HardCodedAkdVRF>(&akd).await?;
 
     // Serialize the generated proof.
-    let serialized_internal_history_proof = serde_json::to_string(&internal_proof).unwrap();
+    let serialized_internal_history_proof = crate::verify::serialize_history_proof(&internal_proof).unwrap();
     println!(
         "Serialized internal history proof: {:?}",
         serialized_internal_history_proof

--- a/akd_client/src/verify.rs
+++ b/akd_client/src/verify.rs
@@ -374,6 +374,16 @@ pub fn key_history_verify(
     Ok(tombstones)
 }
 
+/// Serializes a LookupProof
+pub fn serialize_lookup_proof(proof: &LookupProof) -> Result<String, serde_json::Error> {
+    serde_json::to_string(proof)
+}
+
+/// Serializes a HistoryProof
+pub fn serialize_history_proof(proof: &HistoryProof) -> Result<String, serde_json::Error> {
+    serde_json::to_string(proof)
+}
+
 /// Verifies a single update proof
 fn verify_single_update_proof(
     root_hash: Digest,


### PR DESCRIPTION
Provide a serialization API from the `akd_client` so that its users do not need to know the underlying serialization used.