### PR TITLE
Changing lookup + history verification APIs to return VerifyResult structs

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -881,7 +881,8 @@ mod tests {
         let search_label = NodeLabel::new(byte_arr_from_u64(0b1111 << 60), 64);
         let proof = azks.get_non_membership_proof(&db, search_label).await?;
         assert!(
-            verify_nonmembership::<Blake3>(azks.get_root_hash::<_, Blake3>(&db).await?, &proof)?,
+            verify_nonmembership::<Blake3>(azks.get_root_hash::<_, Blake3>(&db).await?, &proof)
+                .is_ok(),
             "Nonmembership proof does not verify"
         );
         Ok(())

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -409,104 +409,10 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage, H: Hasher> Directory<S, V, H> {
     /// this function returns all the values ever associated with it,
     /// and the epoch at which each value was first committed to the server state.
     /// It also returns the proof of the latest version being served at all times.
-    pub async fn key_history(&self, uname: &AkdLabel) -> Result<HistoryProof<H>, AkdError> {
-        // The guard will be dropped at the end of the proof generation
-        let _guard = self.cache_lock.read().await;
-
-        let username = uname.to_vec();
-        let current_azks = self.retrieve_current_azks().await?;
-        let current_epoch = current_azks.get_latest_epoch();
-
-        if let Ok(this_user_data) = self.storage.get_user_data(uname).await {
-            let mut user_data = this_user_data.states;
-            // reverse sort from highest epoch to lowest
-            user_data.sort_by(|a, b| b.epoch.partial_cmp(&a.epoch).unwrap());
-
-            let mut update_proofs = Vec::<UpdateProof<H>>::new();
-            let mut last_version = 0;
-            for user_state in user_data {
-                // Ignore states in storage that are ahead of current directory epoch
-                if user_state.epoch <= current_epoch {
-                    let proof = self.create_single_update_proof(uname, &user_state).await?;
-                    update_proofs.push(proof);
-                    last_version = if user_state.version > last_version {
-                        user_state.version
-                    } else {
-                        last_version
-                    };
-                }
-            }
-            let next_marker = get_marker_version(last_version) + 1;
-            let final_marker = get_marker_version(current_epoch);
-
-            let mut next_few_vrf_proofs = Vec::<Vec<u8>>::new();
-            let mut non_existence_of_next_few = Vec::<NonMembershipProof<H>>::new();
-
-            for ver in last_version + 1..(1 << next_marker) {
-                let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
-                let non_existence_of_ver = current_azks
-                    .get_non_membership_proof(&self.storage, label_for_ver)
-                    .await?;
-                non_existence_of_next_few.push(non_existence_of_ver);
-                next_few_vrf_proofs.push(
-                    self.vrf
-                        .get_label_proof::<H>(uname, false, ver)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                );
-            }
-
-            let mut future_marker_vrf_proofs = Vec::<Vec<u8>>::new();
-            let mut non_existence_of_future_markers = Vec::<NonMembershipProof<H>>::new();
-
-            for marker_power in next_marker..final_marker + 1 {
-                let ver = 1 << marker_power;
-                let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
-                let non_existence_of_ver = current_azks
-                    .get_non_membership_proof(&self.storage, label_for_ver)
-                    .await?;
-                non_existence_of_future_markers.push(non_existence_of_ver);
-                future_marker_vrf_proofs.push(
-                    self.vrf
-                        .get_label_proof::<H>(uname, false, ver)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                );
-            }
-
-            Ok(HistoryProof {
-                update_proofs,
-                next_few_vrf_proofs,
-                non_existence_of_next_few,
-                future_marker_vrf_proofs,
-                non_existence_of_future_markers,
-            })
-        } else {
-            match std::str::from_utf8(&username) {
-                Ok(name) => Err(AkdError::Storage(StorageError::NotFound(format!(
-                    "User {} at epoch {}",
-                    name, current_epoch
-                )))),
-                _ => Err(AkdError::Storage(StorageError::NotFound(format!(
-                    "User {:?} at epoch {}",
-                    username, current_epoch
-                )))),
-            }
-        }
-    }
-
-    /// Takes in the current state of the server and a label along with
-    /// a "top" number of key updates to generate a proof for.
-    ///
-    /// If the label is present in the current state,
-    /// this function returns all the values & proof of validity
-    /// up to `top_n_updates` results.
-    pub async fn limited_key_history(
+    pub async fn key_history(
         &self,
-        top_n_updates: usize,
         uname: &AkdLabel,
+        params: HistoryParams,
     ) -> Result<HistoryProof<H>, AkdError> {
         // The guard will be dropped at the end of the proof generation
         let _guard = self.cache_lock.read().await;
@@ -514,84 +420,95 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage, H: Hasher> Directory<S, V, H> {
         let current_azks = self.retrieve_current_azks().await?;
         let current_epoch = current_azks.get_latest_epoch();
         let mut user_data = self.storage.get_user_data(uname).await?.states;
+
         // reverse sort from highest epoch to lowest
-        user_data.sort_by(|a, b| b.epoch.partial_cmp(&a.epoch).unwrap());
+        user_data.sort_by(|a, b| b.epoch.cmp(&a.epoch));
 
-        let limited_history = user_data
-            .into_iter()
-            .take(top_n_updates)
-            .collect::<Vec<_>>();
+        // apply filters specified by HistoryParams struct
+        user_data = match params {
+            HistoryParams::Complete => user_data,
+            HistoryParams::MostRecent(n) => user_data.into_iter().take(n).collect::<Vec<_>>(),
+            HistoryParams::SinceEpoch(epoch) => {
+                user_data = user_data
+                    .into_iter()
+                    .filter(|val| val.epoch >= epoch)
+                    .collect::<Vec<_>>();
+                // Ordering should be maintained after filtering, but let's re-sort just in case
+                user_data.sort_by(|a, b| b.epoch.cmp(&a.epoch));
+                user_data
+            }
+        };
 
-        if limited_history.is_empty() {
+        if user_data.is_empty() {
             let msg = if let Ok(username_str) = std::str::from_utf8(uname) {
                 format!("User {}", username_str)
             } else {
                 format!("User {:?}", uname)
             };
-            Err(AkdError::Storage(StorageError::NotFound(msg)))
-        } else {
-            let mut update_proofs = Vec::<UpdateProof<H>>::new();
-            let mut last_version = 0;
-            for user_state in limited_history {
-                // Ignore states in storage that are ahead of current directory epoch
-                if user_state.epoch <= current_epoch {
-                    let proof = self.create_single_update_proof(uname, &user_state).await?;
-                    update_proofs.push(proof);
-                    last_version = if user_state.version > last_version {
-                        user_state.version
-                    } else {
-                        last_version
-                    };
-                }
-            }
-            let next_marker = get_marker_version(last_version) + 1;
-            let final_marker = get_marker_version(current_epoch);
-
-            let mut next_few_vrf_proofs = Vec::<Vec<u8>>::new();
-            let mut non_existence_of_next_few = Vec::<NonMembershipProof<H>>::new();
-
-            for ver in last_version + 1..(1 << next_marker) {
-                let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
-                let non_existence_of_ver = current_azks
-                    .get_non_membership_proof(&self.storage, label_for_ver)
-                    .await?;
-                non_existence_of_next_few.push(non_existence_of_ver);
-                next_few_vrf_proofs.push(
-                    self.vrf
-                        .get_label_proof::<H>(uname, false, ver)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                );
-            }
-
-            let mut future_marker_vrf_proofs = Vec::<Vec<u8>>::new();
-            let mut non_existence_of_future_markers = Vec::<NonMembershipProof<H>>::new();
-
-            for marker_power in next_marker..final_marker + 1 {
-                let ver = 1 << marker_power;
-                let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
-                let non_existence_of_ver = current_azks
-                    .get_non_membership_proof(&self.storage, label_for_ver)
-                    .await?;
-                non_existence_of_future_markers.push(non_existence_of_ver);
-                future_marker_vrf_proofs.push(
-                    self.vrf
-                        .get_label_proof::<H>(uname, false, ver)
-                        .await?
-                        .to_bytes()
-                        .to_vec(),
-                );
-            }
-
-            Ok(HistoryProof {
-                update_proofs,
-                next_few_vrf_proofs,
-                non_existence_of_next_few,
-                future_marker_vrf_proofs,
-                non_existence_of_future_markers,
-            })
+            return Err(AkdError::Storage(StorageError::NotFound(msg)));
         }
+
+        let mut update_proofs = Vec::<UpdateProof<H>>::new();
+        let mut last_version = 0;
+        for user_state in user_data {
+            // Ignore states in storage that are ahead of current directory epoch
+            if user_state.epoch <= current_epoch {
+                let proof = self.create_single_update_proof(uname, &user_state).await?;
+                update_proofs.push(proof);
+                last_version = if user_state.version > last_version {
+                    user_state.version
+                } else {
+                    last_version
+                };
+            }
+        }
+        let next_marker = get_marker_version(last_version) + 1;
+        let final_marker = get_marker_version(current_epoch);
+
+        let mut next_few_vrf_proofs = Vec::<Vec<u8>>::new();
+        let mut non_existence_of_next_few = Vec::<NonMembershipProof<H>>::new();
+
+        for ver in last_version + 1..(1 << next_marker) {
+            let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
+            let non_existence_of_ver = current_azks
+                .get_non_membership_proof(&self.storage, label_for_ver)
+                .await?;
+            non_existence_of_next_few.push(non_existence_of_ver);
+            next_few_vrf_proofs.push(
+                self.vrf
+                    .get_label_proof::<H>(uname, false, ver)
+                    .await?
+                    .to_bytes()
+                    .to_vec(),
+            );
+        }
+
+        let mut future_marker_vrf_proofs = Vec::<Vec<u8>>::new();
+        let mut non_existence_of_future_markers = Vec::<NonMembershipProof<H>>::new();
+
+        for marker_power in next_marker..final_marker + 1 {
+            let ver = 1 << marker_power;
+            let label_for_ver = self.vrf.get_node_label::<H>(uname, false, ver).await?;
+            let non_existence_of_ver = current_azks
+                .get_non_membership_proof(&self.storage, label_for_ver)
+                .await?;
+            non_existence_of_future_markers.push(non_existence_of_ver);
+            future_marker_vrf_proofs.push(
+                self.vrf
+                    .get_label_proof::<H>(uname, false, ver)
+                    .await?
+                    .to_bytes()
+                    .to_vec(),
+            );
+        }
+
+        Ok(HistoryProof {
+            update_proofs,
+            next_few_vrf_proofs,
+            non_existence_of_next_few,
+            future_marker_vrf_proofs,
+            non_existence_of_future_markers,
+        })
     }
 
     /// Poll for changes in the epoch number of the AZKS struct
@@ -800,6 +717,25 @@ impl<S: Storage + Sync + Send, V: VRFKeyStorage, H: Hasher> Directory<S, V, H> {
         let raw_key = self.vrf.retrieve().await?;
         let commitment_key = H::hash(&raw_key);
         Ok(commitment_key)
+    }
+}
+
+/// The parameters that dictate how much of the history proof to return to the consumer
+/// (either a complete history, or some limited form).
+#[derive(Copy, Clone)]
+pub enum HistoryParams {
+    /// Returns a complete history for a label
+    Complete,
+    /// Returns up to the most recent N updates for a label
+    MostRecent(usize),
+    /// Returns all updates since a specified epoch (inclusive)
+    SinceEpoch(u64),
+}
+
+impl Default for HistoryParams {
+    /// By default, we return a complete history
+    fn default() -> Self {
+        Self::Complete
     }
 }
 

--- a/akd/src/proof_structs.rs
+++ b/akd/src/proof_structs.rs
@@ -302,3 +302,22 @@ impl<H: Hasher> Clone for UpdateProof<H> {
         }
     }
 }
+
+/// The payload that is outputted as a result of successful verification of
+/// a [LookupProof] or [HistoryProof]. This includes the fields containing the
+/// epoch that the leaf was published in, the version corresponding to the value,
+/// and the value itself.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde_serialization",
+    derive(serde::Deserialize, serde::Serialize)
+)]
+#[cfg_attr(feature = "serde_serialization", serde(bound = ""))]
+pub struct VerifyResult {
+    /// The epoch of this record
+    pub epoch: u64,
+    /// Version at this update
+    pub version: u64,
+    /// The plaintext value associated with the record
+    pub value: AkdValue,
+}

