### PR TITLE
Removing a lot of needless debug statements

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -219,6 +219,8 @@ impl Azks {
                 "Preload of tree ({} objects loaded), took {} s",
                 load_count, time,
             );
+        } else {
+            info!("Preload of tree ({} objects loaded) completed", load_count);
         }
 
         self.increment_epoch();
@@ -253,6 +255,8 @@ impl Azks {
             hash_q.push(node.label, priorities);
             priorities -= 1;
         }
+
+        info!("Completed inserting new nodes");
         // Now hash up the tree, the highest priority items will be closer to the leaves.
         while let Some((next_node_label, _)) = hash_q.pop() {
             let mut next_node: TreeNode = TreeNode::get_from_storage(
@@ -277,6 +281,7 @@ impl Azks {
                 priorities -= 1;
             }
         }
+        info!("Completed evaluating updated hashes");
         Ok(())
     }
 
@@ -388,6 +393,11 @@ impl Azks {
                 info!(
                     "Preload of nodes for audit ({} objects loaded), took {} s",
                     load_count, time,
+                );
+            } else {
+                info!(
+                    "Preload of nodes for audit ({} objects loaded) completed.",
+                    load_count
                 );
             }
             storage.log_metrics(log::Level::Info).await;

--- a/akd/src/storage/manager.rs
+++ b/akd/src/storage/manager.rs
@@ -480,7 +480,7 @@ impl<Db: Database + Sync + Send> StorageManager<Db> {
             }
 
             return Ok(KeyData {
-                states: map.into_iter().map(|(_, v)| v).collect::<Vec<_>>(),
+                states: map.into_values().collect::<Vec<_>>(),
             });
         }
 

--- a/akd_core/src/utils.rs
+++ b/akd_core/src/utils.rs
@@ -93,7 +93,7 @@ pub mod serde_helpers {
         <T as FromHex>::Error: core::fmt::Display,
     {
         let hex_str = String::deserialize(deserializer)?;
-        T::from_hex(&hex_str).map_err(serde::de::Error::custom)
+        T::from_hex(hex_str).map_err(serde::de::Error::custom)
     }
 
     /// Serialize a digest

--- a/akd_local_auditor/src/auditor/mod.rs
+++ b/akd_local_auditor/src/auditor/mod.rs
@@ -54,7 +54,7 @@ pub async fn audit_epoch(blob: akd::local_auditing::AuditBlob, qr: bool) -> Resu
         if qr {
             info!("Generating scan-able QR code for the verification on device");
             let qr_code_data = format_qr_record(p_hash, c_hash, epoch);
-            if let Err(error) = qr2term::print_qr(&qr_code_data) {
+            if let Err(error) = qr2term::print_qr(qr_code_data) {
                 error!("Error generating QR code {}", error);
                 bail!("Error generating QR code {}", error);
             }


### PR DESCRIPTION
This PR removes a lot of `debug!("BEGIN...` and `debug!("END...` statements which required a lot of string formatting needlessly