### PR TITLE
Update bugged get_root_hash_at_epoch function

### DIFF
--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -211,7 +211,7 @@ pub enum DirectoryError {
     VerifyLookupProof(String),
     /// Key-History proof did not verify
     VerifyKeyHistoryProof(String),
-    /// Tried to audit an invalid epoch range
+    /// Tried to perform an operation on an invalid epoch or epoch range
     InvalidEpoch(String),
     /// AZKS not found in read-only directory mode
     ReadOnlyDirectory(String),

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -11,7 +11,7 @@
 use crate::{
     auditor::audit_verify,
     client::{key_history_verify, lookup_verify},
-    directory::{get_key_history_hashes, Directory, PublishCorruption},
+    directory::{Directory, PublishCorruption},
     ecvrf::{HardCodedAkdVRF, VRFKeyStorage},
     errors::AkdError,
     proof_structs::VerifyResult,
@@ -830,8 +830,6 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
     let history_proof = akd
         .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
         .await?;
-    let (root_hashes, _) = get_key_history_hashes(&akd, &history_proof).await?;
-    assert_eq!(2, root_hashes.len());
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
     let current_azks = akd.retrieve_current_azks().await?;

--- a/poc/src/commands.rs
+++ b/poc/src/commands.rs
@@ -155,15 +155,8 @@ impl Command {
         }
     }
 
-    fn root_hash(parts: Vec<&str>) -> Option<DirectoryCommand> {
-        let mut epoch = None;
-        if parts.len() > 1 {
-            if let Ok(a) = parts[1].parse::<u64>() {
-                epoch = Some(a);
-            }
-        }
-
-        let cmd = DirectoryCommand::RootHash(epoch);
+    fn root_hash(_parts: Vec<&str>) -> Option<DirectoryCommand> {
+        let cmd = DirectoryCommand::RootHash;
         Some(cmd)
     }
 }


### PR DESCRIPTION
The API does not function as intended - instead of getting the root hash at a specific epoch, it gets the root hash at the latest epoch. 

As we no longer store all nodes from past epochs, we are unable to generate root hashes of past epochs with the directory. Therefore I update the function to `get_root_hash_safe`, which instead checks that the input epoch is equivalent to the latest epoch before returning the root hash (of the latest epoch). This gives callers a way to know if the root hash they are trying to retrieve is not from the epoch that they expect.