### PR TITLE
Use enums to distinguish regular and auditor directory constructions

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -44,10 +44,10 @@ async fn tic_toc<T>(f: impl core::future::Future<Output = T>) -> (T, Option<f64>
 /// mode enum is used to differentiate between the two.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum InsertMode {
-    /// The regular construction of the the tree
+    /// The regular construction of the the tree.
     Directory,
-    /// The auditor's mode of constructing the tree - last modified epochs of
-    /// leaves are not included in node hashes
+    /// The auditor's mode of constructing the tree - last epochs of leaves are
+    /// not included in node hashes.
     Auditor,
 }
 

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -41,7 +41,7 @@ async fn tic_toc<T>(f: impl core::future::Future<Output = T>) -> (T, Option<f64>
 
 /// An azks is built both by the [crate::directory::Directory] and the auditor.
 /// However, both constructions have very minor differences, and the insert
-/// usage enum is used to differentiate between the two.
+/// mode enum is used to differentiate between the two.
 #[derive(Debug, Clone, Copy)]
 pub enum AzksInsertMode {
     /// The default mode of constructing the tree
@@ -58,8 +58,8 @@ impl Default for AzksInsertMode {
 }
 
 impl From<AzksInsertMode> for HashMode {
-    fn from(usage: AzksInsertMode) -> Self {
-        match usage {
+    fn from(mode: AzksInsertMode) -> Self {
+        match mode {
             AzksInsertMode::Directory => HashMode::WithLeafEpoch,
             AzksInsertMode::Auditor => HashMode::NoLeafEpoch,
         }

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -10,7 +10,7 @@
 use crate::{
     errors::{AkdError, AuditorError, AzksError},
     storage::{manager::StorageManager, memory::AsyncInMemoryDatabase},
-    AppendOnlyProof, Azks, AzksInsertUsage, Digest, SingleAppendOnlyProof,
+    AppendOnlyProof, Azks, AzksInsertMode, Digest, SingleAppendOnlyProof,
 };
 
 /// Verifies an audit proof, given start and end hashes for a merkle patricia tree.
@@ -55,7 +55,7 @@ pub async fn verify_consecutive_append_only(
     let manager = StorageManager::new_no_cache(&db);
 
     let mut azks = Azks::new::<_>(&manager).await?;
-    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, AzksInsertUsage::Auditor)
+    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, AzksInsertMode::Auditor)
         .await?;
     let computed_start_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     let mut verified = computed_start_root_hash == start_hash;
@@ -68,7 +68,7 @@ pub async fn verify_consecutive_append_only(
             y
         })
         .collect();
-    azks.batch_insert_leaves::<_>(&manager, updated_inserted, AzksInsertUsage::Auditor)
+    azks.batch_insert_leaves::<_>(&manager, updated_inserted, AzksInsertMode::Auditor)
         .await?;
     let computed_end_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     verified = verified && (computed_end_root_hash == end_hash);

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -10,7 +10,7 @@
 use crate::{
     errors::{AkdError, AuditorError, AzksError},
     storage::{manager::StorageManager, memory::AsyncInMemoryDatabase},
-    AppendOnlyProof, Azks, Digest, SingleAppendOnlyProof,
+    AppendOnlyProof, Azks, AzksInsertUsage, Digest, SingleAppendOnlyProof,
 };
 
 /// Verifies an audit proof, given start and end hashes for a merkle patricia tree.
@@ -55,7 +55,7 @@ pub async fn verify_consecutive_append_only(
     let manager = StorageManager::new_no_cache(&db);
 
     let mut azks = Azks::new::<_>(&manager).await?;
-    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, true)
+    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, AzksInsertUsage::Auditor)
         .await?;
     let computed_start_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     let mut verified = computed_start_root_hash == start_hash;
@@ -68,7 +68,7 @@ pub async fn verify_consecutive_append_only(
             y
         })
         .collect();
-    azks.batch_insert_leaves::<_>(&manager, updated_inserted, true)
+    azks.batch_insert_leaves::<_>(&manager, updated_inserted, AzksInsertUsage::Auditor)
         .await?;
     let computed_end_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     verified = verified && (computed_end_root_hash == end_hash);

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -8,9 +8,10 @@
 //! Code for an auditor of a authenticated key directory
 
 use crate::{
+    append_only_zks::InsertMode,
     errors::{AkdError, AuditorError, AzksError},
     storage::{manager::StorageManager, memory::AsyncInMemoryDatabase},
-    AppendOnlyProof, Azks, AzksInsertMode, Digest, SingleAppendOnlyProof,
+    AppendOnlyProof, Azks, Digest, SingleAppendOnlyProof,
 };
 
 /// Verifies an audit proof, given start and end hashes for a merkle patricia tree.
@@ -55,7 +56,7 @@ pub async fn verify_consecutive_append_only(
     let manager = StorageManager::new_no_cache(&db);
 
     let mut azks = Azks::new::<_>(&manager).await?;
-    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, AzksInsertMode::Auditor)
+    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, InsertMode::Auditor)
         .await?;
     let computed_start_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     let mut verified = computed_start_root_hash == start_hash;
@@ -68,7 +69,7 @@ pub async fn verify_consecutive_append_only(
             y
         })
         .collect();
