### PR TITLE
Fixing the AWS pipeline and reorganizing other workflows

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -4,11 +4,13 @@ on:
     branches:
       - main
     paths:
-      - 'akd_local_auditor/'
+      - 'akd_local_auditor/**'
   pull_request:
+    branches:
+      - main
     types: [opened, repoened, synchronize]
     paths:
-      - 'akd_local_auditor/'
+      - 'akd_local_auditor/**'
 
 jobs:
   test-auditor:

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -13,7 +13,7 @@ on:
       - 'akd_local_auditor/**'
 
 jobs:
-  test-auditor:
+  test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest
     strategy:
@@ -21,6 +21,7 @@ jobs:
       matrix:
         toolchain: [stable]
         os: [ubuntu]
+
     steps:
       - uses: actions/checkout@main
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Set up protoc
         uses: arduino/setup-protoc@v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -30,6 +30,9 @@ jobs:
           toolchain: ${{matrix.toolchain}}
           override: true
 
+      - name: Set up protoc
+        uses: arduino/setup-protoc@v1.1.2
+
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Set up dynamodb-local from AWS
         run: |
           docker run --detach \
+            --name "dynamodb_test_env" \
             -p 9002:9002 \
             amazon/dynamodb-local -jar DynamoDBLocal.jar -inMemory -port 9002
 
@@ -51,6 +52,7 @@ jobs:
       - name: Set up minio
         run: |
           docker run --detach \
+            --name "minio_test_env" \
             -p 9000:9000 \
             -p 9001:9001 \
             -v "$(mktemp -d)":/data \
@@ -70,3 +72,11 @@ jobs:
         with:
           command: test
           args: --manifest-path Cargo.toml -p akd_local_auditor integration_test_ -- --ignored
+
+      -name: Teardown dynamodb container
+        run: |
+          docker stop dynamodb_test_env
+
+      -name: Teardown minio container
+        run: |
+          docker stop minio_test_env

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - 'akd_local_auditor/**'
 
@@ -74,10 +74,10 @@ jobs:
           command: test
           args: --manifest-path Cargo.toml -p akd_local_auditor integration_test_ -- --ignored
 
-      -name: Teardown dynamodb container
+      - name: Teardown dynamodb container
         run: |
           docker stop dynamodb_test_env
 
-      -name: Teardown minio container
+      - name: Teardown minio container
         run: |
           docker stop minio_test_env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,57 +15,63 @@ jobs:
       matrix:
         toolchain: [stable]
         os: [ubuntu]
+
     steps:
       - uses: actions/checkout@main
+
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{matrix.toolchain}}
           override: true
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml up -d
-      - name: Check running containers
-        run: docker ps -a
-      - name: Verify MySQL db connection
-        run: |
-          while ! docker exec akd-test-db mysql --user=root --password=example -e "SHOW DATABASES" >/dev/null 2>&1; do
-            sleep 1
-          done
-          echo "MySQL container is up"
-      - name: Check container akd-test-db logs
-        run: docker logs akd-test-db
+
       - name: Set up protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Test general profile
+
+      - name: Test the base library, with default features
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Cleanup docker container
-        run: docker-compose -f docker-compose.yml down -v
-      - name: Copy integration test logs for review
-        run: cat integration_tests/integration_test.log
-      - name: Test the lean client for wasm and SHA3-256 hashing
+          args: --package akd
+
+      - name: Test the local auditor, with default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package akd_local_auditor
+
+      - name: Test the base client library, with default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package akd_client
+
+      - name: Test the client for wasm and SHA3-256 hashing
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --package akd_client --no-default-features --features wasm,sha3_256,vrf
+
       - name: Test AKD with no-vrf support
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --package akd --no-default-features --features public-tests
+
       - name: Test AKD with protobuf serialization of the audit proofs
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --package akd --features public_auditing
+
       - name: Test the lean client for wasm and BLAKE3 hashing
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --package akd_client --no-default-features --features wasm,blake3,vrf
+
       - name: Test the lean client for VRF verification
         uses: actions-rs/cargo@v1
         with:
@@ -84,11 +90,13 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
+
       - name: Set up protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Clippy
+
+      - name: Run Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -107,7 +115,7 @@ jobs:
           components: rustfmt
           override: true
 
-      - name: rustfmt
+      - name: Run rustfmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: docker logs akd-test-db
       - name: Set up protoc
         uses: arduino/setup-protoc@v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test general profile
         uses: actions-rs/cargo@v1
         with:
@@ -84,6 +86,8 @@ jobs:
           override: true
       - name: Set up protoc
         uses: arduino/setup-protoc@v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -1,0 +1,69 @@
+name: MySQL and Integration Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  run-tests:
+    name: Run tests (Rust ${{matrix.toolchain}} on ${{matrix.os}})
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+
+      - name: Set up protoc
+        uses: arduino/setup-protoc@v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Build the docker-compose stack
+        run: docker-compose -f docker-compose.yml up -d
+
+      - name: Check running containers
+        run: docker ps -a
+
+      - name: Verify MySQL db connection
+        run: |
+          while ! docker exec akd-test-db mysql --user=root --password=example -e "SHOW DATABASES" >/dev/null 2>&1; do
+            sleep 1
+          done
+          echo "MySQL container is up"
+
+      - name: Check container akd-test-db logs
+        run: docker logs akd-test-db
+
+      - name: Run MySQL tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path Cargo.toml -p akd_mysql
+
+      - name: Run integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path Cargo.toml -p integration_tests
+
+      - name: Cleanup docker container
+        run: docker-compose -f docker-compose.yml down -v
+
+      - name: Copy integration test logs for review
+        run: cat integration_tests/integration_test.log

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path Cargo.toml -p integration_tests
+          args: --manifest-path Cargo.toml -p akd_integration_tests
 
       - name: Cleanup docker container
         run: docker-compose -f docker-compose.yml down -v

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   run-tests:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,31 +15,41 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - name: Setup protoc
+
+    - name: Set up protoc
       uses: arduino/setup-protoc@v1.1.2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: actions/checkout@main
