### PR TITLE
Adding a BFS preload for audit proof generation.

### DIFF
--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -47,7 +47,7 @@ type Directory = akd::Directory<InMemoryDb, HardCodedAkdVRF>;
 
 /// Makes a JSON String unparsable by replacing "{"s with gibberish.
 fn make_unparsable_json(serialized_json: &str) -> String {
-    serialized_json.replace("{", "t3845")
+    serialized_json.replace('{', "t3845")
 }
 
 // ===================================
@@ -130,7 +130,7 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
     let serialized_lean_result = crate::verify::serialized_lookup_verify(
         &vrf_pk.to_bytes(),
         converters::to_digest::<Hash>(root_hash),
-        target_label_bytes.clone(),
+        target_label_bytes,
         &serialized_internal_lookup_proof,
     );
 


### PR DESCRIPTION
Audit proofs don't currently due batch-retrieval preloading, meaning they walk the binary-tree in a depth-first manner. This is wildly inefficient at-scale, and a BFS is far more efficient.

This adds a BFS preload step to audit proof generation, such that we shouldn't need to retrieve any other nodes along the path to generate the proof itself as we greedily generate it.

This is critically important if we have a cold cache (i.e. no cache at all) and therefore need to go all the way to the data layer.