### PR TITLE
Adding a test for WASM lookup proof verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,14 +162,10 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Run test (Chrome profile)
+      - name: Test default profile (blake3)
         working-directory: ./akd_client
-        run: wasm-pack test --headless --chrome --features wasm
+        run: wasm-pack test --node --features wasm
 
-      - name: Run test (Firefox profile)
-        working-directory: ./akd_client  
-        run: wasm-pack test --headless --firefox --features wasm
-
-      - name: Run SHA3_256 test (Chrome profile)
+      - name: Test SHA3_256 and no default features
         working-directory: ./akd_client
-        run: wasm-pack test --headless --chrome --no-default-features --features wasm,sha3_256
+        run: wasm-pack test --node --no-default-features --features wasm,sha3_256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,32 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  wasm-tests:
+    name: WASM tests
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu]
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Run test (Chrome profile)
+        working-directory: ./akd_client
+        run: wasm-pack test --headless --chrome --features wasm
+
+      - name: Run test (Firefox profile)
+        working-directory: ./akd_client  
+        run: wasm-pack test --headless --firefox --features wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,7 @@ jobs:
       - name: Run test (Firefox profile)
         working-directory: ./akd_client  
         run: wasm-pack test --headless --firefox --features wasm
+
+      - name: Run SHA3_256 test (Chrome profile)
+        working-directory: ./akd_client
+        run: wasm-pack test --headless --chrome --no-default-features --features wasm,sha3_256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - name: Build WASM compatible binary
+        working-directory: ./akd_client
+        run: wasm-pack build --features wasm
+
       - name: Test default profile (blake3)
         working-directory: ./akd_client
         run: wasm-pack test --node --features wasm

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -20,10 +20,12 @@ blake3 = ["akd_core/blake3"]
 bench = ["public-tests"]
 public-tests = ["rand", "bincode", "colored", "once_cell", "serde_serialization", "akd_core/rand"]
 public_auditing = ["protobuf", "akd_core/protobuf"]
-default = ["blake3", "public_auditing"]
 serde_serialization = ["serde", "ed25519-dalek/serde", "akd_core/serde_serialization"]
 # Collect runtime metrics on db access calls + timing
 runtime_metrics = []
+
+# Default features mix (blake3 + audit-proof protobuf mgmt support)
+default = ["blake3", "public_auditing"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -691,7 +691,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut input = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut input = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut input);
             let hash = akd_core::hash::hash(&input);
             let node = Node { label, hash };
@@ -726,7 +726,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -760,7 +760,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -795,7 +795,7 @@ mod tests {
             let label = NodeLabel::new(label_arr, 256u32);
             let node = Node {
                 label,
-                hash: [0u8; akd_core::hash::DIGEST_BYTES],
+                hash: crate::hash::EMPTY_DIGEST,
             };
             insertion_set.push(node);
         }
