### PR TITLE
Disable build.rs in akd/ as well

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -8,7 +8,12 @@ edition = "2018"
 keywords = ["key-transparency", "akd"]
 repository = "https://github.com/novifinancial/akd"
 readme = "../README.md"
-build = "src/build.rs"
+## Uncomment for automated building of the protobuf Rust sources. Necessary if the .proto specs change
+# build = "src/build.rs"
+#
+# [build-dependencies]
+# protoc = "=2.8.1"
+# protoc-rust = "=2.8.1"
 
 [features]
 bench = ["public-tests"]
@@ -53,10 +58,6 @@ once_cell = { version = "1" }
 ctor = "0.1"
 
 akd = { path =".", features = ["vrf", "public-tests"] }
-
-[build-dependencies]
-protoc = "=2.8.1"
-protoc-rust = "=2.8.1"
 
 [[bench]]
 name = "azks"


### PR DESCRIPTION
Similar to #251 but also covers the akd/ Cargo.toml in addition to akd_client/.

Right now, running `cargo test` in the root directory produces an error because of this.