--- a/akd/src/serialization.rs
+++ b/akd/src/serialization.rs
@@ -81,7 +81,7 @@ mod tests {
     use crate::proof_structs::{AppendOnlyProof, HistoryProof, LookupProof};
     use crate::storage::memory::AsyncInMemoryDatabase;
     use crate::storage::types::{AkdLabel, AkdValue};
-    use crate::Blake3;
+    use crate::{Blake3, HistoryParams};
 
     #[derive(Serialize, Deserialize)]
     struct Wrapper<H: Hasher> {
@@ -159,7 +159,7 @@ mod tests {
         .unwrap();
         // Generate latest proof
         let history_proof = akd
-            .key_history(&AkdLabel::from_utf8_str("hello"))
+            .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
             .await
             .unwrap();
 

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -14,11 +14,13 @@ use crate::{
     directory::{get_key_history_hashes, Directory, PublishCorruption},
     ecvrf::{HardCodedAkdVRF, VRFKeyStorage},
     errors::AkdError,
+    proof_structs::VerifyResult,
     storage::{
         memory::AsyncInMemoryDatabase,
         types::{AkdLabel, AkdValue, DbRecord},
         Storage,
     },
+    HistoryParams, HistoryVerificationParams,
 };
 use winter_crypto::{Digest, Hasher};
 use winter_math::fields::f128::BaseElement;
@@ -122,7 +124,9 @@ async fn test_small_key_history() -> Result<(), AkdError> {
     .await?;
 
     // Get the key_history_proof for the label "hello"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     // Get the latest root hash
     let current_azks = akd.retrieve_current_azks().await?;
     let current_epoch = current_azks.get_latest_epoch();
@@ -130,14 +134,30 @@ async fn test_small_key_history() -> Result<(), AkdError> {
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
     // Verify the key history proof
-    key_history_verify::<Blake3>(
+    let result = key_history_verify::<Blake3>(
         &vrf_pk,
         root_hash,
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     )?;
+
+    assert_eq!(
+        result,
+        vec![
+            VerifyResult {
+                epoch: 2,
+                version: 2,
+                value: AkdValue::from_utf8_str("world2"),
+            },
+            VerifyResult {
+                epoch: 1,
+                version: 1,
+                value: AkdValue::from_utf8_str("world"),
+            },
+        ]
+    );
 
     Ok(())
 }
@@ -218,7 +238,9 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
     ])
     .await?;
     // Get the key history proof for the label "hello". This should have 4 versions.
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 4 {
         return Err(AkdError::TestErr(format!(
@@ -238,11 +260,13 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello2"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello2")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello2"), HistoryParams::default())
+        .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 3 {
         return Err(AkdError::TestErr(format!(
@@ -256,11 +280,13 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello2"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello3"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello3")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello3"), HistoryParams::default())
+        .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 2 {
         return Err(AkdError::TestErr(format!(
@@ -274,11 +300,13 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello3"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello4"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello4")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello4"), HistoryParams::default())
+        .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 2 {
         return Err(AkdError::TestErr(format!(
@@ -292,7 +320,7 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello4"),
         key_history_proof.clone(),
-        false,
+        HistoryVerificationParams::default(),
     )?;
 
     // history proof with updates of non-decreasing versions/epochs fail to verify
@@ -304,9 +332,176 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello4"),
         borked_proof,
-        false,
+        HistoryVerificationParams::default(),
     );
     assert!(matches!(result, Err(_)), "{:?}", result);
+
+    Ok(())
+}
+
+// This test is testing the key_history function with a limited history.
+// We also want this update to verify.
+#[tokio::test]
+async fn test_limited_key_history() -> Result<(), AkdError> {
+    let db = AsyncInMemoryDatabase::new();
+    let vrf = HardCodedAkdVRF {};
+    // epoch 0
+    let akd = Directory::<_, _, Blake3>::new(&db, &vrf, false).await?;
+
+    // epoch 1
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello"),
+            AkdValue::from_utf8_str("world"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello2"),
+            AkdValue::from_utf8_str("world2"),
+        ),
+    ])
+    .await?;
+
+    // epoch 2
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello"),
+            AkdValue::from_utf8_str("world_2"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello2"),
+            AkdValue::from_utf8_str("world2_2"),
+        ),
+    ])
+    .await?;
+
+    // epoch 3
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello"),
+            AkdValue::from_utf8_str("world3"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello2"),
+            AkdValue::from_utf8_str("world4"),
+        ),
+    ])
+    .await?;
+
+    // epoch 4
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello3"),
+            AkdValue::from_utf8_str("world"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello4"),
+            AkdValue::from_utf8_str("world2"),
+        ),
+    ])
+    .await?;
+
+    // epoch 5
+    akd.publish(vec![(
+        AkdLabel::from_utf8_str("hello"),
+        AkdValue::from_utf8_str("world_updated"),
+    )])
+    .await?;
+
+    // epoch 6
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello3"),
+            AkdValue::from_utf8_str("world6"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello4"),
+            AkdValue::from_utf8_str("world12"),
+        ),
+    ])
+    .await?;
+
+    // epoch 7
+    akd.publish(vec![
+        (
+            AkdLabel::from_utf8_str("hello3"),
+            AkdValue::from_utf8_str("world7"),
+        ),
+        (
+            AkdLabel::from_utf8_str("hello4"),
+            AkdValue::from_utf8_str("world13"),
+        ),
+    ])
+    .await?;
+    // Get the VRF public key
+    let vrf_pk = akd.get_public_key().await?;
+
+    // Get the current epoch and the current root hash for this akd.
+    let current_azks = akd.retrieve_current_azks().await?;
+    let current_epoch = current_azks.get_latest_epoch();
+    let root_hash = akd.get_root_hash(&current_azks).await?;
+
+    // "hello" was updated in epochs 1,2,3,5. Pull the latest item from the history (i.e. a lookup proof)
+    let history_proof = akd
+        .key_history(
+            &AkdLabel::from_utf8_str("hello"),
+            HistoryParams::MostRecent(1),
+        )
+        .await?;
+    assert_eq!(1, history_proof.update_proofs.len());
+    assert_eq!(5, history_proof.update_proofs[0].epoch);
+
+    // Now check that the key history verifies
+    key_history_verify::<Blake3>(
+        &vrf_pk,
+        root_hash,
+        current_epoch,
+        AkdLabel::from_utf8_str("hello"),
+        history_proof,
+        HistoryVerificationParams::default(),
+    )?;
+
+    // Take the top 3 results, and check that we're getting the right epoch updates
+    let history_proof = akd
+        .key_history(
+            &AkdLabel::from_utf8_str("hello"),
+            HistoryParams::MostRecent(3),
+        )
+        .await?;
+    assert_eq!(3, history_proof.update_proofs.len());
+    assert_eq!(5, history_proof.update_proofs[0].epoch);
+    assert_eq!(3, history_proof.update_proofs[1].epoch);
+    assert_eq!(2, history_proof.update_proofs[2].epoch);
+
+    // Now check that the key history verifies
+    key_history_verify::<Blake3>(
+        &vrf_pk,
+        root_hash,
+        current_epoch,
+        AkdLabel::from_utf8_str("hello"),
+        history_proof,
+        HistoryVerificationParams::default(),
+    )?;
+
+    // "hello" was updated in epochs 1,2,3,5. Pull the updates since epoch 3 (inclusive)
+    let history_proof = akd
+        .key_history(
+            &AkdLabel::from_utf8_str("hello"),
+            HistoryParams::SinceEpoch(3),
+        )
+        .await?;
+    assert_eq!(2, history_proof.update_proofs.len());
+    assert_eq!(5, history_proof.update_proofs[0].epoch);
+    assert_eq!(3, history_proof.update_proofs[1].epoch);
+
+    // Now check that the key history verifies
+    key_history_verify::<Blake3>(
+        &vrf_pk,
+        root_hash,
+        current_epoch,
+        AkdLabel::from_utf8_str("hello"),
+        history_proof,
+        HistoryVerificationParams::default(),
+    )?;
 
     Ok(())
 }
@@ -343,7 +538,9 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
     .await?;
 
     // Get the key_history_proof for the label "hello"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     // Get the latest root hash
     let current_azks = akd.retrieve_current_azks().await?;
     let current_epoch = current_azks.get_latest_epoch();
@@ -358,7 +555,7 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     ).expect_err("The key history proof should fail here since the previous value was not marked stale at all");
 
     // Mark the first value for the label "hello" as stale