+
     - name: Login to crates.io
       run: cargo login $CRATES_IO_TOKEN
       env:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }}
+
     - name: Dry run publish AKD
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd
+
     - name: Publish crate akd
       run: cargo publish --manifest-path Cargo.toml -p akd
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+
     - name: Dry run publish AKD_CLIENT
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_client
+
     - name: Publish crate akd_client
       run: cargo publish --manifest-path Cargo.toml -p akd_client
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+
     - name: Run the script that waits for AKD to be published
       run: bash ./.github/workflows/wait-for-akd-publish.sh
+
     - name: Dry run publish AKD_MYSQL
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_mysql
+
     - name: Publish crate akd_mysql
       run: cargo publish --manifest-path Cargo.toml -p akd_mysql
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
         rust-version: ${{ matrix.rust }}
     - name: Setup protoc
       uses: arduino/setup-protoc@v1.1.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@main
     - name: Login to crates.io
       run: cargo login $CRATES_IO_TOKEN

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -7,6 +7,7 @@
 
 //! This module implements some common test functionality (i.e. proof generation and whatnot)
 //! for use in test infra
+
 use crate::{Digest, Hasher};
 use akd::directory::Directory;
 use akd::ecvrf::HardCodedAkdVRF;

--- a/akd_local_auditor/src/console_log.rs
+++ b/akd_local_auditor/src/console_log.rs
@@ -5,6 +5,9 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+//! This module provides a basic logger implementation to the console with
+//! some additional information (file, line number, thread, etc)
+
 use colored::*;
 use log::Level;
 use log::Metadata;

--- a/akd_local_auditor/src/main.rs
+++ b/akd_local_auditor/src/main.rs
@@ -5,11 +5,39 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-//! A tool to verify audit proofs from a public S3 bucket storage of all proofs
-
-mod console_log;
+//! A tool to verify audit proofs from a public (ideally immutable) storage
+//! medium. This tool is a read-evaluate-print-loop (REPL) interface, where
+//! a user can retrieve the information necessary about all operations by typing
+//! `help` into the REPL prompt.
+//!
+//! # Summary
+//!
+//! To startup the client, you can choose 1 of the supported storage mediums.
+//! Presently the supported storage mediums are
+//!
+//! 1. AWS DynamoDB index backed by S3 storage
+//! 2. AWS S3 only, without an index
+//!
+//! The applicate is started with all necessary flags to connect to the storage medium
+//! of choice, and then the REPL will start allowing the user to interact as an auditor.
+//!
+//! # Examples
+//!
+//! Assuming the audit proofs are stored in an S3 bucket in the AWS region `us-east-2` named
+//! "myproofs". To start the application, you can run
+//!
+//! ```bash
+//! cargo run -p akd_local_auditor -- s3 --bucket myproofs --region us-east-2
+//! ```
+//!
+//! ## Connection customization
+//!
+//! If you need to customize the connection to AWS, both data-layers support providing custom
+//! endpoints as well as a access key and secret key for authentication.
+//!
 
 pub mod auditor;
+mod console_log;
 pub mod storage;
 
 #[cfg(test)]

--- a/akd_local_auditor/src/main.rs
+++ b/akd_local_auditor/src/main.rs
@@ -34,7 +34,6 @@
 //!
 //! If you need to customize the connection to AWS, both data-layers support providing custom
 //! endpoints as well as a access key and secret key for authentication.
-//!
 
 pub mod auditor;
 mod console_log;

--- a/akd_local_auditor/src/storage/mod.rs
+++ b/akd_local_auditor/src/storage/mod.rs
@@ -6,7 +6,9 @@
 // of this source tree.
 
 //! This module holds the generic storage interaction layer trait along with the underlying implemented
-//! storage interactions
+//! storage interactions. We need to implement the trait for a [Box] of the same trait in order to support
+//! passing the boxed implementations around. This is required for the async nature of the command and Rust's
+//! type inference engine
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -23,7 +25,7 @@ pub mod s3;
 pub enum StorageSubcommand {
     /// Amazon S3 compatible storage
     S3(s3::S3ClapSettings),
-    // /// DynamoDB
+    /// DynamoDB
     DynamoDb(dynamodb::DynamoDbClapSettings),
 }
 

--- a/akd_local_auditor/test.txt
+++ b/akd_local_auditor/test.txt
@@ -1,1 +1,0 @@
-test test test

--- a/akd_local_auditor/test.txt
+++ b/akd_local_auditor/test.txt
@@ -1,0 +1,1 @@
+test test test


### PR DESCRIPTION
This PR fixes errors in the triggers on the of the AWS test suite. Additionally it reworks the CI pipeline testing layouts so that tests requiring the MySQL container to be running are in a separate CI to manage what's regular unit test breaks vs more involved integration-test style breaks.