### PR TITLE
Updating VRF label derivation, commitment generation, and switching to big-endian

### DIFF
--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -77,7 +77,7 @@ impl crate::storage::Storable for ValueState {
 
     fn get_full_binary_key_id(key: &ValueStateKey) -> Vec<u8> {
         let mut result = vec![StorageType::ValueState as u8];
-        result.extend_from_slice(&key.1.to_le_bytes());
+        result.extend_from_slice(&key.1.to_be_bytes());
         result.extend_from_slice(&key.0);
 
         result
@@ -93,7 +93,7 @@ impl crate::storage::Storable for ValueState {
         }
 
         let epoch_bytes: [u8; 8] = bin[1..=8].try_into().expect("Slice with incorrect length");
-        let epoch = u64::from_le_bytes(epoch_bytes);
+        let epoch = u64::from_be_bytes(epoch_bytes);
         Ok(ValueStateKey(bin[9..].to_vec(), epoch))
     }
 }

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -106,7 +106,7 @@ impl Storable for TreeNodeWithPreviousValue {
 
     fn get_full_binary_key_id(key: &NodeKey) -> Vec<u8> {
         let mut result = vec![StorageType::TreeNode as u8];
-        result.extend_from_slice(&key.0.label_len.to_le_bytes());
+        result.extend_from_slice(&key.0.label_len.to_be_bytes());
         result.extend_from_slice(&key.0.label_val);
         result
     }
@@ -122,7 +122,7 @@ impl Storable for TreeNodeWithPreviousValue {
 
         let len_bytes: [u8; 4] = bin[1..=4].try_into().expect("Slice with incorrect length");
         let val_bytes: [u8; 32] = bin[5..=36].try_into().expect("Slice with incorrect length");
-        let len = u32::from_le_bytes(len_bytes);
+        let len = u32::from_be_bytes(len_bytes);
 
         Ok(NodeKey(NodeLabel::new(val_bytes, len)))
     }
@@ -383,7 +383,7 @@ impl TreeNode {
         parent: NodeLabel,
         node_type: NodeType,
         birth_epoch: u64,
-        smallest_descendant_ep: u64,
+        min_descendant_epoch: u64,
         left_child: Option<NodeLabel>,
         right_child: Option<NodeLabel>,
         hash: crate::Digest,
@@ -391,7 +391,7 @@ impl TreeNode {
         let new_node = TreeNode {
             label,
             last_epoch: birth_epoch,
-            min_descendant_epoch: smallest_descendant_ep,
+            min_descendant_epoch,
             parent, // Root node is its own parent
             node_type,
             left_child,

--- a/akd_core/src/ecvrf/mod.rs
+++ b/akd_core/src/ecvrf/mod.rs
@@ -25,7 +25,7 @@
 mod ecvrf_impl;
 mod traits;
 // export the functionality we want visible
-pub use crate::ecvrf::ecvrf_impl::{Proof, VRFPrivateKey, VRFPublicKey};
+pub use crate::ecvrf::ecvrf_impl::{Output, Proof, VRFPrivateKey, VRFPublicKey};
 pub use crate::ecvrf::traits::VRFKeyStorage;
 #[cfg(feature = "nostd")]
 use alloc::boxed::Box;

--- a/akd_core/src/hash/mod.rs
+++ b/akd_core/src/hash/mod.rs
@@ -101,9 +101,7 @@ pub fn merge(items: &[Digest]) -> Digest {
 pub fn merge_with_int(digest: Digest, value: u64) -> Digest {
     let mut data = [0; DIGEST_BYTES + 8];
     data[..DIGEST_BYTES].copy_from_slice(&digest);
-    // this comes from winter_crypto::Hasher. We stick with little-endian bytes everywhere
-    // to avoid system-specific implementation headaches
-    data[DIGEST_BYTES..].copy_from_slice(&value.to_le_bytes());
+    data[DIGEST_BYTES..].copy_from_slice(&value.to_be_bytes());
     hash(&data)
 }
 

--- a/akd_core/src/hash/tests.rs
+++ b/akd_core/src/hash/tests.rs
@@ -112,7 +112,7 @@ fn test_merge_int_validity() {
     let random_hash = random_hash();
     let merged = merge_with_int(random_hash, random_epoch);
 
-    let data = vec![random_hash.to_vec(), random_epoch.to_le_bytes().to_vec()].concat();
+    let data = vec![random_hash.to_vec(), random_epoch.to_be_bytes().to_vec()].concat();
     let expected = hash(&data);
 
     assert_eq!(expected, merged);

--- a/akd_core/src/lib.rs
+++ b/akd_core/src/lib.rs
@@ -5,15 +5,60 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-//! Core utilities for the auditable-key-directory `akd` and `akd_client` crates.
+//! Core utilities for the auditable key directory `akd` and `akd_client` crates.
 //! Mainly contains (1) hashing utilities and (2) type definitions as well as (3)
 //! protobuf specifications for all external types
 //!
-//! The default configuration is to utilize the standard-library (`std`) along with
+//! The default configuration is to utilize the standard library (`std`) along with
 //! blake3 hashing (from the [blake3] crate). If you wish to customize which hash and
 //! which features are utilized, you can pass --no-default-features on the command line
 //! or `default-features = false` in your Cargo.toml import to disable all the default features
 //! which you can then enable one-by-one as you wish.
+//!
+//! # Incorporating label-value pairs into the tree
+//!
+//! When inserting a ([AkdLabel], [AkdValue]) pair into the tree, the server commits to the [AkdValue]
+//! and invokes a VRF on the [AkdLabel]. Together, these two processes form what is actually stored
+//! as a node in the tree.
+//!
+//! ## VRF on the [AkdLabel]
+//!
+//! The position in which this value lies is determined by the [NodeLabel], which is the output
+//! of a VRF evaluation of the [AkdLabel] and the current epoch. This is computed by the
+//! `get_hash_from_label_input` function, which sets the node label as:
+//! `node_label = H(label, stale, version)`
+//!
+//! Specifically, we concatenate the following together:
+//! - `I2OSP(len(label) as u64, label)`
+//! - A single byte encoded as `0u8` if "stale", `1u8` if "fresh"
+//! - A `u64` representing the version
+//! The resulting values are hashed together and used as the bytestring (truncated to 256 bits,
+//! if necessary) that determines the exact location of the node in the tree.
+//!
+//! In the event that the label already exists in the tree, an additional stale label will be
+//! added to the tree, with an empty value associated with it.
+//!
+//! ## Committing to an [AkdValue]
+//!
+//! The function [akd_core::commit_value] is used to commit the [AkdValue] to the tree. The actual value
+//! that is stored in the node is a commitment, generated as follows:
+//! - `proof = H(commitment_key, label, version, i2osp_array(value))`
+//! - `commmitment = H(i2osp_array(value), i2osp_array(value))`
+//!
+//! Finally, the commitment is hashed together with the epoch that it ends up being inserted into the tree
+//! computed as: `value_stored_in_node = H(commitment, epoch)`
+//!
+//! Here, `commitment_key` is a secret random value held by the server for the purposes of generating
+//! these commitments.
+//!
+//! A client can then verify that the value stored in the tree is the same as the value they are expecting
+//! upon requesting a [LookupProof] or [HistoryProof] which includes this commitment proof, and can then
+//! insert their expected value and verify that it matches the node's value (indirectly, through an inclusion
+//! proof in the Merkle tree). Note that without the commitment proof, a value cannot be verified, which
+//! is a privacy feature that prevents an auditor from learning the value of a node.
+//!
+//!
+//!
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/akd_core/src/types/node_label/tests.rs
+++ b/akd_core/src/types/node_label/tests.rs
@@ -38,7 +38,7 @@ fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
 // places the bits to the front of the output byte_array.
 fn byte_arr_from_u64_le(input_int: u64) -> [u8; 32] {
     let mut output_arr = [0u8; 32];
-    let input_arr = input_int.to_le_bytes();
+    let input_arr = input_int.to_be_bytes();
     output_arr[..8].clone_from_slice(&input_arr[..8]);
     output_arr
 }

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -7,8 +7,9 @@
 
 //! Verification of key history proofs
 
-use super::base::{hash_leaf_with_value, verify_membership, verify_nonmembership, verify_vrf};
+use super::base::{verify_label, verify_membership, verify_nonmembership};
 use super::VerificationError;
+use crate::utils::hash_leaf_with_value;
 
 use crate::hash::{hash, merge_with_int, Digest};
 use crate::{AkdLabel, HistoryProof, UpdateProof, VerifyResult};
@@ -110,7 +111,7 @@ pub fn key_history_verify(
         let pf = &proof.non_existence_of_next_few[i];
         let vrf_pf = &proof.next_few_vrf_proofs[i];
         let ver_label = pf.label;
-        verify_vrf(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
+        verify_label(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
         if verify_nonmembership(root_hash, pf).is_err() {
             return Err(VerificationError::HistoryProof(format!("Non-existence of next few proof of user {:?}'s version {:?} at epoch {:?} does not verify",
             &akd_key, ver, current_epoch)));
@@ -123,7 +124,7 @@ pub fn key_history_verify(
         let pf = &proof.non_existence_of_future_markers[i];
         let vrf_pf = &proof.future_marker_vrf_proofs[i];
         let ver_label = pf.label;
-        verify_vrf(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
+        verify_label(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
         if verify_nonmembership(root_hash, pf).is_err() {
             return Err(VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {:?}'s version {:?} at epoch {:?} does not verify",
             akd_key, ver, current_epoch)));
@@ -166,7 +167,7 @@ fn verify_single_update_proof(
 
     // ***** PART 1 ***************************
     // Verify the VRF and membership proof for the corresponding label for the version being updated to.
-    verify_vrf(
+    verify_label(
         vrf_public_key,
         uname,
         false,
@@ -211,7 +212,7 @@ fn verify_single_update_proof(
                     epoch
                 ))
             })?;
-        verify_vrf(
+        verify_label(
             vrf_public_key,
             uname,
             true,

--- a/akd_core/src/verify/lookup.rs
+++ b/akd_core/src/verify/lookup.rs
@@ -7,8 +7,9 @@
 
 //! Verification of lookup proofs
 
-use super::base::{hash_leaf_with_value, verify_membership, verify_nonmembership, verify_vrf};
+use super::base::{verify_label, verify_membership, verify_nonmembership};
 use super::VerificationError;
+use crate::utils::hash_leaf_with_value;
 
 use crate::hash::Digest;
 use crate::{AkdLabel, LookupProof, VerifyResult};
@@ -39,7 +40,7 @@ pub fn lookup_verify(
         ));
     }
 
-    verify_vrf(
+    verify_label(
         vrf_public_key,
         &akd_key,
         false,
@@ -50,7 +51,7 @@ pub fn lookup_verify(
     verify_membership(root_hash, &existence_proof)?;
 
     let marker_label = marker_proof.label;
-    verify_vrf(
+    verify_label(
         vrf_public_key,
         &akd_key,
         false,
@@ -62,7 +63,7 @@ pub fn lookup_verify(
     verify_membership(root_hash, &marker_proof)?;
 
     let stale_label = freshness_proof.label;
-    verify_vrf(
+    verify_label(
         vrf_public_key,
         &akd_key,
         true,

--- a/akd_core/src/verify/mod.rs
+++ b/akd_core/src/verify/mod.rs
@@ -87,6 +87,6 @@ impl From<protobuf::Error> for VerificationError {
 }
 
 // Re-export the necessary verification functions
-pub use base::{verify_membership, verify_nonmembership, verify_vrf};
+pub use base::{verify_membership, verify_nonmembership};
 pub use history::{key_history_verify, HistoryVerificationParams};
 pub use lookup::lookup_verify;

--- a/akd_local_auditor/src/auditor/mod.rs
+++ b/akd_local_auditor/src/auditor/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 pub(crate) const HISTORY_FILE: &str = ".akd_local_auditor_history";
 
 fn format_qr_record(p_hash: Digest, c_hash: Digest, epoch: u64) -> Vec<u8> {
-    let epoch_bytes = epoch.to_le_bytes();
+    let epoch_bytes = epoch.to_be_bytes();
     let header = "WA_AKD_VERIFY".as_bytes();
 
     let mut result = vec![];

--- a/akd_test_tools/src/fixture_generator/examples/test.yaml
+++ b/akd_test_tools/src/fixture_generator/examples/test.yaml
@@ -30,159 +30,21 @@ epoch: 9
 records:
   - TreeNode:
       label:
-        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 6
-      latest_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-          label_len: 256
-        right_child:
-          label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-          label_len: 256
-        hash: 1CFEA805E9297D1BA5E96CE89302117DD96FA3925A58E38FAFE51F7B79B872C0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
+        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
         label_len: 256
       latest_node:
         label:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
+          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
           label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
+        last_epoch: 8
+        min_descendant_epoch: 8
         parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: D9B37EE4BE20D1FE796132CB73F499161C05598BBB11246139084850ABB555B4
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 3
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        right_child:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        hash: 193370D46027EDCAB7D27D49836D1D4F396A5C23D503914905C045F99AEF9D96
-      previous_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-          label_len: 256
-        right_child:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        hash: 56EA8678967E4BF7B60E74A7DE34DB495BD028AEEFA9CF606D3FA54565E145D3
-  - TreeNode:
-      label:
-        label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4965C60BA6692B303F445315455FBE09D8EF670F296BD41FF61DBA46F238FE66
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 4
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: F51F1641F651EAE59E885C645CF1BF49F8F0796DE5D4939569DDCC23D12C3337
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 3
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: 01544164C4FA33BF543DC56B4A1467C3FDEF1084B45DE3289EAB2AC7962CFD6B
-  - TreeNode:
-      label:
-        label_val: B000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-          label_len: 256
-        right_child:
-          label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-          label_len: 256
-        hash: E812D737E3CA304C4A1227BC2B483C7DC8F7C1F608BC95DCDC55A7B574A77FBF
+        hash: 91333870F8E36C126D745D2213982DABA93D05FFA6A789A3E5D352A06E0E9802
       previous_node: ~
   - TreeNode:
       label:
@@ -192,7 +54,7 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 7
+        last_epoch: 8
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -204,12 +66,12 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: 96AEAEA01265A862E92008FE6ABBBC1C2BA62393C154B19FE25241E7A1D2BDBD
+        hash: 0FFA62E6F773C87A007B0951717F0561E1D24B650F02EDEB29116ACEB33D9881
       previous_node:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 6
+        last_epoch: 7
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -221,267 +83,102 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: A70601FA2217B2C0953A9BDD33A2D3D5EEA63DCDD328EA3EBF6E9D02D627955B
+        hash: A1B48E00088A713D56DB52395EB49F4FC96B76309CD73B9466F09188C3037177
   - TreeNode:
       label:
-        label_val: F280000000000000000000000000000000000000000000000000000000000000
-        label_len: 9
+        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+        label_len: 256
       latest_node:
         label:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        last_epoch: 6
-        min_descendant_epoch: 1
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
         parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-          label_len: 256
-        right_child:
-          label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-          label_len: 256
-        hash: ED4A79A449572B22A2E2F75616B277495891BF8CB05001E505DA015F37C3FAC7
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A0A1157A3AB3AA69FCD5801DB235D9FB497DFBA9A132808B03C6973CF6AB7785
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
+        label_val: BC00000000000000000000000000000000000000000000000000000000000000
+        label_len: 7
       latest_node:
         label:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
           label_val: A000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        last_epoch: 7
-        min_descendant_epoch: 4
+        node_type: Interior
+        left_child:
+          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_len: 256
+        right_child:
+          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_len: 256
+        hash: D080CBC9859CA85B928B8759C8DC851F29CB53E9EA743DFC49B03D29E549AB93
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 2
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 2
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        hash: C7857B59D0F2EA96F40E3E3A7BEC0007621FC20D152C449CDD3EBD5D4FD83889
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-        label_len: 256
-      latest_node:
-        label:
-          label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 023D7E75E63E5FD536D1EBC166A47133C93F0979655EBBD419A8ACD0AE93B4DE
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 05D40D75172FD2EECB751D26C92E315A333C46757A54744CD11F9B47CC9ECD7B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4E35E71975DCC503B75042F3B887FA64085CCC745E519562CF042861CFF74676
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 6B32C07DF7724177CFF1CFF2898B7F982038A2A81A60273077C2480158733CCB
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
+        right_child:
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+          label_len: 256
+        hash: A5E7345C592FEF7684D32AF8CF835BBBD5C81D1D5C44951314841FD695D19576
+      previous_node:
         label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
-        last_epoch: 4
-        min_descendant_epoch: 1
+        last_epoch: 3
+        min_descendant_epoch: 2
         parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         node_type: Interior
         left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
-          label_len: 256
-        hash: 59293ECD197F7D22A043424748671C951F6E5ADFCCA541CA32E3509B5774BC7C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-        label_len: 256
-      latest_node:
-        label:
-          label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 09D3ED5FB591AFDE8B82053D7C8B1B1BB5F58786642FA1D2AC6666643F1F4912
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-        label_len: 256
-      latest_node:
-        label:
-          label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4BD04CD75A7126140887A76684E7A68A1F176ACFF35A6F72366D12B67EC5E75A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 62A20A27E3A19C08A37D44E2023CFFEB3C808DF7BB506D6EDB175C198261531A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C800000000000000000000000000000000000000000000000000000000000000
-        label_len: 6
-      latest_node:
-        label:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-          label_len: 256
+          label_len: 3
         right_child:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
           label_len: 256
-        hash: E74A3EEC69F3C16DBBB755A1F0ADC12ABF0571FE185495842AD57A38B4843416
-      previous_node: ~
-  - Azks:
-      latest_epoch: 7
-      num_nodes: 33
+        hash: 5D013E217917C6C45180DE797A9E6517C3D5BE630BABA2C91979634BA5722F0A
   - TreeNode:
       label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
+        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_len: 256
       latest_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+          label_len: 256
         last_epoch: 7
         min_descendant_epoch: 7
         parent:
           label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-          label_len: 256
-        right_child:
-          label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-          label_len: 256
-        hash: 13454026938E1F32F440383D85019493A379B0991E4CEA1C46065CB8CEF5C567
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-          label_len: 256
-        right_child:
-          label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-          label_len: 256
-        hash: AA39462946DE4D47A30791E43856F9E3277CB36EB4B7952F3835F2F3C3B0F60C
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 2A21F859CDA67E1CE949D26C02FB96E53130CC2651E5E870ED2295981B9DEA28
       previous_node: ~
   - TreeNode:
       label:
@@ -491,6 +188,23 @@ records:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
+        last_epoch: 8
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        hash: 6220D51E9A01370B70D8001F1E17E84E987799C0FDBCBF43BEA259A76DF46B5D
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         last_epoch: 7
         min_descendant_epoch: 1
         parent:
@@ -498,29 +212,66 @@ records:
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: 20FCF1B33B8C44A13C1A21602640CB53016A874C124D17CCACB73D0528EA4D07
-      previous_node:
-        label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_len: 2
         right_child:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
-        hash: 1256B99C627EE889748FC29CF74C4862CD25653D742A29EE5AD1A87D84CC5DC5
+        hash: 898C614BFEEA925A0903BE1F1ACB811A6D764C93EF88670BEB41C5F5B01E2252
+  - TreeNode:
+      label:
+        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A7747125CDADCF6D82F0AF8B16D228FE0CD6309AB2E3297803553E430C8A6A3A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 97BA35C108C6A5746703C16C48BCA973C74A642F6B8BA7EEF13CD4D30476773B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+          label_len: 256
+        last_epoch: 8
+        min_descendant_epoch: 8
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: DF35FB0227096C62BEF6324132ED5FD9101F30BF0280C6738F0B2B62B8BF9FB7
+      previous_node: ~
   - TreeNode:
       label:
         label_val: "4000000000000000000000000000000000000000000000000000000000000000"
@@ -529,425 +280,722 @@ records:
         label:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 4
-        min_descendant_epoch: 1
+        last_epoch: 8
+        min_descendant_epoch: 2
         parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        hash: 2A9D53D189D4638FDD5F046FE5051269D7BB0E23C571E44238B07813611442F0
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
           label_len: 256
         right_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: 92DD6D27FD3167589DEAF55249C40746672254CE06A090F3BE9602B5C3535360
-      previous_node: ~
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        hash: 37941036C27A665B42BD3F556138417389D63835E164EE098A89B67340148B92
   - TreeNode:
       label:
-        label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
+        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
         label_len: 256
       latest_node:
         label:
-          label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
+          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0C46AF311EBE9FABB6DF86B89F2900DC218C5B07A08E57ED9083F1B9FCD8C03F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 7
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Interior
+        left_child:
+          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+          label_len: 256
+        right_child:
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_len: 256
+        hash: 945E6E7A5990D7992EB04420165607F5B4B71FDE6FB72C11D7B230A0CC9F285B
+      previous_node: ~
+  - Azks:
+      latest_epoch: 8
+      num_nodes: 33
+  - TreeNode:
+      label:
+        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+        label_len: 256
+      latest_node:
+        label:
+          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0344848820715FBA584363550A7985E90F0BE4ED78DE5FA68AAB644ADD94ECBC
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
           label_len: 256
         last_epoch: 4
         min_descendant_epoch: 4
         parent:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 35247A8BA087218C901494DB68BB5D84177A0335DAF37DCF2DFBC7F4C055AE01
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_len: 256
+        right_child:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_len: 256
+        hash: A135DFB278062C48F42A733D176FFB6CDB193EC404518709F016E91F24B69702
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+        label_len: 12
+      latest_node:
+        label:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+          label_len: 256
+        right_child:
+          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+          label_len: 256
+        hash: 4B2027CDC94B686B1B61DFFA957A95073330E23F290C8869DE2B7449FB736A43
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E1F60D50473A1AD2293391E0543A1015C717FB2B661E406BC9C8A61BBDBE5AA9
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: DE556607BACE40B761C58C2E34E46C242D7C654FFF4144B239697C44B3E09EEF
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: EAC034EEA7B30C3CE95C98174EB39437991E01E9D33569D4146C80D9942533C1
+  - TreeNode:
+      label:
+        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 083974703AFA5CDC8BA315E2FC5E313AD95BC4A8292BD1E73B970FA7FFDD78D3
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        hash: 2A8B5D0C04D0BB914AC4C2FFF348D6FA871BB20199402BFADEE11F31FA86B73E
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        hash: E9A9A8E1D9391657DA2BA15535E39C686E1DE6D77A805501445978ADBA30D492
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 8
+        min_descendant_epoch: 3
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+          label_len: 256
+        right_child:
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_len: 256
+        hash: 9A87F247FAD6ABCF8EA684353600CEC4F826D70774AB75599983140D17F712D5
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E9C6A4D21D14AB5EF044183DE7BBE975C3ECAC907618EEFCDAA31A702DAC6D0D
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 3
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+          label_len: 256
+        hash: 91EB319EC26483C9479E0B85042F3DCF7D63307789D231518A1684B679153853
+      previous_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_len: 256
+        right_child:
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+          label_len: 256
+        hash: C7C5344620F367264008899FBFEB08C6A6CC34B1A2593B452FA0A4AD6408F131
+  - TreeNode:
+      label:
+        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0E258B0275632E48B2BC369C4F11418E09CA594A140FEEE772489E70148A6E0F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 382DEDBE2B4BB962D14CF2C18257BD2F24020CA7619120172389D2571F728FA1
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 3
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        hash: 43EF361095C8F09953800B71DEEBBC94AEF1C6F15DEA739A7CDFB056C63BEAAE
+      previous_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        hash: 74FDF03A8EE8A6404634B5080289404BE489DDAB78807E291A2A34566895BBDB
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: D34E706699FC477D4DE6A1B7A9C4689CD5BDE231B50873B8E42B0537CEA9E080
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: D3062EBD4134A758A1F9C5CA213C3E50D23202AC297A1A634D1E67250C06D3DB
+  - TreeNode:
+      label:
+        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+        label_len: 256
+      latest_node:
+        label:
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 6E03127AFE3E84BE07F20F3A2819648D26BE281D53388700A044E5CD050A723C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 4
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+          label_len: 256
+        right_child:
+          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+          label_len: 256
+        hash: F5DE6EB21403DD6E329EE86E9D121B4BCF20DCE103A106F54B30843002F2DDC6
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        right_child:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        hash: 2DCFCD612B121357FAE09CA9E5AFB4B3660D8F29B4A429E3BCE59D4C8FB4D6A7
+      previous_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_len: 256
+        right_child:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        hash: 2C739CB97C2A75C278BFD5EDB143E566846663897A24F9F90082F4E692B11D3B
+  - TreeNode:
+      label:
+        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: C79E30BE6AEC3210EF956B6B1FDBA923B6645E26872871ED4CAD7D4CE290B62F
+        hash: 256F50289AD3F58A206554BE44599EB6D5EC0755D78112DA9229F6B928040315
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
+        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
         label_len: 256
       latest_node:
         label:
-          label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
+          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
           label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
+        last_epoch: 3
+        min_descendant_epoch: 3
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 20A29048C76E3276141D1F9284743DBF2B28DC124774BA4A3ED99A2C0B01E40C
+        hash: 53D076977493CDCFB6F28AEDFF691A8B395434E156BD7E7F591FE2175C7F4C88
       previous_node: ~
-  - TreeNode:
-      label:
-        label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D71FB6AC044B2137BC487EABC7BAAE517EEEC7AEE51C89C1E55FA44DE0ACBF91
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 070F36813A985B86132AE669B3B5C0426D5A88005C4AA97BB333599F1C5B1889
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 933D20F55547963937F4C14A1C6D8731155A77080C86725C2B7960889E490C4B
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-          label_len: 256
-        right_child:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        hash: 3D3870811F9C53EC09349013C4890720C6EB901D87DD021BA9F47F55FA621DE3
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-          label_len: 256
-        right_child:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-          label_len: 256
-        hash: 807F9360E0812DB65D55FB1A211C8C2B2D5AF86CB66F11A9F2B9EF5C7A6FD203
-  - TreeNode:
-      label:
-        label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 6402543118B537E38DC030D9DB9DA60C2ADE7E7266CF71470FD2DB31E4D3361E
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 5F0086AC1867BC1BB1EE616A384C9D6A623474225FCBC224CD8DD4CE93756AD1
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2514BA90E02330214680EB79F1B1133FAC9931CE3A60091C9DB252881A495F9B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-        label_len: 256
-      latest_node:
-        label:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 30EE22AE7DA3BE3BA8A351678FD54ED3B9B1F32303D45A34167A4880AD6FB442
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 192B7CEE4D9879DF97216279AE5A1BF1C7283BDEF6E7D5C0D29817E21DC6D0D1
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
-        right_child:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        hash: 2B7C39EAAA7158A1BF33C3F66D40FB40430F6BECDD956DF58B62EB2CB73EC56D
-      previous_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
-        right_child:
-          label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-          label_len: 256
-        hash: 729E8BA4CCB994A11367E2F51569513B8286C6BCC2DD4B3A545CD1164241549B
   - ValueState:
-      plaintext_val: 7534625A5454664A6675355344324C65656C4C7171724D69456C6F7473696F57
+      plaintext_val: 42344750444E534F4854376A45436D4A54767878744D4C65676F39324650746C
       version: 1
       label:
-        label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
+        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+        label_len: 256
+      epoch: 2
+      username: 55517664506A4730614A7A5157454751686A586B526876796248524B69794258
+  - ValueState:
+      plaintext_val: 49704C466B425841696557354D754A6A6C7A705879616C45756172724555536F
+      version: 1
+      label:
+        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
         label_len: 256
       epoch: 5
-      username: 6836564B5A677851795A735A6B6D6B676C5443584A3871344964386D6E645249
+      username: 586D717057716B557632527357385731557A66593941626A704E644B31673450
   - ValueState:
-      plaintext_val: 68493178524A53784C366C5367695A327679526F434E4F534C327A77456E7462
+      plaintext_val: 4D534B757678613669634B7033314968514E65576E414E6A6A53506D326D4D4C
       version: 1
       label:
-        label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-        label_len: 256
-      epoch: 7
-      username: 39464B53634E61386C6D6834366F5357634B43705862333765394E6D62564258
-  - ValueState:
-      plaintext_val: 396330475536424D503958544F683378586864335750666D705A623070504754
-      version: 1
-      label:
-        label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-        label_len: 256
-      epoch: 2
-      username: 51757472695952634A6C426D6E79435747484A53617155726F61744259333159
-  - ValueState:
-      plaintext_val: 386944556663446C32676E74647349575453434976556B73624448616438346E
-      version: 1
-      label:
-        label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-        label_len: 256
-      epoch: 2
-      username: 6549384F6A50387137734A5A30657741514D64484C6A496A7942746832456738
-  - ValueState:
-      plaintext_val: 546F7138573630506D76463338725849434B6775775237626C4A574C34483571
-      version: 1
-      label:
-        label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-        label_len: 256
-      epoch: 2
-      username: 344979487041524948684D79776B674A764D64794549624668726832634E6931
-  - ValueState:
-      plaintext_val: 5868356144347865595A6D79356543423751673268777361656A327A51346449
-      version: 1
-      label:
-        label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-        label_len: 256
-      epoch: 1
-      username: 747148394963656D34623839584F524876517073484A777675667768355A6E6F
-  - ValueState:
-      plaintext_val: 38637275327370345149465559717645766D4947674E66614D3135534F304466
-      version: 1
-      label:
-        label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
-        label_len: 256
-      epoch: 4
-      username: 44426F5775333163795A75616F4D723266613559644B3438664A69416662644C
-  - ValueState:
-      plaintext_val: 6845647A575A7266505059717859753261513834584C50547132706431543468
-      version: 1
-      label:
-        label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-        label_len: 256
-      epoch: 7
-      username: 6942304D436C55496846486C4E517351465875554863704C6C4D426C5032455A
-  - ValueState:
-      plaintext_val: 727A6534395135723357417050785033694861737A4E504D67336C3773436355
-      version: 1
-      label:
-        label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-        label_len: 256
-      epoch: 7
-      username: 797347686439575A3773434B736F53576C4E4F42466D7938385A566E6F466930
-  - ValueState:
-      plaintext_val: 30556833696D3778674642306F713731694B764A774F687961534D4C43594C6B
-      version: 1
-      label:
-        label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-        label_len: 256
-      epoch: 1
-      username: 58636E527556745276456D727537686D70693754635656765A51486C53615767
-  - ValueState:
-      plaintext_val: 6738787A6433716A714E44653041567171427378666E766B6A704C4433566442
-      version: 1
-      label:
-        label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-        label_len: 256
-      epoch: 4
-      username: 4C6C765759504B47674C62555061736F6B4C526E3450306B683943556753315A
-  - ValueState:
-      plaintext_val: 735A61425965336A49506461704E6D48574D386F6C7541715868413976503033
-      version: 1
-      label:
-        label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
+        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
         label_len: 256
       epoch: 6
-      username: 584170706B3057364A5074424A646C73364C55646F644D393678585A786B434A
+      username: 7070726833424262555374446E585637726D5047363734494B5A47304D694F5A
   - ValueState:
-      plaintext_val: 7A6E6A583257424874306E415941345356536A363544694D646F396A69337064
+      plaintext_val: 34774561314D3858566E525A456169777666395855454D4B6F365A6C50533270
       version: 1
       label:
-        label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-        label_len: 256
-      epoch: 3
-      username: 674D55687357645665657171414776484F515667494B6D614453486B4C53354E
-  - ValueState:
-      plaintext_val: 714D556D6B73415543424B38554742554B657033714454436C67386B46364579
-      version: 1
-      label:
-        label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-        label_len: 256
-      epoch: 1
-      username: 6C6861677A5470624F3746724B7A316937616E4C6D70317735536E5A75395174
-  - ValueState:
-      plaintext_val: 78556D6654434564624779565368304852724C5A763734477232387678394152
-      version: 1
-      label:
-        label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
+        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
         label_len: 256
       epoch: 2
-      username: 445A376E325A705357503173416B5941394377514A51784F527832734A76335A
+      username: 726841445830786372526F4A687345706F534D51747933467470617A3546474F
   - ValueState:
-      plaintext_val: 6F336148327052356B4B58786E506577676154767567564342716A3853647177
+      plaintext_val: 4761574D524C574D6C55537A424E674A52776148326E454C4C47413564673978
       version: 1
       label:
-        label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
+        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
         label_len: 256
       epoch: 4
-      username: 614A447369556A48546235486135536C594253714468684349416B36556E5470
+      username: 545466663742364335306C786765544B4369474C4F6165464D44536844673441
   - ValueState:
-      plaintext_val: 4C434E5674773642374970466F354368776B716A364761525A46466639666A30
+      plaintext_val: 6C697673455138444D667A7863736C467352576A4C3067476342304172774454
       version: 1
       label:
-        label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
+        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
         label_len: 256
       epoch: 1
-      username: 427A58624B656842414F4A4F51325968664B71506A596B44727746525A383735
+      username: 624338356F6E6F61484453796C736E74334164505261706273526B4D3777326C
+  - ValueState:
+      plaintext_val: 783155426571613935596C796C676168413469517A64763134476347786A5356
+      version: 1
+      label:
+        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_len: 256
+      epoch: 7
+      username: 6678366A556C5531453541764435776A35704A507458326D5947556837453068
+  - ValueState:
+      plaintext_val: 41374C4B754C36765542655734314C4D6B716876634C3179386D6C426F723677
+      version: 1
+      label:
+        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_len: 256
+      epoch: 2
+      username: 56457073444B77396A53474435586C4B763638496744486B6E4A6543634F4B76
+  - ValueState:
+      plaintext_val: 7957653067616F4B614953304D516A7A534232546C524A696E4962693433426C
+      version: 1
+      label:
+        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_len: 256
+      epoch: 5
+      username: 46764436754C6B5A396E6E736130767636376C526A7438635646444534646764
+  - ValueState:
+      plaintext_val: 347A5A7A574D5570577A544243435945525838586B7044383968657471696549
+      version: 1
+      label:
+        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_len: 256
+      epoch: 8
+      username: 7751594252516B344A6932574C44426668584F59794F66697A7466676A7A6B4E
+  - ValueState:
+      plaintext_val: 3367684738576768634751743077596930706A63717562616C73417647696833
+      version: 1
+      label:
+        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_len: 256
+      epoch: 2
+      username: 4B774938737A52433142336E6A4738717A316C4478386E417069706759743168
+  - ValueState:
+      plaintext_val: 4D52314D4837334C5155537A74786878644D66526D674E5A3578374C51326978
+      version: 1
+      label:
+        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+        label_len: 256
+      epoch: 3
+      username: 68395176724C6D3332554F56666170726E514B474F6E4E7438636B467353496F
+  - ValueState:
+      plaintext_val: 656235414C4E4B4842597158456D4A534D41636E3166626D5176764E54594E48
+      version: 1
+      label:
+        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+        label_len: 256
+      epoch: 3
+      username: 4C664A47346B6D53384C3649596B72384D72694B437242706166763156437344
+  - ValueState:
+      plaintext_val: 6377416B507A596457303749475861777836784A666D6131726C6F5536757A4C
+      version: 1
+      label:
+        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+        label_len: 256
+      epoch: 3
+      username: 684D576675334B70514F437976624B4E5970524A387A4C65326B493432504333
+  - ValueState:
+      plaintext_val: 613665687856434C676D71467968496647714A774D627372555374614F6A3067
+      version: 1
+      label:
+        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+        label_len: 256
+      epoch: 5
+      username: 776F634C31724D4F416D38427A62714877314D39356D477165484D4947363234
+  - ValueState:
+      plaintext_val: 55624C6B4E657A596F567A39666E336642314C33687058634C4C6262394C7170
+      version: 1
+      label:
+        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+        label_len: 256
+      epoch: 8
+      username: 69755A6439507A7765335A6D706E4C775845586D6E4F6A6A6638376F45355349
+  - ValueState:
+      plaintext_val: 5578575A3271344446395A634C784A326C655A326567416649365331714D4D71
+      version: 1
+      label:
+        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+        label_len: 256
+      epoch: 3
+      username: 79683875496769737A7652446B4458444F44466868776256456568336A304336
 
 # Delta - Epoch 10
 ---
 epoch: 10
 updates:
-  - - 674F456C5269684641645132454437304E77463646446D4F335869694C707A61
-    - 696D48506E6A324438457A4D63336C467757784E7A3576774858326266357866
-  - - 37347039794E52673763464C43596B534B794430374F3670496D5630444A754F
-    - 574B70667644374B417144796F6851754D36745A306F4434314763454B756D4A
-  - - 5535524E4B4C76364548624C457376593042486766613148505239563344516E
-    - 4B3148776466786C687241526E704C575848706B724246343273657379375870
+  - - 6E59524366344A6964527858524670583856443559546C4B53656C6970646C6D
+    - 3578337577576B43714552793870516651765936365567754C516A737236494B
+  - - 7836686A53706C424C4C6168464F376C763842793059646E396B565154514736
+    - 4A516536366F62656F39673634565675694F53744F31675530643476464D4878
+  - - 6D647566747756424A316D5A49786E424A313932387351325641564B61577354
+    - 637649764141505443463471705A5141775A6C454E795037646A4562544B4656
 
 # State - Epoch 10
 ---
@@ -955,159 +1003,21 @@ epoch: 10
 records:
   - TreeNode:
       label:
-        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 6
-      latest_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-          label_len: 256
-        right_child:
-          label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-          label_len: 256
-        hash: 1CFEA805E9297D1BA5E96CE89302117DD96FA3925A58E38FAFE51F7B79B872C0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
+        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
         label_len: 256
       latest_node:
         label:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
+          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
           label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D9B37EE4BE20D1FE796132CB73F499161C05598BBB11246139084850ABB555B4
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 3
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        right_child:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        hash: 193370D46027EDCAB7D27D49836D1D4F396A5C23D503914905C045F99AEF9D96
-      previous_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-          label_len: 256
-        right_child:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        hash: 56EA8678967E4BF7B60E74A7DE34DB495BD028AEEFA9CF606D3FA54565E145D3
-  - TreeNode:
-      label:
-        label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4965C60BA6692B303F445315455FBE09D8EF670F296BD41FF61DBA46F238FE66
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
         last_epoch: 8
-        min_descendant_epoch: 1
+        min_descendant_epoch: 8
         parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: E81C6C4A521526AE048D3E9072A912CE61FC6C6D6E6AEE034A5D9DE029C50A0E
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 4
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: F51F1641F651EAE59E885C645CF1BF49F8F0796DE5D4939569DDCC23D12C3337
-  - TreeNode:
-      label:
-        label_val: B000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-          label_len: 256
-        right_child:
-          label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-          label_len: 256
-        hash: E812D737E3CA304C4A1227BC2B483C7DC8F7C1F608BC95DCDC55A7B574A77FBF
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 91333870F8E36C126D745D2213982DABA93D05FFA6A789A3E5D352A06E0E9802
       previous_node: ~
   - TreeNode:
       label:
@@ -1117,7 +1027,7 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 8
+        last_epoch: 9
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1129,12 +1039,12 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: 5AFA28D189A083EF74DB61AD57E76313C0FB01CA53EF295EC63D81366223F699
+        hash: C862A67D365FE324F16C99DDCB27D3D4A70360A9D6290DB96FDF42DDD066600B
       previous_node:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 7
+        last_epoch: 8
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1146,345 +1056,102 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: 96AEAEA01265A862E92008FE6ABBBC1C2BA62393C154B19FE25241E7A1D2BDBD
+        hash: 0FFA62E6F773C87A007B0951717F0561E1D24B650F02EDEB29116ACEB33D9881
   - TreeNode:
       label:
-        label_val: F280000000000000000000000000000000000000000000000000000000000000
-        label_len: 9
-      latest_node:
-        label:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: F000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-          label_len: 256
-        right_child:
-          label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-          label_len: 256
-        hash: ED4A79A449572B22A2E2F75616B277495891BF8CB05001E505DA015F37C3FAC7
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 7
-        min_descendant_epoch: 4
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        hash: C7857B59D0F2EA96F40E3E3A7BEC0007621FC20D152C449CDD3EBD5D4FD83889
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 4
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
-          label_len: 256
-        right_child:
-          label_val: 734AF7DE4E0C80CEA7CAB491467B743064C0C85B2B81CB9FF9B76093D4B3A525
-          label_len: 256
-        hash: 7E5CB2FBFC8AAAEA7A91CF7DC4FC1445A2EFA4C432D7FD1EED5A5619BC682862
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
+        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
         label_len: 256
       latest_node:
         label:
-          label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
           label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 023D7E75E63E5FD536D1EBC166A47133C93F0979655EBBD419A8ACD0AE93B4DE
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 05D40D75172FD2EECB751D26C92E315A333C46757A54744CD11F9B47CC9ECD7B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4E35E71975DCC503B75042F3B887FA64085CCC745E519562CF042861CFF74676
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 734AF7DE4E0C80CEA7CAB491467B743064C0C85B2B81CB9FF9B76093D4B3A525
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 734AF7DE4E0C80CEA7CAB491467B743064C0C85B2B81CB9FF9B76093D4B3A525
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 99505E38ACEA043141890FC62F3EEF7A4742318DB1AFA37B014669DA96EC8C85
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
+        last_epoch: 3
+        min_descendant_epoch: 3
         parent:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 6B32C07DF7724177CFF1CFF2898B7F982038A2A81A60273077C2480158733CCB
+        hash: A0A1157A3AB3AA69FCD5801DB235D9FB497DFBA9A132808B03C6973CF6AB7785
       previous_node: ~
   - TreeNode:
       label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_val: BC00000000000000000000000000000000000000000000000000000000000000
+        label_len: 7
+      latest_node:
+        label:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_len: 256
+        right_child:
+          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_len: 256
+        hash: D080CBC9859CA85B928B8759C8DC851F29CB53E9EA743DFC49B03D29E549AB93
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
         label_len: 2
       latest_node:
         label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        hash: CE190DB3E8BBDBDEC0D46EBF1061B013E836BAFC7B3F70723E83B0B723AFC6C7
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 4
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
-          label_len: 256
-        hash: 59293ECD197F7D22A043424748671C951F6E5ADFCCA541CA32E3509B5774BC7C
-  - TreeNode:
-      label:
-        label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-        label_len: 256
-      latest_node:
-        label:
-          label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 09D3ED5FB591AFDE8B82053D7C8B1B1BB5F58786642FA1D2AC6666643F1F4912
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-        label_len: 256
-      latest_node:
-        label:
-          label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: B000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 4BD04CD75A7126140887A76684E7A68A1F176ACFF35A6F72366D12B67EC5E75A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 62A20A27E3A19C08A37D44E2023CFFEB3C808DF7BB506D6EDB175C198261531A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C800000000000000000000000000000000000000000000000000000000000000
-        label_len: 6
-      latest_node:
-        label:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_len: 2
+        last_epoch: 9
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         node_type: Interior
         left_child:
-          label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-          label_len: 256
-        right_child:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-          label_len: 256
-        hash: E74A3EEC69F3C16DBBB755A1F0ADC12ABF0571FE185495842AD57A38B4843416
-      previous_node: ~
-  - Azks:
-      latest_epoch: 8
-      num_nodes: 39
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-          label_len: 256
         right_child:
-          label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-          label_len: 256
-        hash: 13454026938E1F32F440383D85019493A379B0991E4CEA1C46065CB8CEF5C567
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: F000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: F000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
+        hash: AE4AD159212364E13BD80F8CEAD63919518BD0480FE4CB433161D6B400391E7E
+      previous_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         node_type: Interior
         left_child:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
         right_child:
-          label_val: FDB4D2F054694710CC853393FDAC2261D7622517A21473B034188FC5EC0C49EB
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
           label_len: 256
-        hash: FBCCE2669AD6AB5350D1C59087CFBE590951B2A5EC2E1297FB09E32361F9C88C
-      previous_node: ~
+        hash: A5E7345C592FEF7684D32AF8CF835BBBD5C81D1D5C44951314841FD695D19576
   - TreeNode:
       label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
+        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_len: 256
       latest_node:
         label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 2
-        min_descendant_epoch: 1
+          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
         parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-          label_len: 256
-        right_child:
-          label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-          label_len: 256
-        hash: AA39462946DE4D47A30791E43856F9E3277CB36EB4B7952F3835F2F3C3B0F60C
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 2A21F859CDA67E1CE949D26C02FB96E53130CC2651E5E870ED2295981B9DEA28
       previous_node: ~
   - TreeNode:
       label:
@@ -1494,57 +1161,125 @@ records:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 8
+        last_epoch: 9
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         right_child:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
-        hash: 230F4C2E860AB08947A23C503BA3F088C582C5C6A88A9F8AC133BBB34E5DA1FB
+        hash: D449546D65DCAAC51E279FA28DEB36A966546252F4C0880E4F8D4093CFAEBE88
       previous_node:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 7
+        last_epoch: 8
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         right_child:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
-        hash: 20FCF1B33B8C44A13C1A21602640CB53016A874C124D17CCACB73D0528EA4D07
+        hash: 6220D51E9A01370B70D8001F1E17E84E987799C0FDBCBF43BEA259A76DF46B5D
   - TreeNode:
       label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
+        label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
+        label_len: 256
       latest_node:
         label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 2FFECB58A39A4A90F3FE224AE5A60B89ED94698B445E701B9EC466F4929260EF
+          label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
           label_len: 256
-        hash: B94B63AC295553033A625A11724E53A60617CD42C79408DB09EC32A5E60A3897
+        last_epoch: 9
+        min_descendant_epoch: 9
+        parent:
+          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: B7C5698A8031FC155341F662C7DFFD074F1B679850C60E8CF8CF24A0CAD7CB15
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A7747125CDADCF6D82F0AF8B16D228FE0CD6309AB2E3297803553E430C8A6A3A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 97BA35C108C6A5746703C16C48BCA973C74A642F6B8BA7EEF13CD4D30476773B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+          label_len: 256
+        last_epoch: 8
+        min_descendant_epoch: 8
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: DF35FB0227096C62BEF6324132ED5FD9101F30BF0280C6738F0B2B62B8BF9FB7
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
+          label_len: 256
+        last_epoch: 9
+        min_descendant_epoch: 9
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 22167C3002782912AD5A26063509687AFA1ED304F7AFD406FFEE12548E3A29DA
       previous_node: ~
   - TreeNode:
       label:
@@ -1554,275 +1289,634 @@ records:
         label:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 4
-        min_descendant_epoch: 1
+        last_epoch: 9
+        min_descendant_epoch: 2
         parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
-          label_len: 256
-        right_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        hash: 92DD6D27FD3167589DEAF55249C40746672254CE06A090F3BE9602B5C3535360
-      previous_node: ~
+        right_child:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        hash: BB714707BEF8543A4EF4B8A7A71940C1C4D4701A88DCB3A7ED90265210736BF0
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        hash: 2A9D53D189D4638FDD5F046FE5051269D7BB0E23C571E44238B07813611442F0
   - TreeNode:
       label:
-        label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
+        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
         label_len: 256
       latest_node:
         label:
-          label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
+          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0C46AF311EBE9FABB6DF86B89F2900DC218C5B07A08E57ED9083F1B9FCD8C03F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 7
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Interior
+        left_child:
+          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+          label_len: 256
+        right_child:
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_len: 256
+        hash: 945E6E7A5990D7992EB04420165607F5B4B71FDE6FB72C11D7B230A0CC9F285B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
+        label_len: 256
+      latest_node:
+        label:
+          label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
+          label_len: 256
+        last_epoch: 9
+        min_descendant_epoch: 9
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: DB61B5882BB06338E6116983EC0C0F87830E5C190C595247233F3FDF86EC704E
+      previous_node: ~
+  - Azks:
+      latest_epoch: 9
+      num_nodes: 39
+  - TreeNode:
+      label:
+        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+        label_len: 256
+      latest_node:
+        label:
+          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0344848820715FBA584363550A7985E90F0BE4ED78DE5FA68AAB644ADD94ECBC
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
           label_len: 256
         last_epoch: 4
         min_descendant_epoch: 4
         parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: C79E30BE6AEC3210EF956B6B1FDBA923B6645E26872871ED4CAD7D4CE290B62F
+        hash: 35247A8BA087218C901494DB68BB5D84177A0335DAF37DCF2DFBC7F4C055AE01
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 20A29048C76E3276141D1F9284743DBF2B28DC124774BA4A3ED99A2C0B01E40C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D71FB6AC044B2137BC487EABC7BAAE517EEEC7AEE51C89C1E55FA44DE0ACBF91
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 2FFECB58A39A4A90F3FE224AE5A60B89ED94698B445E701B9EC466F4929260EF
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 2FFECB58A39A4A90F3FE224AE5A60B89ED94698B445E701B9EC466F4929260EF
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: C985DABEAA9973E47EAFFE4C6087D72FE299641D044B3A07B885069EEA584235
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: FDB4D2F054694710CC853393FDAC2261D7622517A21473B034188FC5EC0C49EB
-        label_len: 256
-      latest_node:
-        label:
-          label_val: FDB4D2F054694710CC853393FDAC2261D7622517A21473B034188FC5EC0C49EB
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: F000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D7367242B28FF821B26FF1B4D9B309F7BABAAEC8C0871F0DE96C0B13ED507284
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 8BDFF188624AE9859F9C931909DF08AC5DC00BA1453836E07BDBA3A780523223
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 070F36813A985B86132AE669B3B5C0426D5A88005C4AA97BB333599F1C5B1889
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
         label_len: 4
       latest_node:
         label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
-        last_epoch: 7
-        min_descendant_epoch: 1
+        last_epoch: 9
+        min_descendant_epoch: 9
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
         node_type: Interior
         left_child:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
+          label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
           label_len: 256
         right_child:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        hash: 3D3870811F9C53EC09349013C4890720C6EB901D87DD021BA9F47F55FA621DE3
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 2
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
+          label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
           label_len: 256
-        right_child:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-          label_len: 256
-        hash: 807F9360E0812DB65D55FB1A211C8C2B2D5AF86CB66F11A9F2B9EF5C7A6FD203
+        hash: F0A628E8521641D247042E3E9401D290FF4682949843958D4AF33A586AA55754
+      previous_node: ~
   - TreeNode:
       label:
-        label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 9
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_len: 256
+        right_child:
+          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        hash: 0FB699E98FF34BA422637D6A0F34F7280D4815AA4EC5D0500F9BA9EBD44A55CA
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_len: 256
+        right_child:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_len: 256
+        hash: A135DFB278062C48F42A733D176FFB6CDB193EC404518709F016E91F24B69702
+  - TreeNode:
+      label:
+        label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+        label_len: 12
+      latest_node:
+        label:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+          label_len: 256
+        right_child:
+          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+          label_len: 256
+        hash: 4B2027CDC94B686B1B61DFFA957A95073330E23F290C8869DE2B7449FB736A43
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
         label_len: 256
       latest_node:
         label:
-          label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
           label_len: 256
         last_epoch: 2
         min_descendant_epoch: 2
         parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 6402543118B537E38DC030D9DB9DA60C2ADE7E7266CF71470FD2DB31E4D3361E
+        hash: E1F60D50473A1AD2293391E0543A1015C717FB2B661E406BC9C8A61BBDBE5AA9
       previous_node: ~
   - TreeNode:
       label:
-        label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-        label_len: 256
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
       latest_node:
         label:
-          label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-          label_len: 256
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         last_epoch: 7
-        min_descendant_epoch: 7
+        min_descendant_epoch: 1
         parent:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 5F0086AC1867BC1BB1EE616A384C9D6A623474225FCBC224CD8DD4CE93756AD1
-      previous_node: ~
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: DE556607BACE40B761C58C2E34E46C242D7C654FFF4144B239697C44B3E09EEF
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: EAC034EEA7B30C3CE95C98174EB39437991E01E9D33569D4146C80D9942533C1
   - TreeNode:
       label:
-        label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
+        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
         label_len: 256
       latest_node:
         label:
-          label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
           label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 083974703AFA5CDC8BA315E2FC5E313AD95BC4A8292BD1E73B970FA7FFDD78D3
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 9
+        min_descendant_epoch: 2
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        hash: 28409C715FF6DA78A681A933A0712F2581B5BCAD121568412CEED15D58E4629E
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        hash: 2A8B5D0C04D0BB914AC4C2FFF348D6FA871BB20199402BFADEE11F31FA86B73E
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 8
+        min_descendant_epoch: 3
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+          label_len: 256
+        right_child:
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_len: 256
+        hash: 9A87F247FAD6ABCF8EA684353600CEC4F826D70774AB75599983140D17F712D5
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E9C6A4D21D14AB5EF044183DE7BBE975C3ECAC907618EEFCDAA31A702DAC6D0D
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 3
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+          label_len: 256
+        hash: 91EB319EC26483C9479E0B85042F3DCF7D63307789D231518A1684B679153853
+      previous_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_len: 256
+        right_child:
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+          label_len: 256
+        hash: C7C5344620F367264008899FBFEB08C6A6CC34B1A2593B452FA0A4AD6408F131
+  - TreeNode:
+      label:
+        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0E258B0275632E48B2BC369C4F11418E09CA594A140FEEE772489E70148A6E0F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 2514BA90E02330214680EB79F1B1133FAC9931CE3A60091C9DB252881A495F9B
+        hash: 382DEDBE2B4BB962D14CF2C18257BD2F24020CA7619120172389D2571F728FA1
       previous_node: ~
   - TreeNode:
       label:
-        label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 3
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        hash: 43EF361095C8F09953800B71DEEBBC94AEF1C6F15DEA739A7CDFB056C63BEAAE
+      previous_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: BC00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        hash: 74FDF03A8EE8A6404634B5080289404BE489DDAB78807E291A2A34566895BBDB
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 9
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: ED022A51B65946B1072EC9E7C62B20D7C04999EB3F23532C9FD2B6404FBA8967
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 8
+        min_descendant_epoch: 2
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: D34E706699FC477D4DE6A1B7A9C4689CD5BDE231B50873B8E42B0537CEA9E080
+  - TreeNode:
+      label:
+        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
         label_len: 256
       latest_node:
         label:
-          label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
+          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
           label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
+        last_epoch: 2
+        min_descendant_epoch: 2
         parent:
-          label_val: C800000000000000000000000000000000000000000000000000000000000000
-          label_len: 6
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 30EE22AE7DA3BE3BA8A351678FD54ED3B9B1F32303D45A34167A4880AD6FB442
+        hash: 6E03127AFE3E84BE07F20F3A2819648D26BE281D53388700A044E5CD050A723C
       previous_node: ~
   - TreeNode:
       label:
-        label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-        label_len: 256
+        label_val: 4A00000000000000000000000000000000000000000000000000000000000000
+        label_len: 7
       latest_node:
         label:
-          label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
+          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        last_epoch: 9
+        min_descendant_epoch: 2
         parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_len: 256
+        right_child:
+          label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
+          label_len: 256
+        hash: 63B5D47D23DDB75861744C745FF3D26139560910B6B85BE143E2166DBDB0BE11
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 4
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+          label_len: 256
+        right_child:
+          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+          label_len: 256
+        hash: F5DE6EB21403DD6E329EE86E9D121B4BCF20DCE103A106F54B30843002F2DDC6
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 7
+        right_child:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        hash: 2DCFCD612B121357FAE09CA9E5AFB4B3660D8F29B4A429E3BCE59D4C8FB4D6A7
+      previous_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_len: 256
+        right_child:
+          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_len: 256
+        hash: 2C739CB97C2A75C278BFD5EDB143E566846663897A24F9F90082F4E692B11D3B
+  - TreeNode:
+      label:
+        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 192B7CEE4D9879DF97216279AE5A1BF1C7283BDEF6E7D5C0D29817E21DC6D0D1
+        hash: 256F50289AD3F58A206554BE44599EB6D5EC0755D78112DA9229F6B928040315
       previous_node: ~
   - TreeNode:
       label:
@@ -1832,193 +1926,195 @@ records:
         label:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 1
+        last_epoch: 9
+        min_descendant_epoch: 3
         parent:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
-        right_child:
-          label_val: F000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        hash: 2FE148C851C3888269BBC0933B82E1F170ECDC7EF3E271262770423F8C6182EA
-      previous_node:
-        label:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-          label_len: 256
+          label_len: 4
         right_child:
-          label_val: F280000000000000000000000000000000000000000000000000000000000000
-          label_len: 9
-        hash: 2B7C39EAAA7158A1BF33C3F66D40FB40430F6BECDD956DF58B62EB2CB73EC56D
-  - ValueState:
-      plaintext_val: 696D48506E6A324438457A4D63336C467757784E7A3576774858326266357866
-      version: 1
+          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+          label_len: 256
+        hash: 4E62B2C65687E6EE1E7FD17F51F8FFCA283FFD9437F7F30F00EDB167715FE92B
+      previous_node: ~
+  - TreeNode:
       label:
-        label_val: FDB4D2F054694710CC853393FDAC2261D7622517A21473B034188FC5EC0C49EB
+        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
         label_len: 256
-      epoch: 8
-      username: 674F456C5269684641645132454437304E77463646446D4F335869694C707A61
+      latest_node:
+        label:
+          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
+          label_len: 12
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 53D076977493CDCFB6F28AEDFF691A8B395434E156BD7E7F591FE2175C7F4C88
+      previous_node: ~
   - ValueState:
-      plaintext_val: 7534625A5454664A6675355344324C65656C4C7171724D69456C6F7473696F57
+      plaintext_val: 637649764141505443463471705A5141775A6C454E795037646A4562544B4656
       version: 1
       label:
-        label_val: B195261A34094CD4A2195A4853BC5D88EA046474931E0012FDEA0C4E71F12A35
+        label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
+        label_len: 256
+      epoch: 9
+      username: 6D647566747756424A316D5A49786E424A313932387351325641564B61577354
+  - ValueState:
+      plaintext_val: 3578337577576B43714552793870516651765936365567754C516A737236494B
+      version: 1
+      label:
+        label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
+        label_len: 256
+      epoch: 9
+      username: 6E59524366344A6964527858524670583856443559546C4B53656C6970646C6D
+  - ValueState:
+      plaintext_val: 42344750444E534F4854376A45436D4A54767878744D4C65676F39324650746C
+      version: 1
+      label:
+        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
+        label_len: 256
+      epoch: 2
+      username: 55517664506A4730614A7A5157454751686A586B526876796248524B69794258
+  - ValueState:
+      plaintext_val: 49704C466B425841696557354D754A6A6C7A705879616C45756172724555536F
+      version: 1
+      label:
+        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
         label_len: 256
       epoch: 5
-      username: 6836564B5A677851795A735A6B6D6B676C5443584A3871344964386D6E645249
+      username: 586D717057716B557632527357385731557A66593941626A704E644B31673450
   - ValueState:
-      plaintext_val: 68493178524A53784C366C5367695A327679526F434E4F534C327A77456E7462
+      plaintext_val: 4D534B757678613669634B7033314968514E65576E414E6A6A53506D326D4D4C
       version: 1
       label:
-        label_val: A257B89FDA6C925A643E334E201CB81F3A55663C5BD837EE0F889D630DDE946D
-        label_len: 256
-      epoch: 7
-      username: 39464B53634E61386C6D6834366F5357634B43705862333765394E6D62564258
-  - ValueState:
-      plaintext_val: 396330475536424D503958544F683378586864335750666D705A623070504754
-      version: 1
-      label:
-        label_val: 500C9D0D838BFAA79F0E874A177E3B3338B8C56C4C36605256052F9AD8D1CF22
-        label_len: 256
-      epoch: 2
-      username: 51757472695952634A6C426D6E79435747484A53617155726F61744259333159
-  - ValueState:
-      plaintext_val: 386944556663446C32676E74647349575453434976556B73624448616438346E
-      version: 1
-      label:
-        label_val: 1402CB61CF85C57FED964A9E09DBA4855B31A850538149AC0DF7FB6F4390A98B
-        label_len: 256
-      epoch: 2
-      username: 6549384F6A50387137734A5A30657741514D64484C6A496A7942746832456738
-  - ValueState:
-      plaintext_val: 546F7138573630506D76463338725849434B6775775237626C4A574C34483571
-      version: 1
-      label:
-        label_val: E4215CE7FA331160BFA366F93C1B45CA53C40E587ECA638E6ACF72AB28698DCB
-        label_len: 256
-      epoch: 2
-      username: 344979487041524948684D79776B674A764D64794549624668726832634E6931
-  - ValueState:
-      plaintext_val: 5868356144347865595A6D79356543423751673268777361656A327A51346449
-      version: 1
-      label:
-        label_val: CB7E7BABBAFCF689F9632519E8F46FA8E19F9EE3F51588D72FB5BF5D0A7E2F3A
-        label_len: 256
-      epoch: 1
-      username: 747148394963656D34623839584F524876517073484A777675667768355A6E6F
-  - ValueState:
-      plaintext_val: 38637275327370345149465559717645766D4947674E66614D3135534F304466
-      version: 1
-      label:
-        label_val: 6AD6541CAD4BEF690EDBAD5D14CE2E54EF1C55188595F8318CA0790240D31E9A
-        label_len: 256
-      epoch: 4
-      username: 44426F5775333163795A75616F4D723266613559644B3438664A69416662644C
-  - ValueState:
-      plaintext_val: 6845647A575A7266505059717859753261513834584C50547132706431543468
-      version: 1
-      label:
-        label_val: C9BD9D7CDE94DEFFF32E5793121F3807840106B234A420988FAA324FF52C3F9F
-        label_len: 256
-      epoch: 7
-      username: 6942304D436C55496846486C4E517351465875554863704C6C4D426C5032455A
-  - ValueState:
-      plaintext_val: 574B70667644374B417144796F6851754D36745A306F4434314763454B756D4A
-      version: 1
-      label:
-        label_val: 734AF7DE4E0C80CEA7CAB491467B743064C0C85B2B81CB9FF9B76093D4B3A525
-        label_len: 256
-      epoch: 8
-      username: 37347039794E52673763464C43596B534B794430374F3670496D5630444A754F
-  - ValueState:
-      plaintext_val: 727A6534395135723357417050785033694861737A4E504D67336C3773436355
-      version: 1
-      label:
-        label_val: AF979E382CE6CE86E73AEC69F36C09BE263ACBD3B2D448946D0DB34FF76369BF
-        label_len: 256
-      epoch: 7
-      username: 797347686439575A3773434B736F53576C4E4F42466D7938385A566E6F466930
-  - ValueState:
-      plaintext_val: 30556833696D3778674642306F713731694B764A774F687961534D4C43594C6B
-      version: 1
-      label:
-        label_val: 02E33C27A4183EA318BB1E2683B9286B04BE1CE861112C35B930973F544F3B71
-        label_len: 256
-      epoch: 1
-      username: 58636E527556745276456D727537686D70693754635656765A51486C53615767
-  - ValueState:
-      plaintext_val: 6738787A6433716A714E44653041567171427378666E766B6A704C4433566442
-      version: 1
-      label:
-        label_val: BA1A1423C4F6734004EB17EC6FA956E6430EA7BBF7D4782E847917ADC9E229FB
-        label_len: 256
-      epoch: 4
-      username: 4C6C765759504B47674C62555061736F6B4C526E3450306B683943556753315A
-  - ValueState:
-      plaintext_val: 4B3148776466786C687241526E704C575848706B724246343273657379375870
-      version: 1
-      label:
-        label_val: 2FFECB58A39A4A90F3FE224AE5A60B89ED94698B445E701B9EC466F4929260EF
-        label_len: 256
-      epoch: 8
-      username: 5535524E4B4C76364548624C457376593042486766613148505239563344516E
-  - ValueState:
-      plaintext_val: 735A61425965336A49506461704E6D48574D386F6C7541715868413976503033
-      version: 1
-      label:
-        label_val: F2BEB29F8DE5C3E435F19E6C8B4489C8525DFC0BB4B5869BF977519614663231
+        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
         label_len: 256
       epoch: 6
-      username: 584170706B3057364A5074424A646C73364C55646F644D393678585A786B434A
+      username: 7070726833424262555374446E585637726D5047363734494B5A47304D694F5A
   - ValueState:
-      plaintext_val: 7A6E6A583257424874306E415941345356536A363544694D646F396A69337064
+      plaintext_val: 4A516536366F62656F39673634565675694F53744F31675530643476464D4878
       version: 1
       label:
-        label_val: 52A904705CD9259633205D952DDFB217388FC0171834B8E717F9BC427CFEAB94
+        label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
         label_len: 256
-      epoch: 3
-      username: 674D55687357645665657171414776484F515667494B6D614453486B4C53354E
+      epoch: 9
+      username: 7836686A53706C424C4C6168464F376C763842793059646E396B565154514736
   - ValueState:
-      plaintext_val: 714D556D6B73415543424B38554742554B657033714454436C67386B46364579
+      plaintext_val: 34774561314D3858566E525A456169777666395855454D4B6F365A6C50533270
       version: 1
       label:
-        label_val: F2D9A7DC2BD6645B737E5F8069823CC3FCC1EE535CF71A8C317E90B3AF8F2ADA
-        label_len: 256
-      epoch: 1
-      username: 6C6861677A5470624F3746724B7A316937616E4C6D70317735536E5A75395174
-  - ValueState:
-      plaintext_val: 78556D6654434564624779565368304852724C5A763734477232387678394152
-      version: 1
-      label:
-        label_val: C76804D98662493E41F1EC019B0969B28731D3EFAF63BF7291C1F06BAC5286F7
+        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
         label_len: 256
       epoch: 2
-      username: 445A376E325A705357503173416B5941394377514A51784F527832734A76335A
+      username: 726841445830786372526F4A687345706F534D51747933467470617A3546474F
   - ValueState:
-      plaintext_val: 6F336148327052356B4B58786E506577676154767567564342716A3853647177
+      plaintext_val: 4761574D524C574D6C55537A424E674A52776148326E454C4C47413564673978
       version: 1
       label:
-        label_val: 4656B1B8E105CC3BDA01F115AB2B2E8F08E6ECC569F4F11372966B13FFF87CE7
+        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
         label_len: 256
       epoch: 4
-      username: 614A447369556A48546235486135536C594253714468684349416B36556E5470
+      username: 545466663742364335306C786765544B4369474C4F6165464D44536844673441
   - ValueState:
-      plaintext_val: 4C434E5674773642374970466F354368776B716A364761525A46466639666A30
+      plaintext_val: 6C697673455138444D667A7863736C467352576A4C3067476342304172774454
       version: 1
       label:
-        label_val: 5F6FA8079AA110754DD3A8F9F8E0F27AAF7FB6E95FDA25CF56B2821702F0299F
+        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
         label_len: 256
       epoch: 1
-      username: 427A58624B656842414F4A4F51325968664B71506A596B44727746525A383735
+      username: 624338356F6E6F61484453796C736E74334164505261706273526B4D3777326C
+  - ValueState:
+      plaintext_val: 783155426571613935596C796C676168413469517A64763134476347786A5356
+      version: 1
+      label:
+        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_len: 256
+      epoch: 7
+      username: 6678366A556C5531453541764435776A35704A507458326D5947556837453068
+  - ValueState:
+      plaintext_val: 41374C4B754C36765542655734314C4D6B716876634C3179386D6C426F723677
+      version: 1
+      label:
+        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_len: 256
+      epoch: 2
+      username: 56457073444B77396A53474435586C4B763638496744486B6E4A6543634F4B76
+  - ValueState:
+      plaintext_val: 7957653067616F4B614953304D516A7A534232546C524A696E4962693433426C
+      version: 1
+      label:
+        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_len: 256
+      epoch: 5
+      username: 46764436754C6B5A396E6E736130767636376C526A7438635646444534646764
+  - ValueState:
+      plaintext_val: 347A5A7A574D5570577A544243435945525838586B7044383968657471696549
+      version: 1
+      label:
+        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_len: 256
+      epoch: 8
+      username: 7751594252516B344A6932574C44426668584F59794F66697A7466676A7A6B4E
+  - ValueState:
+      plaintext_val: 3367684738576768634751743077596930706A63717562616C73417647696833
+      version: 1
+      label:
+        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_len: 256
+      epoch: 2
+      username: 4B774938737A52433142336E6A4738717A316C4478386E417069706759743168
+  - ValueState:
+      plaintext_val: 4D52314D4837334C5155537A74786878644D66526D674E5A3578374C51326978
+      version: 1
+      label:
+        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+        label_len: 256
+      epoch: 3
+      username: 68395176724C6D3332554F56666170726E514B474F6E4E7438636B467353496F
+  - ValueState:
+      plaintext_val: 656235414C4E4B4842597158456D4A534D41636E3166626D5176764E54594E48
+      version: 1
+      label:
+        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+        label_len: 256
+      epoch: 3
+      username: 4C664A47346B6D53384C3649596B72384D72694B437242706166763156437344
+  - ValueState:
+      plaintext_val: 6377416B507A596457303749475861777836784A666D6131726C6F5536757A4C
+      version: 1
+      label:
+        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+        label_len: 256
+      epoch: 3
+      username: 684D576675334B70514F437976624B4E5970524A387A4C65326B493432504333
+  - ValueState:
+      plaintext_val: 613665687856434C676D71467968496647714A774D627372555374614F6A3067
+      version: 1
+      label:
+        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
+        label_len: 256
+      epoch: 5
+      username: 776F634C31724D4F416D38427A62714877314D39356D477165484D4947363234
+  - ValueState:
+      plaintext_val: 55624C6B4E657A596F567A39666E336642314C33687058634C4C6262394C7170
+      version: 1
+      label:
+        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+        label_len: 256
+      epoch: 8
+      username: 69755A6439507A7765335A6D706E4C775845586D6E4F6A6A6638376F45355349
+  - ValueState:
+      plaintext_val: 5578575A3271344446395A634C784A326C655A326567416649365331714D4D71
+      version: 1
+      label:
+        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+        label_len: 256
+      epoch: 3
+      username: 79683875496769737A7652446B4458444F44466868776256456568336A304336


### PR DESCRIPTION
**Warning: This PR will break existing stored hashes and data because it changes the hashing mechanism in multiple ways!**

To convert a regular label (arbitrary string of bytes) into a [NodeLabel], we compute the output as: H(label || stale || version)

Specifically, we concatenate the following together:
- I2OSP(len(label) as u64, label)
- A single byte encoded as 0u8 if "stale", 1u8 if "fresh"
- A u64 representing the version

This saves on the number of hash computations we do (previously, 3).

In addition, I am adjusting the serialization of things to use big-endian instead of little-endian. This is mainly because the I2OSP serialization follows network byte order and does big-endian, and I'm hoping to keep endianness conversions consistent across the akd library. But let me know if there are reasons why we should avoid big-endian and would be happy to discuss...

Finally, this PR will also add back in the incorporating of the "version" to the commitment generated by `commit_value`. This was previously removed, perhaps accidentally, but should be re-added.