@@ -374,7 +571,9 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
     .await?;
 
     // Get the key_history_proof for the label "hello"
-    let key_history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let key_history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     // Get the latest root hash
     let current_azks = akd.retrieve_current_azks().await?;
     let current_epoch = current_azks.get_latest_epoch();
@@ -388,7 +587,7 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         key_history_proof,
-        false,
+        HistoryVerificationParams::default(),
     ).expect_err("The key history proof should fail here since the previous value was marked stale one epoch too late.");
 
     Ok(())
@@ -618,7 +817,9 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
         .expect("Error resetting directory to previous epoch");
 
     // History proof should not contain the third epoch's update but still verify
-    let history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     let (root_hashes, _) = get_key_history_hashes(&akd, &history_proof).await?;
     assert_eq!(2, root_hashes.len());
     // Get the VRF public key
@@ -632,7 +833,7 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         history_proof,
-        false,
+        HistoryVerificationParams::default(),
     )?;
 
     // Lookup proof should contain the checkpoint epoch's value and still verify
@@ -742,148 +943,6 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
     Ok(())
 }
 
-// This test is testing the limited_key_history function,
-// which takes a parameter n and gets the history for the
-// n most recent updates.
-// We also want this update to verify.
-#[tokio::test]
-async fn test_limited_key_history() -> Result<(), AkdError> {
-    let db = AsyncInMemoryDatabase::new();
-    let vrf = HardCodedAkdVRF {};
-    // epoch 0
-    let akd = Directory::<_, _, Blake3>::new(&db, &vrf, false).await?;
-
-    // epoch 1
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
-    ])
-    .await?;
-
-    // epoch 2
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_2"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_2"),
-        ),
-    ])
-    .await?;
-
-    // epoch 3
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world3"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world4"),
-        ),
-    ])
-    .await?;
-
-    // epoch 4
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world2"),
-        ),
-    ])
-    .await?;
-
-    // epoch 5
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world_updated"),
-    )])
-    .await?;
-
-    // epoch 6
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world6"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world12"),
-        ),
-    ])
-    .await?;
-
-    // epoch 7
-    akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world7"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world13"),
-        ),
-    ])
-    .await?;
-    // Get the VRF public key
-    let vrf_pk = akd.get_public_key().await?;
-
-    // "hello" was updated in epochs 1,2,3,5. Pull the latest item from the history (i.e. a lookup proof)
-    let history_proof = akd
-        .limited_key_history(1, &AkdLabel::from_utf8_str("hello"))
-        .await?;
-    assert_eq!(1, history_proof.update_proofs.len());
-    assert_eq!(5, history_proof.update_proofs[0].epoch);
-
-    // Get the current epoch and the current root hash for this akd.
-    let current_azks = akd.retrieve_current_azks().await?;
-    let current_epoch = current_azks.get_latest_epoch();
-    let root_hash = akd.get_root_hash(&current_azks).await?;
-
-    // Now check that the key history verifies
-    key_history_verify::<Blake3>(
-        &vrf_pk,
-        root_hash,
-        current_epoch,
-        AkdLabel::from_utf8_str("hello"),
-        history_proof,
-        false,
-    )?;
-
-    // Take the top 3 results, and check that we're getting the right epoch updates
-    let history_proof = akd
-        .limited_key_history(3, &AkdLabel::from_utf8_str("hello"))
-        .await?;
-    assert_eq!(3, history_proof.update_proofs.len());
-    assert_eq!(5, history_proof.update_proofs[0].epoch);
-    assert_eq!(3, history_proof.update_proofs[1].epoch);
-    assert_eq!(2, history_proof.update_proofs[2].epoch);
-
-    // Now check that the key history verifies
-    key_history_verify::<Blake3>(
-        &vrf_pk,
-        root_hash,
-        current_epoch,
-        AkdLabel::from_utf8_str("hello"),
-        history_proof,
-        false,
-    )?;
-
-    Ok(())
-}
-
 #[tokio::test]
 async fn test_tombstoned_key_history() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
