### PR TITLE
Optimizing the BFS preloading prefix computation

### DIFF
--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -9,37 +9,7 @@
 // 2. For each node in current_nodes set, check if each child is in prefix hashmap
 // 3. If so, add child label to batch set
 
-use crate::{NodeLabel, EMPTY_LABEL, EMPTY_VALUE};
-use std::collections::HashSet;
-
-// Builds a set of all prefixes of the input labels
-pub(crate) fn build_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
-    let mut prefixes_set = HashSet::new();
-    for label in labels {
-        for len in 0..(label.get_len() + 1) {
-            prefixes_set.insert(label.get_prefix(len));
-        }
-    }
-    prefixes_set
-}
-
-pub(crate) fn build_lookup_prefixes_set(labels: &[NodeLabel]) -> HashSet<NodeLabel> {
-    let mut lookup_prefixes_set = HashSet::new();
-    for label in labels {
-        // We need the actual node for lookup too
-        lookup_prefixes_set.insert(*label);
-        for len in 0..(label.get_len() + 1) {
-            // Sibling prefixes unfortunately do not cover all the nodes we will need for
-            // a lookup proof. Although we can figure out which nodes are exactly needed
-            // this will require basically doing a pre-lookup.
-            // Instead here we load the prefixes as well.
-            // This combination (sibling- + self-prefixes) covers all the nodes we need.
-            lookup_prefixes_set.insert(label.get_prefix(len));
-            lookup_prefixes_set.insert(label.get_sibling_prefix(len));
-        }
-    }
-    lookup_prefixes_set
-}
+use crate::{EMPTY_LABEL, EMPTY_VALUE};
 
 pub(crate) fn empty_node_hash() -> crate::Digest {
     crate::hash::merge(&[crate::hash::hash(&EMPTY_VALUE), EMPTY_LABEL.hash()])
@@ -48,7 +18,7 @@ pub(crate) fn empty_node_hash() -> crate::Digest {
 // Creates a byte array of 32 bytes from a u64
 // Note that this representation is big-endian, and
 // places the bits to the front of the output byte_array.
-#[allow(dead_code)]
+#[cfg(any(test, feature = "public-tests"))]
 pub(crate) fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
     let mut output_arr = [0u8; 32];
     let input_arr = input_int.to_be_bytes();
@@ -56,7 +26,7 @@ pub(crate) fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
     output_arr
 }
 
-#[allow(dead_code)]
+#[allow(unused)]
 #[cfg(any(test, feature = "public-tests"))]
 pub(crate) fn random_label(rng: &mut rand::rngs::OsRng) -> crate::NodeLabel {
     use crate::rand::Rng;

--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -23,8 +23,12 @@ use crate::ARITY;
 use alloc::vec::Vec;
 #[cfg(feature = "nostd")]
 use alloc::{format, string::String};
+#[cfg(feature = "nostd")]
+use core::cmp::{Ord, Ordering, PartialOrd};
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, Rng};
+#[cfg(not(feature = "nostd"))]
+use std::cmp::{Ord, Ordering, PartialOrd};
 
 pub mod node_label;
 pub use node_label::*;
@@ -226,6 +230,18 @@ pub struct Node {
 impl SizeOf for Node {
     fn size_of(&self) -> usize {
         self.label.size_of() + self.hash.len()
+    }
+}
+
+impl PartialOrd for Node {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Node {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.label.cmp(&other.label)
     }
 }
 

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -87,6 +87,16 @@ impl NodeLabel {
         [&self.label_len.to_be_bytes(), &self.label_val[..]].concat()
     }
 
+    /// Outputs whether or not self is a prefix of the other [NodeLabel]
+    pub fn is_prefix_of(&self, other: &Self) -> bool {
+        if self.label_len > other.label_len {
+            return false;
+        }
+        !(0..self.label_len)
+            .into_iter()
+            .any(|i| self.get_bit_at(i) != other.get_bit_at(i))
+    }
+
     /// Takes as input a pointer to the caller and another [NodeLabel],
     /// returns a NodeLabel that is the longest common prefix of the two.
     pub fn get_longest_common_prefix(&self, other: NodeLabel) -> Self {


### PR DESCRIPTION
Previously we computed the preloading of nodes by first taking the insertion set of labels, computing all prefixes, and then loading the nodes in BFS manner and checking each node's label against the prefix set. For N labels to insert, this was a set of size `256 * N`, which resulted in about `256 * N` work.

Now, we are using a BinaryHeap to insert the labels in sorted order (sorted by label value), and then instead of building a prefix set, we do a binary search to check if the current node during the BFS traversal is contained as a prefix in the sorted insertion set of labels. This is roughly `N * log(N)` work to build the sorted list, and then about `log^2(N)` work for prefix-checking during insertion. This should be much faster -- see benchmarks below.

Before this change:
Inserting 100k nodes into an empty tree:
```
[00:02:50.423] INFO   Preload of tree (1 objects loaded), took 31.261086083 s (append_only_zks:217)
```
Inserting another 100k nodes into the tree subsequently:
```
[00:06:14.654] INFO   Preload of tree (150813 objects loaded), took 34.730958 s (append_only_zks:217)
```

After this change:

Inserting 100k nodes into an empty tree:
```
[00:02:18.657] INFO   Preload of tree (1 objects loaded), took 0.005568666 s (append_only_zks:265)
```
Inserting another 100k nodes into the tree subsequently:
```
[00:05:06.851] INFO   Preload of tree (151035 objects loaded), took 1.7127710409999999 s (append_only_zks:265)
```

-----------

**Edit**: Those above numbers are run with `--profile = dev` mode. In `--profile = release` mode, the numbers are less drastic but about the same in terms of scaling:

Before:
```
[00:00:21.253] INFO   Preload of tree (1 objects loaded), took 4.403417458 s (append_only_zks:217)
Batch insertion (100000 initial leaves) took 22996 ms

[00:00:45.232] INFO   Preload of tree (150755 objects loaded), took 4.546898041 s (append_only_zks:217)
Batch insertion (100000 initial leaves, 100000 inserted leaves) took 25390 ms
```

After:
```
[00:00:16.759] INFO   Preload of tree (1 objects loaded), took 0.000585958 s (append_only_zks:265)
Batch insertion (100000 initial leaves) took 17196 ms

[00:00:34.034] INFO   Preload of tree (151191 objects loaded), took 0.199543458 s (append_only_zks:265)
Batch insertion (100000 initial leaves, 100000 inserted leaves) took 19388 ms
```