### PR TITLE
Fixing mysql_async dependency issues

### DIFF
--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
 tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
-mysql_async = "0.29"
+mysql_async = "0.31"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 akd = { path = "../akd", version = "^0.7.1", features = ["serde_serialization"] }
 

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -620,7 +620,11 @@ impl MySqlStorable for DbRecord {
         Self: std::marker::Sized,
     {
         fn cast_err() -> MySqlError {
-            MySqlError::from("Failed to cast label:val into [u8; 32]".to_string())
+            MySqlError::from(mysql_async::ServerError {
+                state: "".to_string(),
+                code: 0,
+                message: "Failed to cast label:val into [u8; 32]".to_string(),
+            })
         }
 
         fn optional_child_label(
@@ -641,8 +645,16 @@ impl MySqlStorable for DbRecord {
                             val.try_into().map_err(|_| cast_err())?,
                             len,
                         ))),
-                        (Err(_len_err), _) => Err(Error::from("Error decoding length")),
-                        (_, Err(_val_err)) => Err(Error::from("Error decoding value")),
+                        (Err(_len_err), _) => Err(Error::from(mysql_async::ServerError {
+                            state: "".to_string(),
+                            code: 0,
+                            message: "Error decoding length".to_string(),
+                        })),
+                        (_, Err(_val_err)) => Err(Error::from(mysql_async::ServerError {
+                            state: "".to_string(),
+                            code: 0,
+                            message: "Error decoding value".to_string(),
+                        })),
                     }
                 }
             }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,7 +13,7 @@ winter-math = "0.2"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 tokio = { version = "1.10", features = ["full"] }
 serial_test = "*"
-mysql_async = "0.29"
+mysql_async = "0.31"
 rand = "0.7"
 once_cell = "1"
 thread-id = "3"


### PR DESCRIPTION
funty 1.2.0 was yanked, which was a dependency for mysql_async v0.29. Upgrading to mysql_async v0.31 fixes the issue.