### PR TITLE
Documentation pass over high-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.4"
+akd = "0.7"
 ```
 
 ### Minimum Supported Rust Version
@@ -33,7 +33,7 @@ Rust **1.51** or higher.
 Contributors
 ------------
 
-The authors of this code are
+The original authors of this code are
 Jasleen Malvai ([@jasleen1](https://github.com/jasleen1)),
 Kevin Lewi ([@kevinlewi](https://github.com/kevinlewi)), and
 Sean Lawlor ([@slawlor](https://github.com/slawlor)).

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -56,6 +56,7 @@ proptest-derive = "0.3"
 colored = { version = "2" }
 once_cell = { version = "1" }
 ctor = "0.1"
+tokio-test = "0.4"
 
 akd = { path =".", features = ["vrf", "public-tests"] }
 

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -35,7 +35,8 @@
 //!
 //! which dictate which hashing function is used by the verification components. Blake3 256-bit hashing is the default
 //! implementation and utilizes the [`blake3`] crate. Features sha256 and sha512 both utilize SHA2 cryptographic functions
-//! from the [`sha2`] crate. Lastly sha3_256 and sha3_512 features utilize the [`sha3`] crate for their hashing implementations.
+//! from the [`sha2`](https://crates.io/crates/sha2) crate. Lastly sha3_256 and sha3_512 features utilize the
+//! [`sha3`](https://crates.io/crates/sha3) crate for their hashing implementations.
 //! To utilize a hash implementation other than blake3, you should compile with
 //!
 //! ```bash

--- a/akd_local_auditor/src/storage/dynamodb/mod.rs
+++ b/akd_local_auditor/src/storage/dynamodb/mod.rs
@@ -76,19 +76,19 @@ pub struct DynamoDbClapSettings {
     )]
     bucket: String,
 
-    /// [OPTIONAL] AWS DynamoDb custom endpoint
+    /// (OPTIONAL) AWS DynamoDb custom endpoint
     #[clap(long, value_parser = super::s3::validate_uri)]
     dynamo_endpoint: Option<String>,
 
-    /// [OPTIONAL] AWS S3 bucket custom endpoint
+    /// (OPTIONAL) AWS S3 bucket custom endpoint
     #[clap(long, value_parser = super::s3::validate_uri)]
     s3_endpoint: Option<String>,
 
-    /// [OPTIONAL] AWS Access key for the session
+    /// (OPTIONAL) AWS Access key for the session
     #[clap(long)]
     access_key: Option<String>,
 
-    /// [OPTIONAL] AWS secret key for the session
+    /// (OPTIONAL) AWS secret key for the session
     #[clap(long)]
     secret_key: Option<String>,
 }
@@ -101,13 +101,13 @@ pub struct DynamoDbAuditStorage {
     region: String,
     /// The S3 bucket which contains the underlying proof material
     bucket: String,
-    /// [OPTIONAL] AWS DynamoDb custom endpoint
+    /// (OPTIONAL) AWS DynamoDb custom endpoint
     dynamo_endpoint: Option<String>,
-    /// [OPTIONAL] AWS S3 bucket custom endpoint
+    /// (OPTIONAL) AWS S3 bucket custom endpoint
     s3_endpoint: Option<String>,
-    /// [OPTIONAL] AWS Access key for the session
+    /// (OPTIONAL) AWS Access key for the session
     access_key: Option<String>,
-    /// [OPTIONAL] AWS secret key for the session
+    /// (OPTIONAL) AWS secret key for the session
     secret_key: Option<String>,
     /// The configuration, cached for subsequent accesses
     config: Arc<RwLock<Option<aws_config::SdkConfig>>>,

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -78,15 +78,15 @@ pub struct S3ClapSettings {
     #[clap(long)]
     region: String,
 
-    /// [OPTIONAL] An custom URI for the AWS endpoint
+    /// (OPTIONAL) An custom URI for the AWS endpoint
     #[clap(long, value_parser = validate_uri)]
     endpoint: Option<String>,
 
-    /// [OPTIONAL] AWS Access key for the session
+    /// (OPTIONAL) AWS Access key for the session
     #[clap(long)]
     access_key: Option<String>,
 
-    /// [OPTIONAL] AWS secret key for the session
+    /// (OPTIONAL) AWS secret key for the session
     #[clap(long)]
     secret_key: Option<String>,
 }


### PR DESCRIPTION
Improves the akd rust docs by simplifying the examples and adding some more text to explain what an AKD is.

No actual code changes other than documentation comments in this PR.