### PR TITLE
Remove Unnecessary Clone Impls in Favor of Derive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Cargo.lock
 **/*.log
 
 .idea/**
+*.iml

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -62,7 +62,7 @@ impl From<InsertMode> for NodeHashingMode {
 
 /// An append-only zero knowledge set, the data structure used to efficiently implement
 /// a auditable key directory.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -105,15 +105,6 @@ impl Storable for Azks {
 }
 
 unsafe impl Sync for Azks {}
-
-impl Clone for Azks {
-    fn clone(&self) -> Self {
-        Self {
-            latest_epoch: self.latest_epoch,
-            num_nodes: self.num_nodes,
-        }
-    }
-}
 
 impl Azks {
     /// Creates a new azks

--- a/akd/src/storage/cache/high_parallelism.rs
+++ b/akd/src/storage/cache/high_parallelism.rs
@@ -24,8 +24,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
-/// Implements a basic cahce with timing information which automatically flushes
+/// Implements a basic cache with timing information which automatically flushes
 /// expired entries and removes them
+#[derive(Clone)]
 pub struct TimedCache {
     azks: Arc<RwLock<Option<DbRecord>>>,
     map: Arc<DashMap<Vec<u8>, CachedItem>>,
@@ -56,21 +57,6 @@ impl TimedCache {
                 log::Level::Warn => warn!("{}", msg),
                 _ => error!("{}", msg),
             }
-        }
-    }
-}
-
-impl Clone for TimedCache {
-    fn clone(&self) -> Self {
-        TimedCache {
-            azks: self.azks.clone(),
-            map: self.map.clone(),
-            last_clean: self.last_clean.clone(),
-            can_clean: self.can_clean.clone(),
-            item_lifetime: self.item_lifetime,
-            memory_limit_bytes: self.memory_limit_bytes,
-            hit_count: self.hit_count.clone(),
-            clean_frequency: self.clean_frequency,
         }
     }
 }

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -218,7 +218,7 @@ impl TreeNodeWithPreviousValue {
 /// At a later time, we may need to access older sub-trees of the tree built with these nodes.
 /// To facilitate this, we require this struct to include the last time a node was updated
 /// as well as the oldest descendant it holds.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -358,21 +358,6 @@ impl TreeNode {
 pub struct NodeKey(pub NodeLabel);
 
 unsafe impl Sync for TreeNode {}
-
-impl Clone for TreeNode {
-    fn clone(&self) -> Self {
-        Self {
-            label: self.label,
-            last_epoch: self.last_epoch,
-            min_descendant_epoch: self.min_descendant_epoch,
-            parent: self.parent,
-            node_type: self.node_type,
-            left_child: self.left_child,
-            right_child: self.right_child,
-            hash: self.hash,
-        }
-    }
-}
 
 impl TreeNode {
     // FIXME: Figure out how to better group arguments.
@@ -795,22 +780,21 @@ mod tests {
         };
 
         let root_expected_min_dec = 1u64;
-        assert!(
-            root_expected_min_dec == root_smallest_descendant_ep,
+        assert_eq!(
+            root_expected_min_dec, root_smallest_descendant_ep,
             "Minimum descendant epoch not equal to expected: root, expected: {:?}, got: {:?}",
-            root_expected_min_dec,
-            root_smallest_descendant_ep
+            root_expected_min_dec, root_smallest_descendant_ep
         );
 
         let right_child_expected_min_dec = 2u64;
-        assert!(
-            right_child_expected_min_dec == right_child_smallest_descendant_ep,
+        assert_eq!(
+            right_child_expected_min_dec, right_child_smallest_descendant_ep,
             "Minimum descendant epoch not equal to expected: right child"
         );
 
         let left_child_expected_min_dec = 1u64;
-        assert!(
-            left_child_expected_min_dec == left_child_smallest_descendant_ep,
+        assert_eq!(
+            left_child_expected_min_dec, left_child_smallest_descendant_ep,
             "Minimum descendant epoch not equal to expected: left child"
         );
 
@@ -1084,7 +1068,7 @@ mod tests {
             crate::hash::merge(&[left_child_expected_hash, right_child_expected_hash]),
             hash_label(root.label),
         ]);
-        assert!(root_digest == expected, "Root hash not equal to expected");
+        assert_eq!(root_digest, expected, "Root hash not equal to expected");
 
         Ok(())
     }
@@ -1199,7 +1183,7 @@ mod tests {
             _ => panic!("Root not found in storage."),
         };
 
-        assert!(root_digest == expected, "Root hash not equal to expected");
+        assert_eq!(root_digest, expected, "Root hash not equal to expected");
         Ok(())
     }
 }


### PR DESCRIPTION
- Remove manual implementations of the Clone trait in favor of deriving the trait instead.
- Convert some usages of `assert!` with equality checks to `assert_eq!`.
- Update .gitignore to ignore .iml files (IDEA IDEs).