### PR TITLE
Optimizing VRF computation by saving expanded private key and public key

### DIFF
--- a/akd_core/benches/parallel_vrfs.rs
+++ b/akd_core/benches/parallel_vrfs.rs
@@ -9,6 +9,7 @@
 
 extern crate criterion;
 use self::criterion::*;
+use akd_core::ecvrf::{VRFExpandedPrivateKey, VRFPublicKey};
 use akd_core::{ecvrf::VRFKeyStorage, AkdLabel};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -28,10 +29,18 @@ fn bench_single_vrf(c: &mut Criterion) {
     let key = runtime
         .block_on(akd_core::ecvrf::HardCodedAkdVRF.get_vrf_private_key())
         .unwrap();
+    let expanded_key = VRFExpandedPrivateKey::from(&key);
+    let pk = VRFPublicKey::from(&key);
 
     c.bench_function("Single VRF label generation", |b| {
         b.iter(|| {
-            akd_core::ecvrf::HardCodedAkdVRF::get_node_label_with_key(&key, &label, false, 1);
+            akd_core::ecvrf::HardCodedAkdVRF::get_node_label_with_expanded_key(
+                &expanded_key,
+                &pk,
+                &label,
+                false,
+                1,
+            );
         })
     });
 }
@@ -60,9 +69,15 @@ fn bench_parallel_vrfs(c: &mut Criterion) {
             let key = runtime
                 .block_on(akd_core::ecvrf::HardCodedAkdVRF.get_vrf_private_key())
                 .unwrap();
+            let expanded_key = VRFExpandedPrivateKey::from(&key);
+            let pk = VRFPublicKey::from(&key);
             for (label, stale, version) in labels.iter() {
-                akd_core::ecvrf::HardCodedAkdVRF::get_node_label_with_key(
-                    &key, label, *stale, *version,
+                akd_core::ecvrf::HardCodedAkdVRF::get_node_label_with_expanded_key(
+                    &expanded_key,
+                    &pk,
+                    label,
+                    *stale,
+                    *version,
                 );
             }
         })

--- a/akd_core/src/ecvrf/ecvrf_impl.rs
+++ b/akd_core/src/ecvrf/ecvrf_impl.rs
@@ -89,6 +89,7 @@ impl core::ops::Deref for VRFPublicKey {
 ///
 /// This is similar in structure to ed25519_dalek::ExpandedSecretKey. It can be produced from
 /// a VRFPrivateKey.
+#[derive(Clone)]
 pub struct VRFExpandedPrivateKey {
     pub(super) key: ed25519_Scalar,
     pub(super) nonce: [u8; 32],

--- a/akd_core/src/ecvrf/mod.rs
+++ b/akd_core/src/ecvrf/mod.rs
@@ -25,7 +25,9 @@
 mod ecvrf_impl;
 mod traits;
 // export the functionality we want visible
-pub use crate::ecvrf::ecvrf_impl::{Output, Proof, VRFPrivateKey, VRFPublicKey};
+pub use crate::ecvrf::ecvrf_impl::{
+    Output, Proof, VRFExpandedPrivateKey, VRFPrivateKey, VRFPublicKey,
+};
 pub use crate::ecvrf::traits::VRFKeyStorage;
 #[cfg(feature = "nostd")]
 use alloc::boxed::Box;


### PR DESCRIPTION
One more VRF computation optimization that we can do:

Rather than re-expanding the VRF private key into a VRFExpandedPrivateKey and recomputing the public key every time we call evaluate, we can just compute the expanded private key and public key once, and then reuse them across VRF evaluate calls.

Before this change:
```
Batch insertion (100000 initial leaves) took 14172 ms
Batch insertion (100000 initial leaves, 100000 inserted leaves) took 16920 ms
```

After this change:
```
Batch insertion (100000 initial leaves) took 13712 ms
Batch insertion (100000 initial leaves, 100000 inserted leaves) took 15315 ms
```