@@ -824,7 +824,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -905,7 +905,7 @@ mod tests {
             let mut label_arr = [0u8; 32];
             label_arr[31] = i;
             let label = NodeLabel::new(label_arr, 256u32);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             hash[31] = i;
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -934,7 +934,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -961,7 +961,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set.push(node);
@@ -1054,7 +1054,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set_1.push(node);
@@ -1072,7 +1072,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set_2.push(node);
@@ -1087,7 +1087,7 @@ mod tests {
 
         for _ in 0..num_nodes {
             let label = crate::utils::random_label(&mut rng);
-            let mut hash = [0u8; akd_core::hash::DIGEST_BYTES];
+            let mut hash = crate::hash::EMPTY_DIGEST;
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             insertion_set_3.push(node);

--- a/akd/src/proto/mod.rs
+++ b/akd/src/proto/mod.rs
@@ -41,17 +41,8 @@ impl From<protobuf::Error> for LocalAuditorError {
 
 macro_rules! hash_from_ref {
     ($obj:expr) => {
-        if $obj.len() == akd_core::hash::DIGEST_BYTES {
-            let mut v = [0u8; akd_core::hash::DIGEST_BYTES];
-            v.copy_from_slice($obj);
-            Ok(v)
-        } else {
-            Err(akd_core::proto::ConversionError::Deserialization(format!(
-                "Hash didn't have correct length (expected {} != got {})",
-                akd_core::hash::DIGEST_BYTES,
-                $obj.len()
-            )))
-        }
+        crate::hash::try_parse_digest($obj)
+            .map_err(akd_core::proto::ConversionError::Deserialization)
     };
 }
 
@@ -220,8 +211,8 @@ mod tests {
         let expected_name = "54/0101010101010101010101010101010101010101010101010101010101010101/0000000000000000000000000000000000000000000000000000000000000000";
 
         let blob_name = AuditBlobName {
-            current_hash: [0u8; 32],
-            previous_hash: [1u8; 32],
+            current_hash: crate::hash::EMPTY_DIGEST,
+            previous_hash: [1u8; crate::hash::DIGEST_BYTES],
             epoch: 54,
         };
 

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -328,7 +328,7 @@ mod tests {
             node_type: NodeType::Root,
             left_child: None,
             right_child: None,
-            hash: [0u8; crate::DIGEST_BYTES],
+            hash: crate::hash::EMPTY_DIGEST,
         }));
         let node2 = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
@@ -338,7 +338,7 @@ mod tests {
             node_type: NodeType::Leaf,
             left_child: None,
             right_child: None,
-            hash: [0u8; crate::DIGEST_BYTES],
+            hash: crate::hash::EMPTY_DIGEST,
         }));
         let value1 = DbRecord::ValueState(ValueState {
             username: AkdLabel::from_utf8_str("test"),

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -567,7 +567,7 @@ impl TreeNode {
             min(self.least_descendant_ep, epoch),
             None,
             None,
-            [0u8; crate::DIGEST_BYTES],
+            crate::hash::EMPTY_DIGEST,
         )
         .await?;
         // Set up child-parent connections from top to bottom

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -52,6 +52,7 @@ pub(crate) fn empty_node_hash_no_label() -> crate::Digest {
 // Creates a byte array of 32 bytes from a u64
 // Note that this representation is big-endian, and
 // places the bits to the front of the output byte_array.
+#[allow(dead_code)]
 pub(crate) fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
     let mut output_arr = [0u8; 32];
     let input_arr = input_int.to_be_bytes();

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -45,6 +45,7 @@ default = ["blake3"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+akd = { path = "../akd" }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -45,7 +45,7 @@ default = ["blake3"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-akd = { path = "../akd" }
+akd = { path = "../akd", default-features = false }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/akd_client/src/wasm.rs
+++ b/akd_client/src/wasm.rs
@@ -151,11 +151,6 @@ pub mod tests {
     use crate::ecvrf::HardCodedAkdVRF;
 
     #[wasm_bindgen_test]
-    fn test_build_pipeline_failure() {
-        assert_eq!(true, false);
-    }
-
-    #[wasm_bindgen_test]
     async fn test_simple_wasm_lookup() {
         let db = AsyncInMemoryDatabase::new();
         let storage = StorageManager::new_no_cache(&db);

--- a/akd_client/src/wasm.rs
+++ b/akd_client/src/wasm.rs
@@ -151,6 +151,11 @@ pub mod tests {
     use crate::ecvrf::HardCodedAkdVRF;
 
     #[wasm_bindgen_test]
+    fn test_build_pipeline_failure() {
+        assert_eq!(true, false);
+    }
+
+    #[wasm_bindgen_test]
     async fn test_simple_wasm_lookup() {
         let db = AsyncInMemoryDatabase::new();
         let storage = StorageManager::new_no_cache(&db);

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -18,8 +18,6 @@ protobuf-parse = "3.2"
 [features]
 # Disable all STD for the crate
 nostd = []
-# Default feature mix (blake3 + vrf verification logic)
-default = ["blake3/std", "vrf"]
 # Supported SHA-based hash functions
 sha512 = ["sha2"]
 sha256 = ["sha2"]
@@ -27,8 +25,10 @@ sha3_256 = ["sha3"]
 sha3_512 = ["sha3"]
 # Include the VRF verification logic
 vrf = ["ed25519-dalek", "curve25519-dalek/std"]
-
 serde_serialization = ["serde", "serde_bytes", "ed25519-dalek/serde"]
+
+# Default features mix (Blake3 + VRFs)
+default = ["vrf", "blake3"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd_core/src/hash/mod.rs
+++ b/akd_core/src/hash/mod.rs
@@ -21,6 +21,8 @@ use core::slice;
 
 /// A hash digest of a specified number of bytes
 pub type Digest = [u8; DIGEST_BYTES];
+/// Represents an empty digest, with no data contained
+pub const EMPTY_DIGEST: [u8; DIGEST_BYTES] = [0u8; DIGEST_BYTES];
 
 // =========================================
 // ========== Blake3 settings ==============
@@ -68,6 +70,22 @@ impl core::fmt::Display for HashError {
             HashError::NoDirection(msg) => format!("(No Direction) - {}", msg),
         };
         write!(f, "Hashing error {}", code)
+    }
+}
+
+/// Try and parse a digest from an unknown length of bytes. Helpful for converting a Vec<u8>
+/// to a Digest
+pub fn try_parse_digest(value: &[u8]) -> Result<Digest, String> {
+    if value.len() != DIGEST_BYTES {
+        Err(format!(
+            "Failed to parse Digest. Expected {} bytes but the value has {} bytes",
+            DIGEST_BYTES,
+            value.len()
+        ))
+    } else {
+        let mut arr = EMPTY_DIGEST;
+        arr.copy_from_slice(value);
+        Ok(arr)
     }
 }
 

--- a/akd_core/src/hash/tests.rs
+++ b/akd_core/src/hash/tests.rs
@@ -14,7 +14,7 @@ use alloc::vec;
 use rand::{thread_rng, Rng};
 
 fn random_hash() -> [u8; DIGEST_BYTES] {
-    let mut results = [0u8; DIGEST_BYTES];
+    let mut results = crate::hash::EMPTY_DIGEST;
     let mut rng = thread_rng();
     for b in results.iter_mut().take(DIGEST_BYTES) {
         *b = rng.gen::<u8>();

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -79,13 +79,7 @@ macro_rules! require_messagefield {
 
 macro_rules! hash_from_bytes {
     ($obj:expr) => {{
-        // get the raw data & it's length, but at most crate::hash::DIGEST_BYTES bytes
-        let len = std::cmp::min($obj.len(), crate::hash::DIGEST_BYTES);
-        // construct the output buffer
-        let mut out_val = [0u8; crate::hash::DIGEST_BYTES];
-        // copy into the output buffer the raw data up to the computed length
-        out_val[..len].clone_from_slice(&$obj[..len]);
-        out_val
+        crate::hash::try_parse_digest($obj).map_err(Self::Error::Deserialization)?
     }};
 }
 

--- a/akd_core/src/utils.rs
+++ b/akd_core/src/utils.rs
@@ -113,16 +113,6 @@ pub mod serde_helpers {
         D: serde::Deserializer<'de>,
     {
         let buf = <Vec<u8> as serde_bytes::Deserialize>::deserialize(deserializer)?;
-        if buf.len() == crate::hash::DIGEST_BYTES {
-            let mut v = [0u8; crate::hash::DIGEST_BYTES];
-            v.copy_from_slice(&buf);
-            Ok(v)
-        } else {
-            Err(serde::de::Error::custom(format!(
-                "Digest of unexpected size (expected {} != got {})",
-                crate::hash::DIGEST_BYTES,
-                buf.len()
-            )))
-        }
+        crate::hash::try_parse_digest(&buf).map_err(serde::de::Error::custom)
     }
 }

--- a/akd_local_auditor/src/storage/dynamodb/mod.rs
+++ b/akd_local_auditor/src/storage/dynamodb/mod.rs
@@ -178,17 +178,7 @@ impl DynamoDbAuditStorage {
     }
 
     fn convert_digest(data: &[u8]) -> Result<akd::Digest> {
-        if data.len() == akd::DIGEST_BYTES {
-            let mut v = [0u8; akd::DIGEST_BYTES];
-            v.copy_from_slice(data);
-            Ok(v)
-        } else {
-            Err(anyhow::anyhow!(
-                "Digest is not of correct size (expected {} != got {})",
-                akd::DIGEST_BYTES,
-                data.len()
-            ))
-        }
+        akd::hash::try_parse_digest(data).map_err(|msg| anyhow::anyhow!(msg))
     }
 
     fn parse_summary(


### PR DESCRIPTION
The test is executed with

```
cd akd_client
wasm-pack test --node --features wasm
```

which emits

```
$ wasm-pack test --node --features wasm
[INFO]: 🎯  Checking for the Wasm target...
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/seanlawlor/Code/slawlor_akd/akd_core/Cargo.toml
workspace: /Users/seanlawlor/Code/slawlor_akd/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/seanlawlor/Code/slawlor_akd/akd_client/Cargo.toml
workspace: /Users/seanlawlor/Code/slawlor_akd/Cargo.toml
   Compiling akd v0.8.0 (/Users/seanlawlor/Code/slawlor_akd/akd)
   Compiling akd_client v0.8.0 (/Users/seanlawlor/Code/slawlor_akd/akd_client)
    Finished dev [unoptimized + debuginfo] target(s) in 4.38s
[INFO]: ⬇️  Installing wasm-bindgen...
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/seanlawlor/Code/slawlor_akd/akd_core/Cargo.toml
workspace: /Users/seanlawlor/Code/slawlor_akd/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/seanlawlor/Code/slawlor_akd/akd_client/Cargo.toml
workspace: /Users/seanlawlor/Code/slawlor_akd/Cargo.toml
    Finished test [unoptimized + debuginfo] target(s) in 0.74s
     Running unittests src/lib.rs (/Users/seanlawlor/Code/slawlor_akd/target/wasm32-unknown-unknown/debug/deps/akd_client-3dfab7e06dc18fa8.wasm)
Set timeout to 20 seconds...
running 1 test                                    

test akd_client::wasm::tests::test_simple_wasm_lookup ... ok

test result: ok. 1 passed; 0 failed; 0 ignored
```

Additionally I took the opportunity to cleanup some of the usage around `Digest`s, a shared parsing function along with more common application of the `Digest` type alias rather than `[u8; DIGEST_BYTES]`.