### PR TITLE
Passing in knowledge of if we're in a transaction to the db batch_set

### DIFF
--- a/akd/src/storage/manager.rs
+++ b/akd/src/storage/manager.rs
@@ -171,7 +171,7 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
     /// Commit a transaction in the database
     pub async fn commit_transaction(&self) -> Result<(), StorageError> {
         // this retrieves all the trans operations, and "de-activates" the transaction flag
-        let ops = self.transaction.commit_transaction().await?;
+        let records = self.transaction.commit_transaction().await?;
 
         // The transaction is now complete (or reverted) and therefore we can re-enable
         // the cache cleaning status
@@ -179,7 +179,12 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
             cache.enable_clean();
         }
 
-        let _epoch = match ops.last() {
+        if records.is_empty() {
+            // no-op, there's nothing to commit
+            return Ok(());
+        }
+
+        let _epoch = match records.last() {
             Some(DbRecord::Azks(azks)) => Ok(azks.latest_epoch),
             other => Err(StorageError::Transaction(format!(
                 "The last record in the transaction log is NOT an Azks record {:?}",
@@ -187,11 +192,16 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
             ))),
         }?;
 
-        // We're calling the internal batch set operation in order to manage the cache correctly.
-        // Since we've "committed" the in-memory transaction, the batch_set operation will bypass
-        // the transaction management and simply interact with the cache then write to the underlying
-        // DB
-        self.batch_set(ops).await
+        // update the cache
+        if let Some(cache) = &self.cache {
+            cache.batch_put(&records).await;
+        }
+
+        // Write to the database
+        self.tic_toc(METRIC_WRITE_TIME, self.db.batch_set(records, true))
+            .await?;
+        self.increment_metric(METRIC_BATCH_SET).await;
+        Ok(())
     }
 
     /// Rollback a transaction
@@ -248,7 +258,7 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
         }
 
         // Write to the database
-        self.tic_toc(METRIC_WRITE_TIME, self.db.batch_set(records))
+        self.tic_toc(METRIC_WRITE_TIME, self.db.batch_set(records, false))
             .await?;
         self.increment_metric(METRIC_BATCH_SET).await;
         Ok(())

--- a/akd/src/storage/manager.rs
+++ b/akd/src/storage/manager.rs
@@ -16,6 +16,7 @@ use crate::storage::types::KeyData;
 use crate::storage::types::ValueState;
 use crate::storage::types::ValueStateKey;
 use crate::storage::Database;
+use crate::storage::DbSetState;
 use crate::storage::Storable;
 use crate::storage::StorageError;
 use crate::AkdLabel;
@@ -198,8 +199,11 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
         }
 
         // Write to the database
-        self.tic_toc(METRIC_WRITE_TIME, self.db.batch_set(records, true))
-            .await?;
+        self.tic_toc(
+            METRIC_WRITE_TIME,
+            self.db.batch_set(records, DbSetState::TransactionCommit),
+        )
+        .await?;
         self.increment_metric(METRIC_BATCH_SET).await;
         Ok(())
     }
@@ -258,8 +262,11 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
         }
 
         // Write to the database
-        self.tic_toc(METRIC_WRITE_TIME, self.db.batch_set(records, false))
-            .await?;
+        self.tic_toc(
+            METRIC_WRITE_TIME,
+            self.db.batch_set(records, DbSetState::General),
+        )
+        .await?;
         self.increment_metric(METRIC_BATCH_SET).await;
         Ok(())
     }

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -16,7 +16,6 @@ use crate::storage::types::{
 };
 use crate::storage::{Database, Storable, StorageUtil};
 use async_trait::async_trait;
-use log::debug;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -87,7 +86,7 @@ impl Database for AsyncInMemoryDatabase {
         Ok(())
     }
 
-    async fn batch_set(&self, records: Vec<DbRecord>) -> Result<(), StorageError> {
+    async fn batch_set(&self, records: Vec<DbRecord>, _is_committing_transaction: bool) -> Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles
             return Ok(());
@@ -158,35 +157,6 @@ impl Database for AsyncInMemoryDatabase {
             // swallow errors (i.e. not found)
         }
         Ok(map)
-    }
-
-    async fn tombstone_value_states(&self, keys: &[ValueStateKey]) -> Result<(), StorageError> {
-        if keys.is_empty() {
-            return Ok(());
-        }
-
-        let data = self.batch_get::<ValueState>(keys).await?;
-        let mut new_data = vec![];
-        for record in data {
-            if let DbRecord::ValueState(value_state) = record {
-                debug!(
-                    "Tombstoning 0x{}",
-                    hex::encode(value_state.username.to_vec())
-                );
-
-                new_data.push(DbRecord::ValueState(ValueState {
-                    plaintext_val: crate::AkdValue(crate::TOMBSTONE.to_vec()),
-                    ..value_state
-                }));
-            }
-        }
-
-        if !new_data.is_empty() {
-            debug!("Tombstoning {} entries", new_data.len());
-            self.batch_set(new_data).await?;
-        }
-
-        Ok(())
     }
 
     /// Retrieve the user data for a given user

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -86,7 +86,11 @@ impl Database for AsyncInMemoryDatabase {
         Ok(())
     }
 
