### PR TITLE
AKD_CLIENT cleanup and leanout

### DIFF
--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -23,8 +23,8 @@ akd = { path = "../akd", features = ["vrf", "public-tests"], optional = true }
 blake3 = { version = "1.3.1", optional = true, default-features = false }
 curve25519-dalek = { version = "3", optional = true, default-features = false }
 ed25519-dalek = { version = "1", optional = true, default-features = false }
-protobuf_crate = { package = "protobuf", version = "=2.8.1", optional = true }
-serde_crate = { package = "serde", version = "1.0", optional = true, features = ["derive"], default-features = false }
+protobuf = { version = "=2.8.1", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"], default-features = false }
 serde_json = { version = "1", optional = true }
 sha2 = { version = "0.10.1", optional = true, default-features = false }
 sha3 = { version = "0.10.0", optional = true, default-features = false }
@@ -51,9 +51,7 @@ sha3_512 = ["sha3"]
 # Enable web assembly compilation of the AKD client crate
 wasm = ["wasm-bindgen", "serde"]
 # Support serde-based serialization
-serde = ["serde_crate", "serde_json", "ed25519-dalek/serde"]
-# Support protobuf based serialization
-protobuf = ["protobuf_crate"]
+serde_serialization = ["serde", "serde_json", "ed25519-dalek/serde"]
 # Verify with Verifiable random functions (VRFs)
 vrf = ["curve25519-dalek", "ed25519-dalek"]
 

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -49,7 +49,7 @@ sha256 = ["sha2"]
 sha3_256 = ["sha3"]
 sha3_512 = ["sha3"]
 # Enable web assembly compilation of the AKD client crate
-wasm = ["wasm-bindgen", "serde"]
+wasm = ["wasm-bindgen", "serde_serialization"]
 # Support serde-based serialization
 serde_serialization = ["serde", "serde_json", "ed25519-dalek/serde"]
 # Verify with Verifiable random functions (VRFs)

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -19,47 +19,46 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-# Currently only used in the "converters" feature
 akd = { path = "../akd", features = ["vrf", "public-tests"], optional = true }
-winter-crypto = { version = "0.2", optional = true }
-winter-utils = { version = "0.2", optional = true }
-
+blake3 = { version = "1.3.1", optional = true, default-features = false }
+curve25519-dalek = { version = "3", optional = true, default-features = false }
+ed25519-dalek = { version = "1", optional = true, default-features = false }
+protobuf_crate = { package = "protobuf", version = "=2.8.1", optional = true }
+serde_crate = { package = "serde", version = "1.0", optional = true, features = ["derive"], default-features = false }
+serde_json = { version = "1", optional = true }
 sha2 = { version = "0.10.1", optional = true, default-features = false }
 sha3 = { version = "0.10.0", optional = true, default-features = false }
-blake3 = { version = "1.3.1", optional = true, default-features = false }
-
 wasm-bindgen = { version = "0.2.79", optional = true, features = ["serde-serialize"] }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1", optional = true}
-protobuf = { version = "=2.8.1", optional = true }
-
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 #
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 wee_alloc = { version = "0.4.5", optional = true }
-
-curve25519-dalek = { version = "3", optional = true }
-ed25519-dalek = { version = "1", features = ["serde"], optional = true}
+winter-crypto = { version = "0.2", optional = true }
+winter-utils = { version = "0.2", optional = true }
 
 [features]
+# Disable all STD for the crate
 nostd = []
 # Enable converters API from akd to akd_client types
 converters = ["akd", "winter-crypto", "winter-utils"]
-# Optional hash functions
+# Supported hash functions
 sha512 = ["sha2"]
 sha256 = ["sha2"]
 sha3_256 = ["sha3"]
 sha3_512 = ["sha3"]
-default = ["blake3", "vrf"]
-
 # Enable web assembly compilation of the AKD client crate
-wasm = ["wasm-bindgen", "serde_serialization"]
-serde_serialization = ["serde", "serde_json"]
-
+wasm = ["wasm-bindgen", "serde"]
+# Support serde-based serialization
+serde = ["serde_crate", "serde_json", "ed25519-dalek/serde"]
+# Support protobuf based serialization
+protobuf = ["protobuf_crate"]
 # Verify with Verifiable random functions (VRFs)
 vrf = ["curve25519-dalek", "ed25519-dalek"]
+
+# Default feature mix (blake3 + VRFs enabled)
+default = ["blake3", "vrf"]
 
 [dev-dependencies]
 akd = { path = "../akd", features = ["vrf", "public-tests"] }


### PR DESCRIPTION
This PR 

1. Re-organizes the dependencies in the `Cargo.toml` of `akd_client` to be easier to maintain in the future
2. Removes the `serde` feature from `ed25519-dalek` and makes it only enabled if `serde` serialization is requested of this crate.
3. Does some crate re-aliasing to make features cleaner