@@ -939,7 +998,9 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
     db.tombstone_value_states(&tombstones).await?;
 
     // Now get a history proof for this key
-    let history_proof = akd.key_history(&AkdLabel::from_utf8_str("hello")).await?;
+    let history_proof = akd
+        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .await?;
     assert_eq!(5, history_proof.update_proofs.len());
 
     // Get the current epoch and the current root hash for this akd.
@@ -953,25 +1014,25 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         history_proof.clone(),
-        false,
+        HistoryVerificationParams::default(),
     );
     assert!(matches!(tombstones, Err(_)));
 
     // We should be able to verify tombstones assuming the client is accepting
     // of tombstoned states
-    let tombstones = key_history_verify::<Blake3>(
+    let results = key_history_verify::<Blake3>(
         &vrf_pk,
         root_hash,
         current_epoch,
         AkdLabel::from_utf8_str("hello"),
         history_proof,
-        true,
+        HistoryVerificationParams::AllowMissingValues,
     )?;
-    assert_eq!(false, tombstones[0]);
-    assert_eq!(false, tombstones[1]);
-    assert_eq!(false, tombstones[2]);
-    assert_eq!(true, tombstones[3]);
-    assert_eq!(true, tombstones[4]);
+    assert_eq!(false, results[0].value.0 == crate::TOMBSTONE);
+    assert_eq!(false, results[1].value.0 == crate::TOMBSTONE);
+    assert_eq!(false, results[2].value.0 == crate::TOMBSTONE);
+    assert_eq!(true, results[3].value.0 == crate::TOMBSTONE);
+    assert_eq!(true, results[4].value.0 == crate::TOMBSTONE);
 
     Ok(())
 }
