### PR TITLE
Verify that there is only 1 version of an object in S3 storage

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'akd_local_auditor/'
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - 'akd_local_auditor/'
 

--- a/akd_local_auditor/src/storage/dynamodb/test.rs
+++ b/akd_local_auditor/src/storage/dynamodb/test.rs
@@ -80,13 +80,13 @@ async fn integration_test_dynamo_listing() {
     // Populate the test storage
     populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 10, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 
     // List the epochs found in the storage layer
     let mut epoch_summaries: Vec<EpochSummary> = storage
         .list_proofs(ProofIndexCacheOption::NoCache)
         .await
-        .unwrap();
+        .expect("Failed to list proofs");
     epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
 
     // There should be 10 proofs in the storage layer
@@ -105,7 +105,7 @@ async fn integration_test_dynamo_listing() {
     // if the test is successful, try a cleanup of the storage now
     maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table)
         .await
-        .unwrap();
+        .expect("Failed to flush storage");
 }
 
 #[tokio::test]
@@ -130,7 +130,7 @@ async fn integration_test_dynamo_audit_verification() {
     // Populate the test storage
     populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 3, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 
     // List the epochs found in the storage layer
     let mut epoch_summaries: Vec<EpochSummary> = storage
@@ -165,7 +165,7 @@ async fn integration_test_dynamo_audit_verification() {
     // if the test is successful, try a cleanup of the storage now
     maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table)
         .await
-        .unwrap();
+        .expect("Failed to flush storage");
 }
 
 #[tokio::test]
