### PR TITLE
Minor cleanups

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -823,6 +823,7 @@ mod tests {
                         .await?
                         .unwrap()
                         .label;
+                    assert_eq!(right_child.label, sibling_label);
                     nodes.push(right_child);
                 }
                 None => {}


### PR DESCRIPTION
- Added a missing assert_eq() in `test_get_sibling_node` that was missed in #296 
- Adding some timing information to directory publish to better debug what the bottlenecks are
- Added a batch insertion test inspired from #302 which we can run and trigger printlns by doing something like: `cargo test -- test_random_batch_insertion --nocapture` to better triage directory publish performance