@@ -1022,10 +1083,17 @@ async fn test_simple_lookup_for_small_tree_blake() -> Result<(), AkdError> {
         root_hash,
         target_label.clone(),
         lookup_proof,
-    );
+    )?;
 
     // check the two results to make sure they both verify
-    assert!(matches!(akd_result, Ok(())));
+    assert_eq!(
+        akd_result,
+        VerifyResult {
+            epoch: 1,
+            version: 1,
+            value: AkdValue::from_utf8_str("hello10"),
+        },
+    );
 
     Ok(())
 }
@@ -1066,10 +1134,17 @@ async fn test_simple_lookup_for_small_tree_sha256() -> Result<(), AkdError> {
 
     // perform the "traditional" AKD verification
     let akd_result =
-        crate::client::lookup_verify(&vrf_pk, root_hash, target_label.clone(), lookup_proof);
+        crate::client::lookup_verify(&vrf_pk, root_hash, target_label.clone(), lookup_proof)?;
 
     // check the two results to make sure they both verify
-    assert!(matches!(akd_result, Ok(())), "{:?}", akd_result);
+    assert_eq!(
+        akd_result,
+        VerifyResult {
+            epoch: 1,
+            version: 1,
+            value: AkdValue::from_utf8_str("hello0"),
+        },
+    );
 
     Ok(())
 }