@@ -193,7 +193,7 @@ async fn populate_test_dynamo() {
     // Populate the test storage
     populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 50, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 }
 
 fn build_dynamo_table_properties(

--- a/akd_local_auditor/src/storage/dynamodb/test.rs
+++ b/akd_local_auditor/src/storage/dynamodb/test.rs
@@ -31,7 +31,7 @@ const TEST_DYNAMO_ENDPOINT: &str = "http://127.0.0.1:9002";
 const TEST_S3_ENDPOINT: &str = "http://127.0.0.1:9000";
 
 #[test]
-fn test_dynamo_table_naming() -> Result<()> {
+fn test_dynamo_table_naming() {
     let too_short = "a";
     assert!(matches!(super::validate_table_name(too_short), Err(_)));
 
@@ -56,13 +56,11 @@ fn test_dynamo_table_naming() -> Result<()> {
         super::validate_table_name("some_table_name"),
         Ok(_)
     ));
-
-    Ok(())
 }
 
 #[tokio::test]
 #[ignore]
-async fn integration_test_dynamo_listing() -> Result<()> {
+async fn integration_test_dynamo_listing() {
     // make sure we have a valid bucket name, that's "somewhat" unique
     let table = crate::common_test::alphanumeric_function_name!();
     log::debug!("Test bucket and table name is {}", table);
@@ -80,11 +78,15 @@ async fn integration_test_dynamo_listing() -> Result<()> {
     let s3_shared_config = s3_storage.get_shared_test_config().await;
 
     // Populate the test storage
-    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 10, false).await?;
+    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 10, false)
+        .await
+        .unwrap();
 
     // List the epochs found in the storage layer
-    let mut epoch_summaries: Vec<EpochSummary> =
-        storage.list_proofs(ProofIndexCacheOption::NoCache).await?;
+    let mut epoch_summaries: Vec<EpochSummary> = storage
+        .list_proofs(ProofIndexCacheOption::NoCache)
+        .await
+        .unwrap();
     epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
 
     // There should be 10 proofs in the storage layer
@@ -101,14 +103,14 @@ async fn integration_test_dynamo_listing() -> Result<()> {
     }
 
     // if the test is successful, try a cleanup of the storage now
-    maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table).await?;
-
-    Ok(())
+    maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 #[ignore]
-async fn integration_test_dynamo_audit_verification() -> Result<()> {
+async fn integration_test_dynamo_audit_verification() {
     // make sure we have a valid bucket name, that's "somewhat" unique
     let table = crate::common_test::alphanumeric_function_name!();
     log::debug!("Test bucket and table name is {}", table);
@@ -126,11 +128,15 @@ async fn integration_test_dynamo_audit_verification() -> Result<()> {
     let s3_shared_config = s3_storage.get_shared_test_config().await;
 
     // Populate the test storage
-    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 3, false).await?;
+    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 3, false)
+        .await
+        .unwrap();
 
     // List the epochs found in the storage layer
-    let mut epoch_summaries: Vec<EpochSummary> =
-        storage.list_proofs(ProofIndexCacheOption::NoCache).await?;
+    let mut epoch_summaries: Vec<EpochSummary> = storage
+        .list_proofs(ProofIndexCacheOption::NoCache)
+        .await
+        .unwrap();
     epoch_summaries.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
 
     // There should be 3 proofs in the storage layer
@@ -142,25 +148,29 @@ async fn integration_test_dynamo_audit_verification() -> Result<()> {
 
     // verify all fo the audit proofs
     for epoch in epoch_summaries.iter() {
-        let proof_blob = storage.get_proof(epoch).await?;
+        let proof_blob = storage.get_proof(epoch).await.unwrap();
         log::info!(
             "Verification epoch {} -> {}",
             epoch.name.epoch,
             epoch.name.epoch + 1
         );
-        crate::auditor::audit_epoch::<Hasher>(proof_blob.clone(), false).await?;
-        crate::auditor::audit_epoch::<Hasher>(proof_blob, true).await?;
+        crate::auditor::audit_epoch::<Hasher>(proof_blob.clone(), false)
+            .await
+            .unwrap();
+        crate::auditor::audit_epoch::<Hasher>(proof_blob, true)
+            .await
+            .unwrap();
     }
 
     // if the test is successful, try a cleanup of the storage now
-    maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table).await?;
-
-    Ok(())
+    maybe_flush_storage(&dynamo_shared_config, &s3_shared_config, &table)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 #[ignore]
-async fn populate_test_dynamo() -> Result<()> {
+async fn populate_test_dynamo() {
     // Populates the test bucket for use with the command-line REPL via the command
     // cargo run -p akd_local_auditor -- dynamo-db --table populatetestdynamo --bucket populatetestdynamo --region us-east-2 --s3-endpoint http://127.0.0.1:9000 --dynamo-endpoint http://127.0.0.1:9002 --access-key test --secret-key someLongAccessKey
 
@@ -181,9 +191,9 @@ async fn populate_test_dynamo() -> Result<()> {
     let s3_shared_config = s3_storage.get_shared_test_config().await;
 
     // Populate the test storage
-    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 50, false).await?;
-
-    Ok(())
+    populate_test_storage(&dynamo_shared_config, &s3_shared_config, &table, 50, false)
+        .await
+        .unwrap();
 }
 
 fn build_dynamo_table_properties(

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -205,7 +205,7 @@ impl S3AuditStorage {
                                 version
                                     .e_tag()
                                     .map(|tag| tag.to_string())
-                                    .unwrap_or("".to_string()),
+                                    .unwrap_or_else(|| "".to_string()),
                             );
 
                             let this_time: std::time::SystemTime = (*mod_time).try_into()?;
@@ -226,9 +226,9 @@ impl S3AuditStorage {
         } else if version_count > 1 {
             // check all the versions for their associated etags, and make sure they're all the same
             let first = &etags[0];
-            for i in 1..etags.len() {
-                if first.cmp(&etags[i]) != std::cmp::Ordering::Equal {
-                    return Err(anyhow::anyhow!("There were duplicate objects with the same key that have different etags which indicates different values. This epoch cannot be trusted ({} != {})", first, etags[i]));
+            for etag in etags.iter().skip(1) {
+                if first.cmp(etag) != std::cmp::Ordering::Equal {
+                    return Err(anyhow::anyhow!("There were duplicate objects with the same key that have different etags which indicates different values. This epoch cannot be trusted ({} != {})", first, etag));
                 }
             }
         }

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -181,10 +181,11 @@ impl S3AuditStorage {
     async fn get_object(&self, key: &str) -> Result<s3::client::fluent_builders::GetObject> {
         // We need to retrieve the minimum version of an object, to guarantee we see the ORIGINAL
         // status of the blob. Future versions are not supported
+
         let attributes = s3::Client::from_conf(self.get_config().await)
             .list_object_versions()
             .bucket(self.bucket.clone())
-            .key_marker(key.to_string())
+            .prefix(key.to_string())
             .max_keys(1)
             .send()
             .await?;

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -178,14 +178,67 @@ impl S3AuditStorage {
             .into_paginator()
     }
 
-    async fn get_object(&self, key: &str) -> s3::client::fluent_builders::GetObject {
-        let config = self.get_config().await;
+    async fn get_object(&self, key: &str) -> Result<s3::client::fluent_builders::GetObject> {
+        // We need to retrieve the minimum version of an object, to guarantee we see the ORIGINAL
+        // status of the blob. Future versions are not supported
+        let attributes = s3::Client::from_conf(self.get_config().await)
+            .list_object_versions()
+            .bucket(self.bucket.clone())
+            .key_marker(key.to_string())
+            .max_keys(1)
+            .send()
+            .await?;
 
-        s3::Client::from_conf(config)
+        let mut version_count = 0usize;
+        let mut min_time = std::time::SystemTime::now();
+        let mut min_version = String::new();
+        let mut etags = vec![];
+        if let Some(versions) = attributes.versions() {
+            for version in versions {
+                if let Some(potential_key) = version.key() {
+                    if potential_key == key {
+                        if let (Some(mod_time), Some(version_id)) =
+                            (version.last_modified(), version.version_id())
+                        {
+                            version_count = version_count + 1;
+                            etags.push(
+                                version
+                                    .e_tag()
+                                    .map(|tag| tag.to_string())
+                                    .unwrap_or("".to_string()),
+                            );
+
+                            let this_time: std::time::SystemTime = mod_time.clone().try_into()?;
+                            if this_time < min_time {
+                                min_version = version_id.to_string();
+                                min_time = this_time;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if version_count == 0 {
+            return Err(anyhow::anyhow!(
+                "Object not found with any version information"
+            ));
+        } else if version_count > 1 {
+            // TODO: check all the versions for their associated etags, and make sure they're all the same
+            let first = &etags[0];
+            for i in 1..etags.len() {
+                if first.cmp(&etags[i]) != std::cmp::Ordering::Equal {
+                    return Err(anyhow::anyhow!("There were duplicate objects with the same key that have different etags which indicates different values. This epoch cannot be trusted ({} != {})", first, etags[i]));
+                }
+            }
+        }
+
+        Ok(s3::Client::from_conf(self.get_config().await)
             .get_object()
             .bucket(self.bucket.clone())
+            .version_id(min_version)
             .key(key.to_string())
-            .checksum_mode(s3::model::ChecksumMode::Enabled)
+            .checksum_mode(s3::model::ChecksumMode::Enabled))
     }
 
     fn process_streamed_response(
@@ -256,7 +309,7 @@ impl super::AuditProofStorage for S3AuditStorage {
     }
 
     async fn get_proof(&self, epoch: &super::EpochSummary) -> Result<akd::proto::AuditBlob> {
-        let client = self.get_object(&epoch.key).await;
+        let client = self.get_object(&epoch.key).await?;
         match client.send().await {
             Err(some_err) => {
                 error!("Error executing get_object in S3 {}", some_err);

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -200,7 +200,7 @@ impl S3AuditStorage {
                         if let (Some(mod_time), Some(version_id)) =
                             (version.last_modified(), version.version_id())
                         {
-                            version_count = version_count + 1;
+                            version_count += 1;
                             etags.push(
                                 version
                                     .e_tag()
@@ -208,7 +208,7 @@ impl S3AuditStorage {
                                     .unwrap_or("".to_string()),
                             );
 
-                            let this_time: std::time::SystemTime = mod_time.clone().try_into()?;
+                            let this_time: std::time::SystemTime = (*mod_time).try_into()?;
                             if this_time < min_time {
                                 min_version = version_id.to_string();
                                 min_time = this_time;
@@ -224,7 +224,7 @@ impl S3AuditStorage {
                 "Object not found with any version information"
             ));
         } else if version_count > 1 {
-            // TODO: check all the versions for their associated etags, and make sure they're all the same
+            // check all the versions for their associated etags, and make sure they're all the same
             let first = &etags[0];
             for i in 1..etags.len() {
                 if first.cmp(&etags[i]) != std::cmp::Ordering::Equal {

--- a/akd_local_auditor/src/storage/s3/test.rs
+++ b/akd_local_auditor/src/storage/s3/test.rs
@@ -211,7 +211,7 @@ async fn integration_test_s3_bucket_listing() {
     // Populate the test storage
     populate_test_storage(&shared_config, &bucket, 10, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 
     // List the epochs found in the storage layer
     let mut epoch_summaries: Vec<EpochSummary> = storage
@@ -234,7 +234,9 @@ async fn integration_test_s3_bucket_listing() {
     }
 
     // if the test is successful, try a cleanup of the storage now
-    maybe_flush_storage(&shared_config, &bucket).await.unwrap();
+    maybe_flush_storage(&shared_config, &bucket)
+        .await
+        .expect("Failed to flush storage");
 }
 
 #[tokio::test]
@@ -252,7 +254,7 @@ async fn integration_test_s3_audit_verification() {
     // Populate the test storage
     populate_test_storage(&shared_config, &bucket, 3, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 
     // List the epochs found in the storage layer
     let mut epoch_summaries: Vec<EpochSummary> = storage
@@ -285,7 +287,9 @@ async fn integration_test_s3_audit_verification() {
     }
 
     // if the test is successful, try a cleanup of the storage now
-    maybe_flush_storage(&shared_config, &bucket).await.unwrap();
+    maybe_flush_storage(&shared_config, &bucket)
+        .await
+        .expect("Failed to flush storage");
 }
 
 // ============================ IMPORTANT ============================ //
@@ -346,7 +350,9 @@ async fn expensive_audit_verification() {
     );
 
     // if the test is successful, try a cleanup of the storage now
-    maybe_flush_storage(&shared_config, &bucket).await.unwrap();
+    maybe_flush_storage(&shared_config, &bucket)
+        .await
+        .expect("Failed to flush storage");
 }
 
 #[tokio::test]
@@ -367,7 +373,7 @@ async fn populate_test_bucket() {
     // Populate the test storage
     populate_test_storage(&shared_config, &bucket, 50, false)
         .await
-        .unwrap();
+        .expect("Failed to populate test storage");
 }
 
 #[test]


### PR DESCRIPTION
S3's object lock does not prevent multiple versions of an object from being present (with the same key). This means, that naively once could enumerate the proofs and there be an updated proof without noticing, leading to a vulnerability. Since the previous + current hashes are part of the key naming, the entire proof would *technically* need to contain the same content, or there would be 2 separate keys with the same epoch, but this PR adds an explicit check of the object's version information to assert that if there are > 1 version for an object, they're all the same hash (`etag`), and if not error out and not validate the proof.

This should not be necessary, but in the event a publisher publishes the same proof multiple times (due to some technical glitch for example), that should not prohibit proof validation, and therefore we still want to be able to utilize this tool. However if multiple versions of a key are present, then we should return a legitimate error!