### PR TITLE
Fixes discovered in manual testing

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -29,7 +29,7 @@ default = ["blake3", "public_auditing"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.1", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.0", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"
@@ -58,7 +58,7 @@ once_cell = { version = "1" }
 ctor = "0.1"
 tokio-test = "0.4"
 tokio = { version = "1.10", features = ["rt", "sync", "time", "macros"] }
-akd = { path = ".", features = ["public-tests"] }
+akd = { path = ".", features = ["public-tests"], version = "0.8.0" }
 
 [[bench]]
 name = "azks"

--- a/akd/src/storage/manager/tests.rs
+++ b/akd/src/storage/manager/tests.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! Tests of the storage manager
+
+use akd_core::hash::EMPTY_DIGEST;
+
+use super::*;
+use crate::storage::memory::AsyncInMemoryDatabase;
+use crate::storage::{types::*, StorageUtil};
+use crate::tree_node::{NodeKey, TreeNode, TreeNodeWithPreviousValue};
+use crate::*;
+
+#[tokio::test]
+async fn test_storage_manager_transaction() {
+    let db = AsyncInMemoryDatabase::new();
+    let storage_manager = StorageManager::new_no_cache(&db);
+
+    assert!(
+        storage_manager.begin_transaction().await,
+        "Failed to start transaction"
+    );
+
+    let mut records = (0..10)
+        .into_iter()
+        .map(|i| {
+            let label = NodeLabel {
+                label_len: i,
+                label_val: [i as u8; 32],
+            };
+            DbRecord::TreeNode(TreeNodeWithPreviousValue {
+                label,
+                latest_node: TreeNode {
+                    hash: EMPTY_DIGEST,
+                    label,
+                    parent: label,
+                    last_epoch: 0,
+                    min_descendant_epoch: 0,
+                    left_child: None,
+                    right_child: None,
+                    node_type: tree_node::NodeType::Leaf,
+                },
+                previous_node: None,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    records.push(DbRecord::Azks(Azks {
+        latest_epoch: 0,
+        num_nodes: 0,
+    }));
+
+    storage_manager
+        .batch_set(records)
+        .await
+        .expect("Failed to set batch of records");
+    // there should be no items in the db, as they should all be in the transaction log
+    assert_eq!(
+        Ok(0),
+        db.batch_get_all_direct().await.map(|items| items.len())
+    );
+    assert_eq!(11, storage_manager.transaction.count().await);
+
+    // test a retrieval doesn't go to the database. Since we know the db is empty, it should be retrieved from the transaction log
+    let key = NodeKey(NodeLabel {
+        label_len: 2,
+        label_val: [2u8; 32],
+    });
+    storage_manager
+        .get::<TreeNodeWithPreviousValue>(&key)
+        .await
+        .expect("Failed to get database record for node label 2");
+
+    let keys = vec![
+        key,
+        NodeKey(NodeLabel {
+            label_len: 3,
+            label_val: [3u8; 32],
+        }),
+    ];
+    let got = storage_manager
+        .batch_get::<TreeNodeWithPreviousValue>(&keys)
+        .await
+        .expect("Failed to batch-get");
+    assert_eq!(2, got.len());
+
+    storage_manager
+        .commit_transaction()
+        .await
+        .expect("Failed to commit transaction");
+    // now the records should be in the database and the transaction log empty
+    assert_eq!(
+        Ok(11),
+        db.batch_get_all_direct().await.map(|items| items.len())
+    );
+    assert_eq!(0, storage_manager.transaction.count().await);
+}
+
+#[tokio::test]
+async fn test_storage_manager_caching() {
+    let db = AsyncInMemoryDatabase::new();
+    let storage_manager = StorageManager::new(&db, None, None, None);
+
+    let mut records = (0..10)
+        .into_iter()
+        .map(|i| {
+            let label = NodeLabel {
+                label_len: i,
+                label_val: [i as u8; 32],
+            };
+            DbRecord::TreeNode(TreeNodeWithPreviousValue {
+                label,
+                latest_node: TreeNode {
+                    hash: EMPTY_DIGEST,
+                    label,
+                    parent: label,
+                    last_epoch: 0,
+                    min_descendant_epoch: 0,
+                    left_child: None,
+                    right_child: None,
+                    node_type: tree_node::NodeType::Leaf,
+                },
+                previous_node: None,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    records.push(DbRecord::Azks(Azks {
+        latest_epoch: 0,
+        num_nodes: 0,
+    }));
+
+    // write straight to the db, populating the cache
+    storage_manager
+        .batch_set(records)
+        .await
+        .expect("Failed to set batch of records");
+
+    // flush the database
+    db.clear().await;
+
+    // test a retrieval still gets data (from the cache)
+    let key = NodeKey(NodeLabel {
+        label_len: 2,
+        label_val: [2u8; 32],
+    });
+    storage_manager
+        .get::<TreeNodeWithPreviousValue>(&key)
+        .await
+        .expect("Failed to get database record for node label 2");
+
+    let keys = vec![
+        key,
+        NodeKey(NodeLabel {
+            label_len: 3,
+            label_val: [3u8; 32],
+        }),
+    ];
+    let got = storage_manager
+        .batch_get::<TreeNodeWithPreviousValue>(&keys)
+        .await
+        .expect("Failed to batch-get");
+    assert_eq!(2, got.len());
+
+    storage_manager.flush_cache().await;
+
+    let got = storage_manager
+        .batch_get::<TreeNodeWithPreviousValue>(&keys)
+        .await
+        .expect("Failed to batch-get");
+    assert_eq!(0, got.len());
+}

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -44,6 +44,12 @@ impl AsyncInMemoryDatabase {
             user_info: Arc::new(RwLock::new(HashMap::new())),
         }
     }
+
+    #[cfg(test)]
+    pub async fn clear(&self) {
+        let mut guard = self.db.write().await;
+        guard.clear();
+    }
 }
 
 impl Default for AsyncInMemoryDatabase {

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -33,7 +33,7 @@ mod memory_storage_tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_v2_in_memory_db() {
+    async fn test_in_memory_db() {
         let db = AsyncInMemoryDatabase::new();
         crate::storage::tests::run_test_cases_for_storage_impl(&db).await;
     }

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -63,6 +63,12 @@ impl Transaction {
         }
     }
 
+    /// Get the current number of items currently in the transaction modifications set
+    pub async fn count(&self) -> usize {
+        let lock = self.state.read().await;
+        lock.mods.len()
+    }
+
     /// Log metrics about the current transaction instance. Metrics will be cleared after log call
     pub async fn log_metrics(&self, level: log::Level) {
         let r = crate::utils::rwlock_swap(&self.num_reads, 0).await;

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.1", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.0", default-features = false, features = ["vrf"] }
 hex = "0.4"
 
 ## Optional dependencies ##

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akd_local_auditor"
 default-run = "akd_local_auditor"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 edition = "2018"
 publish = false
@@ -29,7 +29,7 @@ thread-id = "3"
 tokio = { version = "1.10", features = ["full"] }
 tokio-stream = "0.1"
 
-akd = { path = "../akd", version = "0.8.1", features = ["public-tests", "public_auditing"] }
+akd = { path = "../akd", features = ["public-tests", "public_auditing"] }
 
 [dev-dependencies]
 ctor = "0.1"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.1" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.2" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.1" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.2" }


### PR DESCRIPTION
1. Previously, if we failed in the `Akzs::batch _insert_leaves` call in `Directory::publish`, we wouldn't rollback the transaction which effectively deadlocked future publish attempts without restarting the process. This rolls back the transaction on batch insert failure
2. Version bump and adjustment of min required versions between crates
3. Storage tests covering transactional + caching coverage
4. The cache wasn't being populated on calls to `batch_get` in the StorageManager 🐙 


More may come...