### PR TITLE
Minimize the dependencies on Tokio. 

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 # build = "src/build.rs"
 
 # [build-dependencies]
-# protobuf-codegen = "=3.2.0"
+# protobuf-codegen = "3.2"
 # protoc-bin-vendored = "3"
 
 [features]
@@ -26,27 +26,27 @@ runtime_metrics = []
 
 [dependencies]
 ## Required dependencies ##
-hex = "0.4"
-async-trait = "0.1"
-dashmap = { version = "5" }
-tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
+async-trait = "0.1"
+curve25519-dalek = "3"
+dashmap = { version = "5" }
+ed25519-dalek = "1"
+hex = "0.4"
+keyed_priority_queue = "0.3"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 winter-crypto = "0.2"
 winter-utils = "0.2"
 winter-math = "0.2"
-keyed_priority_queue = "0.3"
 
 ## Optional Dependencies ##
 bincode = { version = "1", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-rand = { version = "0.7", optional = true }
-curve25519-dalek = "3"
-ed25519-dalek = "1"
 colored = { version = "2", optional = true }
 once_cell = { version = "1", optional = true }
-protobuf = { version = "=3.2.0", optional = true }
+protobuf = { version = "3.2", optional = true }
+rand = { version = "0.7", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 thiserror = { version = "1.0.30", optional = true }
+tokio = { version = "1.10", features = ["sync", "time"] }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -57,7 +57,7 @@ colored = { version = "2" }
 once_cell = { version = "1" }
 ctor = "0.1"
 tokio-test = "0.4"
-
+tokio = { version = "1.10", features = ["rt", "sync", "time", "macros"] }
 akd = { path = ".", features = ["public-tests"] }
 
 [[bench]]

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -18,6 +18,7 @@ use crate::storage::{Database, Storable, StorageUtil};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 type Epoch = u64;
 type UserValueMap = HashMap<Epoch, ValueState>;
@@ -28,8 +29,8 @@ type UserStates = HashMap<Vec<u8>, UserValueMap>;
 /// This struct represents a basic in-memory database.
 #[derive(Debug)]
 pub struct AsyncInMemoryDatabase {
-    db: Arc<tokio::sync::RwLock<HashMap<Vec<u8>, DbRecord>>>,
-    user_info: Arc<tokio::sync::RwLock<UserStates>>,
+    db: Arc<RwLock<HashMap<Vec<u8>, DbRecord>>>,
+    user_info: Arc<RwLock<UserStates>>,
 }
 
 unsafe impl Send for AsyncInMemoryDatabase {}
@@ -39,8 +40,8 @@ impl AsyncInMemoryDatabase {
     /// Creates a new in memory db
     pub fn new() -> Self {
         Self {
-            db: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            user_info: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            db: Arc::new(RwLock::new(HashMap::new())),
+            user_info: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -16,7 +16,7 @@ use crate::tree_node::*;
 use crate::NodeLabel;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use tokio::time::{Duration, Instant};
+use std::time::{Duration, Instant};
 
 type Azks = crate::append_only_zks::Azks;
 type TreeNode = crate::tree_node::TreeNode;

--- a/akd/src/test_utils.rs
+++ b/akd/src/test_utils.rs
@@ -12,7 +12,7 @@ use colored::*;
 use log::{Level, Metadata, Record};
 use once_cell::sync::OnceCell;
 use std::sync::Once;
-use tokio::time::{Duration, Instant};
+use std::time::{Duration, Instant};
 
 static EPOCH: OnceCell<Instant> = OnceCell::new();
 static LOGGER: TestConsoleLogger = TestConsoleLogger {};

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -23,7 +23,8 @@ use crate::{
     },
     HistoryParams, HistoryVerificationParams,
 };
-use winter_crypto::{Digest, Hasher};
+use winter_crypto::Digest;
+use winter_crypto::Hasher;
 use winter_math::fields::f128::BaseElement;
 type Blake3 = winter_crypto::hashers::Blake3_256<BaseElement>;
 type Sha3 = winter_crypto::hashers::Sha3_256<BaseElement>;
@@ -1165,7 +1166,6 @@ async fn test_simple_lookup_for_small_tree_sha256() -> Result<(), AkdError> {
 /*
 =========== Test Helpers ===========
 */
-
 async fn async_poll_helper_proof<T: Database + Sync + Send, V: VRFKeyStorage, H: Hasher>(
     reader: &Directory<T, V, H>,
     value: AkdValue,

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -15,6 +15,7 @@ use crate::{
     EMPTY_LABEL, EMPTY_VALUE,
 };
 use std::collections::HashSet;
+// use std::sync::Arc;
 use winter_crypto::{Digest, Hasher};
 
 // Builds a set of all prefixes of the input labels
@@ -95,4 +96,12 @@ pub(crate) fn commit_value<H: Hasher>(
 // Used by the client to supply a commitment proof and value to reconstruct the commitment
 pub(crate) fn bind_commitment<H: Hasher>(value: &AkdValue, proof: &[u8]) -> H::Digest {
     H::hash(&[i2osp_array(value), i2osp_array(proof)].concat())
+}
+
+/// "Swap" values in a RwLock, reading the current value and writing a new value into the lock
+pub(crate) async fn rwlock_swap<T: Clone>(lock: &tokio::sync::RwLock<T>, new_value: T) -> T {
+    let mut guard = lock.write().await;
+    let old = guard.clone();
+    *guard = new_value;
+    old
 }

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 # build = "src/build.rs"
 
 # [build-dependencies]
-# protobuf-codegen = "=3.2.0"
+# protobuf-codegen = "3.2"
 # protoc-bin-vendored = "3"
 
 [lib]
@@ -23,7 +23,7 @@ akd = { path = "../akd", version = "^0.7.7", features = ["public-tests"], option
 blake3 = { version = "1.3.1", optional = true, default-features = false }
 curve25519-dalek = "3"
 ed25519-dalek = { version = "1", default-features = false, features = ["u64_backend", "rand"] }
-protobuf = { version = "=3.2.0", optional = true }
+protobuf = { version = "3.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"], default-features = false }
 serde_json = { version = "1", optional = true }
 sha2 = { version = "0.10.1", optional = true, default-features = false }

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1"
 tokio = { version = "1.10", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.31"
+mysql_common = "0.29.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 akd = { path = "../akd", version = "^0.7.7", features = ["serde_serialization"] }
 


### PR DESCRIPTION
This change leans out the features in the `tokio` crate to just "sync" and "time" for synchronization and communication management features utilized

in the `akd` crate. In the test configuration, more functionality is enabled with "rt" and "macros" due to the tokio testing frameworks utilized in `akd`. This removes the inherited
dependency on `mio` as well as many other downstream crates which should assist in WASM compliation (see: #270)