-    async fn batch_set(&self, records: Vec<DbRecord>, _is_committing_transaction: bool) -> Result<(), StorageError> {
+    async fn batch_set(
+        &self,
+        records: Vec<DbRecord>,
+        _is_committing_transaction: bool,
+    ) -> Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles
             return Ok(());

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -89,7 +89,7 @@ impl Database for AsyncInMemoryDatabase {
     async fn batch_set(
         &self,
         records: Vec<DbRecord>,
-        _is_committing_transaction: bool,
+        _state: crate::storage::DbSetState,
     ) -> Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -95,7 +95,11 @@ pub trait Database: Clone {
     async fn set(&self, record: DbRecord) -> Result<(), StorageError>;
 
     /// Set multiple records in the database with a minimal set of operations
-    async fn batch_set(&self, records: Vec<DbRecord>, is_committing_transaction: bool) -> Result<(), StorageError>;
+    async fn batch_set(
+        &self,
+        records: Vec<DbRecord>,
+        is_committing_transaction: bool,
+    ) -> Result<(), StorageError>;
 
     /// Retrieve a stored record from the database
     async fn get<St: Storable>(&self, id: &St::StorageKey) -> Result<DbRecord, StorageError>;

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -32,6 +32,14 @@ pub use manager::StorageManager;
 #[cfg(any(test, feature = "public-tests"))]
 pub mod tests;
 
+/// Denotes the "state" when a batch_set is being called in the data layer
+pub enum DbSetState {
+    /// Being called as part of a transaction commit operation
+    TransactionCommit,
+    /// Being called as a general, in-line operation
+    General,
+}
+
 /// Support getting the size of a struct or item in bytes
 pub trait SizeOf {
     /// Retrieve the size of the item in bytes
@@ -98,7 +106,7 @@ pub trait Database: Clone {
     async fn batch_set(
         &self,
         records: Vec<DbRecord>,
-        is_committing_transaction: bool,
+        state: DbSetState,
     ) -> Result<(), StorageError>;
 
     /// Retrieve a stored record from the database

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -95,7 +95,7 @@ pub trait Database: Clone {
     async fn set(&self, record: DbRecord) -> Result<(), StorageError>;
 
     /// Set multiple records in the database with a minimal set of operations
-    async fn batch_set(&self, records: Vec<DbRecord>) -> Result<(), StorageError>;
+    async fn batch_set(&self, records: Vec<DbRecord>, is_committing_transaction: bool) -> Result<(), StorageError>;
 
     /// Retrieve a stored record from the database
     async fn get<St: Storable>(&self, id: &St::StorageKey) -> Result<DbRecord, StorageError>;
@@ -105,13 +105,6 @@ pub trait Database: Clone {
         &self,
         ids: &[St::StorageKey],
     ) -> Result<Vec<DbRecord>, StorageError>;
-
-    /// Convert the given value state's into tombstones, replacing the plaintext value with
-    /// the tombstone key array
-    async fn tombstone_value_states(
-        &self,
-        keys: &[types::ValueStateKey],
-    ) -> Result<(), StorageError>;
 
     /* User data searching */
 

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -173,7 +173,12 @@ async fn test_batch_get_items<Ns: Database>(storage: &Ns) {
     }
 
     let tic = Instant::now();
-    assert_eq!(Ok(()), storage.batch_set(data.clone(), false).await);
+    assert_eq!(
+        Ok(()),
+        storage
+            .batch_set(data.clone(), crate::storage::DbSetState::General)
+            .await
+    );
     let toc: Duration = Instant::now() - tic;
     println!("Storage batch op: {} ms", toc.as_millis());
     let got = storage
@@ -577,7 +582,9 @@ async fn test_user_data<S: Database + Sync + Send>(storage: &S) {
         .into_iter()
         .map(DbRecord::ValueState)
         .collect::<Vec<_>>();
-    let result = storage.batch_set(records, false).await;
+    let result = storage
+        .batch_set(records, crate::storage::DbSetState::General)
+        .await;
     assert_eq!(Ok(()), result);
 
     let data = storage.get_user_data(&sample_state_2.username).await;

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -1008,7 +1008,7 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
         crate::storage::types::ValueStateKey("hello".as_bytes().to_vec(), 1u64),
         crate::storage::types::ValueStateKey("hello".as_bytes().to_vec(), 2u64),
     ];
-    db.tombstone_value_states(&tombstones).await?;
+    storage.tombstone_value_states(&tombstones).await?;
 
     // Now get a history proof for this key
     let history_proof = akd

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -652,7 +652,7 @@ impl Database for AsyncMySqlDatabase {
     async fn batch_set(
         &self,
         records: Vec<DbRecord>,
-        _is_committing_transaction: bool,
+        _state: akd::storage::DbSetState,
     ) -> core::result::Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -649,7 +649,11 @@ impl Database for AsyncMySqlDatabase {
         }
     }
 
-    async fn batch_set(&self, records: Vec<DbRecord>, _is_committing_transaction: bool) -> core::result::Result<(), StorageError> {
+    async fn batch_set(
+        &self,
+        records: Vec<DbRecord>,
+        _is_committing_transaction: bool,
+    ) -> core::result::Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles
             return Ok(());

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -649,7 +649,7 @@ impl Database for AsyncMySqlDatabase {
         }
     }
 
-    async fn batch_set(&self, records: Vec<DbRecord>) -> core::result::Result<(), StorageError> {
+    async fn batch_set(&self, records: Vec<DbRecord>, _is_committing_transaction: bool) -> core::result::Result<(), StorageError> {
         if records.is_empty() {
             // nothing to do, save the cycles
             return Ok(());
@@ -862,47 +862,6 @@ impl Database for AsyncMySqlDatabase {
         }
 
         Ok(map)
-    }
-
-    async fn tombstone_value_states(
-        &self,
-        keys: &[akd::storage::types::ValueStateKey],
-    ) -> core::result::Result<(), StorageError> {
-        // NOTE: This might be optimizable in the future where we could use a SQL statement such as
-        //
-        // UPDATE `users`
-        // SET `data` = TOMBSTONE
-        // WHERE key in (set)
-        //
-        // However, the problem comes from managing an active transaction and cache (if there is one)
-        // since we may need to batch load nodes anyways in order to get the other properties
-        // which might need to be set. We could write everything to SQL, and after-the-fact update
-        // the active transaction and caches with replacing nodes which were updated? Anyways it's a
-        // relatively minor improvement here, due to proper use of batch operations
-
-        if keys.is_empty() {
-            return Ok(());
-        }
-
-        let data = self.batch_get::<ValueState>(keys).await?;
-        let mut new_data = vec![];
-        for record in data {
-            if let DbRecord::ValueState(value_state) = record {
-                new_data.push(DbRecord::ValueState(ValueState {
-                    epoch: value_state.epoch,
-                    label: value_state.label,
-                    plaintext_val: akd::AkdValue(akd::TOMBSTONE.to_vec()),
-                    username: value_state.username,
-                    version: value_state.version,
-                }));
-            }
-        }
-        if !new_data.is_empty() {
-            debug!("Tombstoning {} entries", new_data.len());
-            self.batch_set(new_data).await?;
-        }
-
-        Ok(())
     }
 
     async fn get_user_data(

--- a/akd_test_tools/src/fixture_generator/examples/example_tests.rs
+++ b/akd_test_tools/src/fixture_generator/examples/example_tests.rs
@@ -32,7 +32,9 @@ async fn test_use_fixture() {
     // prepare directory with initial state
     let initial_state = reader.read_state(epochs[0]).unwrap();
     let db = AsyncInMemoryDatabase::new();
-    db.batch_set(initial_state.records, false).await.unwrap();
+    db.batch_set(initial_state.records, akd::storage::DbSetState::General)
+        .await
+        .unwrap();
     let vrf = HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(&db);
     let akd = Directory::<_, _, Blake3>::new(&storage_manager, &vrf, false)

--- a/akd_test_tools/src/fixture_generator/examples/example_tests.rs
+++ b/akd_test_tools/src/fixture_generator/examples/example_tests.rs
@@ -32,7 +32,7 @@ async fn test_use_fixture() {
     // prepare directory with initial state
     let initial_state = reader.read_state(epochs[0]).unwrap();
     let db = AsyncInMemoryDatabase::new();
-    db.batch_set(initial_state.records).await.unwrap();
+    db.batch_set(initial_state.records, false).await.unwrap();
     let vrf = HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(&db);
     let akd = Directory::<_, _, Blake3>::new(&storage_manager, &vrf, false)


### PR DESCRIPTION
Currently `batch_set` at the db layer if a transaction is committing and that has some downstream implications if the data layer isn't atomic, or had other atomic wrappers included. This allows us to know if we are calling the underlying batch_set from a transaction commit operation for better handling.

Additionally the db impl doesn't need to implement tombstoning, that's done by the storage manager, and this was just an artifact to cleanup