-    azks.batch_insert_leaves::<_>(&manager, updated_inserted, AzksInsertMode::Auditor)
+    azks.batch_insert_leaves::<_>(&manager, updated_inserted, InsertMode::Auditor)
         .await?;
     let computed_end_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     verified = verified && (computed_end_root_hash == end_hash);

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -15,7 +15,7 @@ use crate::storage::manager::StorageManager;
 use crate::storage::types::{DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Database;
 use crate::{
-    AkdLabel, AkdValue, AppendOnlyProof, AzksInsertUsage, Digest, EpochHash, HistoryProof,
+    AkdLabel, AkdValue, AppendOnlyProof, AzksInsertMode, Digest, EpochHash, HistoryProof,
     LookupProof, Node, NodeLabel, NonMembershipProof, UpdateProof,
 };
 
@@ -212,7 +212,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
             .batch_insert_leaves::<_>(
                 &self.storage,
                 sorted_insertion_set,
-                AzksInsertUsage::Directory,
+                AzksInsertMode::Directory,
             )
             .await
         {
@@ -922,7 +922,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting database insertion");
 
         current_azks
-            .batch_insert_leaves::<_>(&self.storage, insertion_set, AzksInsertUsage::Directory)
+            .batch_insert_leaves::<_>(&self.storage, insertion_set, AzksInsertMode::Directory)
             .await?;
 
         // batch all the inserts into a single transactional write to storage

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -15,8 +15,8 @@ use crate::storage::manager::StorageManager;
 use crate::storage::types::{DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Database;
 use crate::{
-    AkdLabel, AkdValue, AppendOnlyProof, Digest, EpochHash, HistoryProof, LookupProof, Node,
-    NodeLabel, NonMembershipProof, UpdateProof,
+    AkdLabel, AkdValue, AppendOnlyProof, AzksInsertUsage, Digest, EpochHash, HistoryProof,
+    LookupProof, Node, NodeLabel, NonMembershipProof, UpdateProof,
 };
 
 use akd_core::utils::{commit_value, get_commitment_nonce};
@@ -209,7 +209,11 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting inserting new leaves");
 
         if let Err(err) = current_azks
-            .batch_insert_leaves::<_>(&self.storage, sorted_insertion_set, false)
+            .batch_insert_leaves::<_>(
+                &self.storage,
+                sorted_insertion_set,
+                AzksInsertUsage::Directory,
+            )
             .await
         {
             // If we fail to do the batch-leaf insert, we should rollback the transaction so we can try again cleanly.
@@ -918,7 +922,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting database insertion");
 
         current_azks
-            .batch_insert_leaves::<_>(&self.storage, insertion_set, false)
+            .batch_insert_leaves::<_>(&self.storage, insertion_set, AzksInsertUsage::Directory)
             .await?;
 
         // batch all the inserts into a single transactional write to storage

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -7,7 +7,7 @@
 
 //! Implementation of a auditable key directory
 
-use crate::append_only_zks::Azks;
+use crate::append_only_zks::{Azks, InsertMode};
 use crate::ecvrf::{VRFKeyStorage, VRFPublicKey};
 use crate::errors::{AkdError, DirectoryError, StorageError};
 use crate::helper_structs::LookupInfo;
@@ -15,8 +15,8 @@ use crate::storage::manager::StorageManager;
 use crate::storage::types::{DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Database;
 use crate::{
-    AkdLabel, AkdValue, AppendOnlyProof, AzksInsertMode, Digest, EpochHash, HistoryProof,
-    LookupProof, Node, NodeLabel, NonMembershipProof, UpdateProof,
+    AkdLabel, AkdValue, AppendOnlyProof, Digest, EpochHash, HistoryProof, LookupProof, Node,
+    NodeLabel, NonMembershipProof, UpdateProof,
 };
 
 use akd_core::utils::{commit_value, get_commitment_nonce};
@@ -209,11 +209,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting inserting new leaves");
 
         if let Err(err) = current_azks
-            .batch_insert_leaves::<_>(
-                &self.storage,
-                sorted_insertion_set,
-                AzksInsertMode::Directory,
-            )
+            .batch_insert_leaves::<_>(&self.storage, sorted_insertion_set, InsertMode::Directory)
             .await
         {
             // If we fail to do the batch-leaf insert, we should rollback the transaction so we can try again cleanly.
@@ -922,7 +918,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting database insertion");
 
         current_azks
-            .batch_insert_leaves::<_>(&self.storage, insertion_set, AzksInsertMode::Directory)
+            .batch_insert_leaves::<_>(&self.storage, insertion_set, InsertMode::Directory)
             .await?;
 
         // batch all the inserts into a single transactional write to storage

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -428,7 +428,7 @@ pub use akd_core::*;
 mod utils;
 
 // ========== Type re-exports which are commonly used ========== //
-pub use append_only_zks::{Azks, AzksInsertUsage};
+pub use append_only_zks::{Azks, AzksInsertMode};
 pub use client::HistoryVerificationParams;
 pub use directory::{Directory, HistoryParams};
 pub use helper_structs::EpochHash;

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -428,7 +428,7 @@ pub use akd_core::*;
 mod utils;
 
 // ========== Type re-exports which are commonly used ========== //
-pub use append_only_zks::Azks;
+pub use append_only_zks::{Azks, AzksInsertUsage};
 pub use client::HistoryVerificationParams;
 pub use directory::{Directory, HistoryParams};
 pub use helper_structs::EpochHash;

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -428,7 +428,7 @@ pub use akd_core::*;
 mod utils;
 
 // ========== Type re-exports which are commonly used ========== //
-pub use append_only_zks::{Azks, AzksInsertMode};
+pub use append_only_zks::Azks;
 pub use client::HistoryVerificationParams;
 pub use directory::{Directory, HistoryParams};
 pub use helper_structs::EpochHash;

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -563,7 +563,7 @@ pub(crate) fn partition_longest_common_prefix(
 pub(crate) enum NodeHashingMode {
     // Mixes the last epoch into the hashes of any child leaves
     WithLeafEpoch,
-    // Does not mix the last epoch into the hashes of children nodes
+    // Does not mix the last epoch into the hashes of child leaves
     NoLeafEpoch,
 }
 


### PR DESCRIPTION
Per suggestion from @slawlor in #301 , this PR replaces the use of booleans with enums to distinguish between regular and auditor directory constructions/hashing. This is clearer and less error-prone.

Note that there were actually two spots where the parameter of `include_ep` was passed to a function expecting `exclude_ep` without negating the variable (see in-line comment). I believe these were just function naming errors and not actual bugs. This PR will help avoid such mistakes in future.