### PR TITLE
Speeding up vrf computation by directly producing output without proof

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -823,6 +823,7 @@ mod tests {
                         .await?
                         .unwrap()
                         .label;
+                    assert_eq!(right_child.label, sibling_label);
                     nodes.push(right_child);
                 }
                 None => {}


### PR DESCRIPTION
In Directory::publish(), we are doing some unnecessary computation when evaluating VRFs, by first generating the proof, then turning the proof into the VRF output. It is faster to just generate the output directly. Also added a benchmark for a single VRF evaluation on a random label, plus some small performance improvements to generating ECVRF proofs.

See the following benchmarks...

Before this change:
```
% cargo bench -p akd_core -F bench
Sequential VRFs         time:   [133.90 ms 134.97 ms 136.56 ms]
Parallel VRFs (all cores)
                        time:   [22.571 ms 22.866 ms 23.350 ms]
Parallel VRFs (4 cores) time:   [35.997 ms 36.036 ms 36.077 ms]
 ```


After this change:
```
% cargo bench -p akd_core -F bench
Sequential VRFs         time:   [55.253 ms 55.502 ms 55.792 ms]
Parallel VRFs (all cores)
                        time:   [9.8533 ms 9.9332 ms 10.019 ms]
Parallel VRFs (4 cores) time:   [15.230 ms 15.259 ms 15.289 ms]
```