### PR TITLE
Minimize over-the-wire encoding in protobuf formats.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,20 +23,17 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'akd'",
+            "name": "Debug unit tests in library 'akd_core'",
             "cargo": {
                 "args": [
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=akd"
+                    "--package=akd_core",
+                    "--features=protobuf,blake3"
                 ],
-                "filter": {
-                    "name": "akd",
-                    "kind": "lib"
-                }
             },
-            "args": [],
+            "args": ["test_minimum_encoding_label_bytes"],
             "cwd": "${workspaceFolder}"
         },
         {

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -99,11 +99,33 @@ macro_rules! convert_from_vector {
 // NodeLabel
 // ==============================================================
 
+fn minimize_label_bytes(v: &[u8; 32]) -> Vec<u8> {
+    let mut i = 31;
+    for byte in v.iter().rev() {
+        if *byte != 0u8 {
+            break;
+        }
+
+        if i > 0 {
+            i -= 1;
+        } else {
+            return Vec::new();
+        }
+    }
+    v[0..=i].to_vec()
+}
+
+fn parse_min_label(v: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[..v.len()].copy_from_slice(v);
+    out
+}
+
 impl From<&crate::NodeLabel> for specs::types::NodeLabel {
     fn from(input: &crate::NodeLabel) -> Self {
         Self {
             label_len: Some(input.label_len),
-            label_val: Some(input.label_val.to_vec()),
+            label_val: Some(minimize_label_bytes(&input.label_val)),
             ..Default::default()
         }
     }
@@ -115,17 +137,11 @@ impl TryFrom<&specs::types::NodeLabel> for crate::NodeLabel {
     fn try_from(input: &specs::types::NodeLabel) -> Result<Self, Self::Error> {
         require!(input, has_label_len);
         require!(input, has_label_val);
-        // get the raw data & it's length, but at most 32 bytes
-        let raw = input.label_val();
-        let len = std::cmp::min(raw.len(), 32);
-        // construct the output buffer
-        let mut out_val = [0u8; 32];
-        // copy into the output buffer the raw data up to the computed length
-        out_val[..len].clone_from_slice(&raw[..len]);
+        let label_val = parse_min_label(input.label_val());
 
         Ok(Self {
             label_len: input.label_len(),
-            label_val: out_val,
+            label_val,
         })
     }
 }

--- a/akd_core/src/proto/tests.rs
+++ b/akd_core/src/proto/tests.rs
@@ -296,15 +296,15 @@ fn test_minimum_encoding_label_bytes() {
         0, 0,
     ];
 
-    let min_full_label = minimize_label_bytes(&full_label);
-    let min_half_label = minimize_label_bytes(&half_label);
-    let min_zero_label = minimize_label_bytes(&zero_label);
+    let min_full_label = encode_minimum_label(&full_label);
+    let min_half_label = encode_minimum_label(&half_label);
+    let min_zero_label = encode_minimum_label(&zero_label);
 
     assert_eq!(32, min_full_label.len());
     assert_eq!(16, min_half_label.len());
     assert_eq!(0, min_zero_label.len());
 
-    assert_eq!(full_label, parse_min_label(&min_full_label));
-    assert_eq!(half_label, parse_min_label(&min_half_label));
-    assert_eq!(zero_label, parse_min_label(&min_zero_label));
+    assert_eq!(full_label, decode_minimized_label(&min_full_label));
+    assert_eq!(half_label, decode_minimized_label(&min_half_label));
+    assert_eq!(zero_label, decode_minimized_label(&min_zero_label));
 }

--- a/akd_core/src/proto/tests.rs
+++ b/akd_core/src/proto/tests.rs
@@ -278,3 +278,33 @@ fn test_convert_single_append_only_proof() {
     let protobuf: SingleAppendOnlyProof = (&original).into();
     assert_eq!(original, (&protobuf).try_into().unwrap());
 }
+
+#[test]
+fn test_minimum_encoding_label_bytes() {
+    let full_label: [u8; 32] = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 1,
+    ];
+
+    let half_label: [u8; 32] = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    let zero_label: [u8; 32] = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    let min_full_label = minimize_label_bytes(&full_label);
+    let min_half_label = minimize_label_bytes(&half_label);
+    let min_zero_label = minimize_label_bytes(&zero_label);
+
+    assert_eq!(32, min_full_label.len());
+    assert_eq!(16, min_half_label.len());
+    assert_eq!(0, min_zero_label.len());
+
+    assert_eq!(full_label, parse_min_label(&min_full_label));
+    assert_eq!(half_label, parse_min_label(&min_half_label));
+    assert_eq!(zero_label, parse_min_label(&min_zero_label));
+}


### PR DESCRIPTION
This change removes trailing 0's from the node labels as they go over the wire, since we know the length will ALWAYS be 32 bytes. Therefore if there's a bunch of trailing 0's in the label, we can safely trim them off keeping only the most significant data (this is common with nodes higher up in the tree).

When decoding, we see how many bytes are there and put them in the leading spaces, in-order, with a simple slice copy.

Unit test coverage added in `akd_core/src/proto/tests.rs`