### PR TITLE
Missed one version bump

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Need to put `akd` at v0.8.1 as well as all the other crates. Not the end of the world, but a proper release will fail.