--- a/akd_client/src/types.rs
+++ b/akd_client/src/types.rs
@@ -277,3 +277,21 @@ pub struct HistoryProof {
     /// Proof that future markers did not exist
     pub non_existence_of_future_markers: Vec<NonMembershipProof>,
 }
+
+/// The payload that is outputted as a result of successful verification of
+/// a [LookupProof] or [HistoryProof]. This includes the fields containing the
+/// epoch that the leaf was published in, the version corresponding to the value,
+/// and the value itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde_serialization",
+    derive(serde::Deserialize, serde::Serialize)
+)]
+pub struct VerifyResult {
+    /// The epoch of this record
+    pub epoch: u64,
+    /// Version at this update
+    pub version: u64,
+    /// The plaintext value associated with the record
+    pub value: AkdValue,
+}

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -9,8 +9,8 @@ extern crate thread_id;
 
 use akd::ecvrf::VRFKeyStorage;
 use akd::storage::types::{AkdLabel, AkdValue};
-use akd::Blake3;
 use akd::Directory;
+use akd::{Blake3, HistoryParams};
 use rand::distributions::Alphanumeric;
 use rand::seq::IteratorRandom;
 use rand::{thread_rng, Rng};
@@ -81,7 +81,7 @@ pub async fn directory_test_suite<S: akd::storage::Storage + Sync + Send, V: VRF
             // Perform 2 random history proofs on the published material
             for user in users.iter().choose_multiple(&mut rng, 2) {
                 let key = AkdLabel::from_utf8_str(user);
-                match dir.key_history(&key).await {
+                match dir.key_history(&key, HistoryParams::default()).await {
                     Err(error) => panic!("Error performing key history retrieval {:?}", error),
                     Ok(proof) => {
                         let (root_hash, current_epoch) =
@@ -95,7 +95,7 @@ pub async fn directory_test_suite<S: akd::storage::Storage + Sync + Send, V: VRF
                             current_epoch,
                             key,
                             proof,
-                            false,
+                            akd::HistoryVerificationParams::default(),
                         ) {
                             panic!("History proof failed to verify {:?}", error);
                         }

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -9,7 +9,7 @@ extern crate thread_id;
 
 use akd::ecvrf::VRFKeyStorage;
 use akd::storage::types::{AkdLabel, AkdValue};
-use akd::Directory;
+use akd::{Directory, HistoryParams};
 use log::{info, Level, Metadata, Record};
 use once_cell::sync::OnceCell;
 use rand::distributions::Alphanumeric;
@@ -201,7 +201,7 @@ pub(crate) async fn directory_test_suite<
             // Perform 2 random history proofs on the published material
             for user in users.iter().choose_multiple(&mut rng, 2) {
                 let key = AkdLabel::from_utf8_str(user);
-                match dir.key_history(&key).await {
+                match dir.key_history(&key, HistoryParams::default()).await {
                     Err(error) => panic!("Error performing key history retrieval {:?}", error),
                     Ok(proof) => {
                         let (root_hash, current_epoch) =
@@ -215,7 +215,7 @@ pub(crate) async fn directory_test_suite<
                             current_epoch,
                             key,
                             proof,
-                            false,
+                            akd::HistoryVerificationParams::default(),
                         ) {
                             panic!("History proof failed to verify {:?}", error);
                         }

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -9,6 +9,7 @@ use akd::ecvrf::VRFKeyStorage;
 use akd::errors::AkdError;
 use akd::storage::types::*;
 use akd::storage::Storage;
+use akd::HistoryParams;
 use akd::{Directory, EpochHash};
 use log::{debug, error, info};
 use std::marker::{Send, Sync};
@@ -157,7 +158,10 @@ where
                 }
             }
             (DirectoryCommand::KeyHistory(a), Some(response)) => {
-                match directory.key_history(&AkdLabel::from_utf8_str(&a)).await {
+                match directory
+                    .key_history(&AkdLabel::from_utf8_str(&a), HistoryParams::default())
+                    .await
+                {
                     Ok(_proof) => {
                         let msg = format!("GOT KEY HISTORY FOR '{}'", a);
                         response.send(Ok(msg)).unwrap();


### PR DESCRIPTION
Lookup proofs and history proofs now return a `VerifyResult` struct, defined as follows:
```
pub struct VerifyResult {
    /// The epoch of this record
    pub epoch: u64,
    /// Version at this update
    pub version: u64,
    /// The plaintext value associated with the record
    pub value: AkdValue,
}
```
That way, a consumer of the lookup proof / history proof verification API can potentially use these plaintext values to check consistency with the "expected" values.

Also in this PR, I adjusted the API for history proof generation and verification to use enums for custom parameters:

For history proof generation, in order to support the creating of a limited key history, we now have this enum:
```
pub enum HistoryParams {
    /// Returns a complete history for a label
    Complete,
    /// Returns up to the most recent N updates for a label
    MostRecent(usize),
    /// Returns all updates since a specified epoch (inclusive)
    SinceEpoch(u64),
}
```
So a HistoryParams::MostRecent(3) will return the 3 most recent updates for the history proof.

For history proof verification, we used to have a boolean value denoting whether or not we should allow tombstoned values. This has been replaced with the following enum:
```
pub enum HistoryVerificationParams {
    /// No customization to the verification procedure
    Default,
    /// Allows for the encountering of missing (tombstoned) values
    /// instead of attempting to check if their hash matches the leaf node
    /// hash
    AllowMissingValues,
}
```

